### PR TITLE
Add start_backendonly i.e. without Opensearch

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,8 +59,6 @@ services:
     depends_on:
       backend_db:
         condition: service_healthy
-      opensearch-node1:
-        condition: service_healthy
     healthcheck:
       test: curl -s -f backend:8888/health >/dev/null || exit 1
       interval: 5s

--- a/makefile-docker.defs
+++ b/makefile-docker.defs
@@ -7,10 +7,16 @@ start_containers:
 	# Build and run containers
 	docker-compose -f docker-compose.yml -f docker-compose.dev.yml up -d
 
+start_backendonly:
+	# Build and run containers
+	docker-compose -f docker-compose.yml -f docker-compose.dev.yml up -d backend backend_db
+
 show_logs:
 	docker-compose logs -f
 
-start: start_containers migrations upgrade_all_dbs
+start: start_containers migrations 
+
+start_backend: start_backendionly migrations 
 
 stop:
 	docker-compose stop


### PR DESCRIPTION
Docker compose now is only for development - so remove the dependency the backend has on open search... and add a makefile command to just start the backend.