### PR TITLE
Use taxonomy on /config when group_documents=True

### DIFF
--- a/app/api/api_v1/routers/lookups/config.py
+++ b/app/api/api_v1/routers/lookups/config.py
@@ -1,21 +1,27 @@
-from typing import Sequence
+from typing import Sequence, Union
 
 from fastapi import Depends, Request, Response
 
-from app.api.api_v1.schemas.metadata import Config
+from app.api.api_v1.schemas.metadata import Config, TaxonomyConfig
 from app.core.lookups import get_metadata
 from app.db.session import get_db
 from app.db.crud.document import get_document_ids
 from .router import lookups_router
 
+from app.core.organisation import get_organisation_taxonomy_by_name
 
-@lookups_router.get("/config", response_model=Config)
+
+@lookups_router.get("/config", response_model=Union[Config, TaxonomyConfig])
 def lookup_config(
     request: Request,
     db=Depends(get_db),
+    group_documents: bool = False,
 ):
     """Get the config for the metadata."""
-    return get_metadata(db)
+    if not group_documents:
+        return get_metadata(db)
+    else:
+        return get_organisation_taxonomy_by_name(db=db, org_name="CCLW")
 
 
 @lookups_router.get(

--- a/app/api/api_v1/schemas/metadata.py
+++ b/app/api/api_v1/schemas/metadata.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Any, Mapping, Optional
+from typing import Any, Mapping, Optional, Sequence, Union
 
 from pydantic import BaseModel
 
@@ -122,3 +122,10 @@ class Config(BaseModel):
     """Definition of the metadata response object."""
 
     metadata: SourceCollections
+
+
+class TaxonomyConfig(BaseModel):
+    """Definition of the new Config which just includes taxonomy."""
+
+    organisation: str
+    taxonomy: Mapping[str, Mapping[str, Union[str, Sequence[str]]]]

--- a/app/core/ingestion/family.py
+++ b/app/core/ingestion/family.py
@@ -3,7 +3,7 @@ from typing import Any, cast
 from sqlalchemy.orm import Session
 from app.core.ingestion.ingest_row import DocumentIngestRow
 from app.core.ingestion.metadata import add_metadata
-from app.core.ingestion.organisation import get_organisation_taxonomy
+from app.core.organisation import get_organisation_taxonomy
 from app.core.ingestion.physical_document import physical_document_from_row
 from app.core.ingestion.utils import get_or_create, to_dict
 

--- a/app/core/ingestion/processor.py
+++ b/app/core/ingestion/processor.py
@@ -10,7 +10,7 @@ from app.core.ingestion.ingest_row import (
     DocumentIngestRow,
     EventIngestRow,
 )
-from app.core.ingestion.organisation import get_organisation_taxonomy
+from app.core.organisation import get_organisation_taxonomy
 from app.core.ingestion.utils import IngestContext
 from app.core.ingestion.validator import validate_document_row
 from app.db.models.app.users import Organisation

--- a/app/core/organisation.py
+++ b/app/core/organisation.py
@@ -1,4 +1,6 @@
 from sqlalchemy.orm import Session
+from app.api.api_v1.schemas.metadata import TaxonomyConfig
+from app.db.models.app.users import Organisation
 from app.db.models.law_policy.metadata import MetadataOrganisation, MetadataTaxonomy
 from app.core.ingestion.metadata import Taxonomy, TaxonomyEntry
 
@@ -29,3 +31,21 @@ def get_organisation_taxonomy(db: Session, org_id: int) -> tuple[int, Taxonomy]:
     # The above line will throw if there is no taxonomy for the organisation
 
     return taxonomy[0], {k: TaxonomyEntry(**v) for k, v in taxonomy[1].items()}
+
+
+def get_organisation_taxonomy_by_name(db: Session, org_name: str) -> TaxonomyConfig:
+    taxonomy = (
+        db.query(MetadataTaxonomy.valid_metadata)
+        .join(
+            MetadataOrganisation,
+            MetadataOrganisation.taxonomy_id == MetadataTaxonomy.id,
+        )
+        .join(Organisation, Organisation.id == MetadataOrganisation.organisation_id)
+        .filter_by(name=org_name)
+        .one()
+    )
+    # The above line will throw if there is no taxonomy for the organisation
+    return TaxonomyConfig(
+        organisation=org_name,
+        taxonomy=taxonomy[0],
+    )

--- a/app/core/organisation.py
+++ b/app/core/organisation.py
@@ -9,15 +9,9 @@ def get_organisation_taxonomy(db: Session, org_id: int) -> tuple[int, Taxonomy]:
     """
     Returns the taxonomy id and its dict representation for an organisation.
 
-    Args:
-        db (Session): connection to database
-        org_id (int): organisation id
-
-    Raises:
-        ValueError: raised when taxonomy not found
-
-    Returns:
-        tuple[int, Taxonomy]: the taxonomy id and dict value
+    :param Session db: connection to the database
+    :param int org_id: organisation id
+    :return tuple[int, Taxonomy]: the taxonomy id and the Taxonomy
     """
     taxonomy = (
         db.query(MetadataTaxonomy.id, MetadataTaxonomy.valid_metadata)
@@ -34,6 +28,12 @@ def get_organisation_taxonomy(db: Session, org_id: int) -> tuple[int, Taxonomy]:
 
 
 def get_organisation_taxonomy_by_name(db: Session, org_name: str) -> TaxonomyConfig:
+    """
+    Returns the TaxonomyConfig for the named organisation
+
+    :param Session db: connection to the database
+    :return TaxonomyConfig: the TaxonomyConfig from the db
+    """
     taxonomy = (
         db.query(MetadataTaxonomy.valid_metadata)
         .join(

--- a/app/data_migrations/data/keyword_data.json
+++ b/app/data_migrations/data/keyword_data.json
@@ -870,5 +870,9 @@
   {
     "name": "Adaptation Planning",
     "description": "Adaptation Planning"
+  },
+  {
+    "name": "HFCs",
+    "description": "HFCs"
   }
 ]

--- a/tests/core/ingestion/test_metadata.py
+++ b/tests/core/ingestion/test_metadata.py
@@ -3,7 +3,7 @@ from sqlalchemy.exc import NoResultFound
 from sqlalchemy.orm import Session
 from app.core.ingestion.ingest_row import DocumentIngestRow
 from app.core.ingestion.metadata import build_metadata
-from app.core.ingestion.organisation import get_organisation_taxonomy
+from app.core.organisation import get_organisation_taxonomy
 from app.core.ingestion.utils import ResultType
 from tests.core.ingestion.helpers import get_doc_ingest_row_data, init_for_ingest
 

--- a/tests/core/ingestion/test_validate_row.py
+++ b/tests/core/ingestion/test_validate_row.py
@@ -1,7 +1,7 @@
 from app.core.ingestion.ingest_row import DocumentIngestRow
 from app.core.ingestion.utils import IngestContext, ResultType
 from app.core.ingestion.validator import validate_document_row
-from app.core.ingestion.organisation import get_organisation_taxonomy
+from app.core.organisation import get_organisation_taxonomy
 
 from tests.core.ingestion.helpers import (
     get_doc_ingest_row_data,

--- a/tests/core/validation/test_util.py
+++ b/tests/core/validation/test_util.py
@@ -13,6 +13,7 @@ from app.core.validation.util import (
     get_valid_metadata,
     write_documents_to_s3,
 )
+from app.data_migrations import populate_taxonomy
 from app.db.models.deprecated import Keyword, Sector, Source
 
 
@@ -81,6 +82,7 @@ def test__flatten_maybe_tree_is_a_tree(is_a_tree: Sequence, expected: Collection
 def test_valid_metadata(test_db):
     """Test the structure returned and a couple of added values"""
 
+    populate_taxonomy(test_db)
     # Add some test data
     test_db.add(Source(name="Primary"))
     test_db.commit()

--- a/tests/routes/test_config.py
+++ b/tests/routes/test_config.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from app.core.util import tree_table_to_json
+from app.data_migrations import populate_taxonomy
 from app.db.session import SessionLocal
 from tests.routes.test_documents import create_4_documents
 
@@ -33,6 +34,31 @@ def test_endpoint_returns_correct_keys(client):
         "sectors",
         "sources",
         "topics",
+    }
+
+
+def test_endpoint_returns_taxonomy(client, test_db):
+    """Tests whether we get the correct data when the /config endpoint is called."""
+    url_under_test = "/api/v1/config?group_documents=True"
+    populate_taxonomy(test_db)
+    test_db.flush()
+
+    response = client.get(
+        url_under_test,
+    )
+
+    response_json = response.json()
+
+    assert response.status_code == OK
+    assert response_json["organisation"] == "CCLW"
+    assert set(response_json["taxonomy"]) == {
+        "instrument",
+        "keyword",
+        "sector",
+        "document_type",
+        "topic",
+        "framework",
+        "hazard",
     }
 
 


### PR DESCRIPTION
# Description

New return from `/config` when using the query param `group_documents=True` - Similar to the other endpoint so we are able to support both the old style and new style endpoints.

In the case of `group_document` being enabled (new style) - the return value includes the orgainisation and the taxonomy:
```
{
  organisation: "...",
  taxonomy: { ... }
}
``` 
Includes new test.

Adds a keyword too - see https://climate-policy-radar.slack.com/archives/C02ET708QDP/p1677672962069199?thread_ts=1676476399.009199&cid=C02ET708QDP

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
