### PR TITLE
Adding the source url and cdn object as optional fields as they are n…

### DIFF
--- a/app/api/api_v1/schemas/document.py
+++ b/app/api/api_v1/schemas/document.py
@@ -43,8 +43,8 @@ class FamilyDocumentsResponse(BaseModel):
     # What follows is off PhysicalDocument
     title: str
     md5_sum: Optional[str]
-    cdn_object: str
-    source_url: str
+    cdn_object: Optional[str]
+    source_url: Optional[str]
     content_type: Optional[str]
 
 


### PR DESCRIPTION
…ullable in the db.

# Description

Pydantic validation error is being thrown on the FamilyDocumentsResponse.

This is because the type expects cdn object to be a string but it is nullable in the db. 

Therefore, updating the cdn object and source url to be Optional as they are both nullable in the db. 

Please include:
- a summary of the changes
- links to any related issue/ticket
- any additional relevant motivation and context
- details of any dependency updates that are required for this change

## Type of change

Please select the option(s) below that are most relevant:

- [ x] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
