### PR TITLE
Return a FamilyDocument from /documents when using a doc slug

### DIFF
--- a/app/api/api_v1/routers/documents.py
+++ b/app/api/api_v1/routers/documents.py
@@ -1,4 +1,4 @@
-from http.client import NOT_FOUND
+from http.client import INTERNAL_SERVER_ERROR, NOT_FOUND
 import logging
 from typing import List, Union
 
@@ -12,7 +12,7 @@ from fastapi import (
 from app.core.auth import (
     get_current_active_superuser,
 )
-from app.db.crud.document import get_family_and_documents
+from app.db.crud.document import get_family_and_documents, get_slugged_objects
 
 from app.db.crud.deprecated_document import (
     create_document_relationship,
@@ -28,6 +28,7 @@ from app.api.api_v1.schemas.document import (
     DocumentDetailResponse,
     DocumentOverviewResponse,
     FamilyAndDocumentsResponse,
+    FamilyDocumentWithContextResponse,
     RelationshipAndDocumentsGetResponse,
     RelationshipCreateRequest,
     RelationshipEntityResponse,
@@ -67,7 +68,11 @@ async def document_browse(
 
 @documents_router.get(
     "/documents/{import_id_or_slug}",
-    response_model=Union[DocumentDetailResponse, FamilyAndDocumentsResponse],
+    response_model=Union[
+        DocumentDetailResponse,
+        FamilyAndDocumentsResponse,
+        FamilyDocumentWithContextResponse,
+    ],
 )
 async def document_detail(
     import_id_or_slug: str,
@@ -87,11 +92,24 @@ async def document_detail(
     if not group_documents:
         return get_document_detail(db, import_id_or_slug)
 
-    response = get_family_and_documents(db, import_id_or_slug)
-    if response:
-        return response
+    ids = get_slugged_objects(db, import_id_or_slug)
+    if not ids:
+        raise HTTPException(
+            status_code=NOT_FOUND, detail=f"Nothing found for {import_id_or_slug}"
+        )
+
+    family_document_import_id, family_import_id = ids
+
+    if family_import_id:
+        response = get_family_and_documents(db, family_import_id)
+        if response:
+            return response
+    elif family_document_import_id:
+        pass  # TODO: write new code to return a FamilyDocumentWithContextResponse
+
     raise HTTPException(
-        status_code=NOT_FOUND, detail=f"Nothing found for {import_id_or_slug}"
+        status_code=INTERNAL_SERVER_ERROR,
+        detail=f"Slug entry found and not pointing at anything: {import_id_or_slug}",
     )
 
 

--- a/app/api/api_v1/routers/documents.py
+++ b/app/api/api_v1/routers/documents.py
@@ -12,7 +12,11 @@ from fastapi import (
 from app.core.auth import (
     get_current_active_superuser,
 )
-from app.db.crud.document import get_family_and_documents, get_slugged_objects
+from app.db.crud.document import (
+    get_family_and_documents,
+    get_family_document_and_context,
+    get_slugged_objects,
+)
 
 from app.db.crud.deprecated_document import (
     create_document_relationship,
@@ -100,12 +104,15 @@ async def document_detail(
 
     family_document_import_id, family_import_id = ids
 
+    response = None
+
     if family_import_id:
         response = get_family_and_documents(db, family_import_id)
-        if response:
-            return response
     elif family_document_import_id:
-        pass  # TODO: write new code to return a FamilyDocumentWithContextResponse
+        response = get_family_document_and_context(db, family_document_import_id)
+
+    if response:
+        return response
 
     raise HTTPException(
         status_code=INTERNAL_SERVER_ERROR,

--- a/app/api/api_v1/schemas/document.py
+++ b/app/api/api_v1/schemas/document.py
@@ -55,6 +55,7 @@ class FamilyEventsResponse(BaseModel):
 class FamilyDocumentResponse(BaseModel):
     """Response for a FamilyDocument, without any family information"""
 
+    import_id: str
     variant: str
     slugs: list[str]
     # What follows is off PhysicalDocument
@@ -69,6 +70,7 @@ class FamilyContext(BaseModel):
     """Used to given the family context when returning a FamilyDocument"""
 
     title: str
+    import_id: str
     geography: str
     slugs: list[str]
     published_date: Optional[datetime]

--- a/app/api/api_v1/schemas/document.py
+++ b/app/api/api_v1/schemas/document.py
@@ -88,6 +88,7 @@ class FamilyAndDocumentsResponse(BaseModel):
     """Response for a Family and its Documents, part of documents endpoints"""
 
     organisation: str
+    import_id: str
     title: str
     summary: str
     geography: str

--- a/app/api/api_v1/schemas/document.py
+++ b/app/api/api_v1/schemas/document.py
@@ -35,19 +35,6 @@ class DocumentOverviewResponse(BaseModel):  # noqa: D101
         frozen = True
 
 
-class FamilyDocumentsResponse(BaseModel):
-    """Response for a FamilyDocument, part of documents endpoints"""
-
-    variant: str
-    slugs: list[str]
-    # What follows is off PhysicalDocument
-    title: str
-    md5_sum: Optional[str]
-    cdn_object: Optional[str]
-    source_url: Optional[str]
-    content_type: Optional[str]
-
-
 class CollectionOverviewResponse(BaseModel):
     """Response for a Collection - without families"""
 
@@ -65,6 +52,36 @@ class FamilyEventsResponse(BaseModel):
     status: str
 
 
+class FamilyDocumentResponse(BaseModel):
+    """Response for a FamilyDocument, without any family information"""
+
+    variant: str
+    slugs: list[str]
+    # What follows is off PhysicalDocument
+    title: str
+    md5_sum: Optional[str]
+    cdn_object: Optional[str]
+    source_url: Optional[str]
+    content_type: Optional[str]
+
+
+class FamilyContext(BaseModel):
+    """Used to given the family context when returning a FamilyDocument"""
+
+    title: str
+    geography: str
+    slugs: list[str]
+    published_date: Optional[datetime]
+    last_updated_date: Optional[datetime]
+
+
+class FamilyDocumentWithContextResponse(BaseModel):
+    """Response for a FamilyDocument with its family's context"""
+
+    family: FamilyContext
+    document: FamilyDocumentResponse
+
+
 class FamilyAndDocumentsResponse(BaseModel):
     """Response for a Family and its Documents, part of documents endpoints"""
 
@@ -79,7 +96,7 @@ class FamilyAndDocumentsResponse(BaseModel):
     events: list[FamilyEventsResponse]
     published_date: Optional[datetime]
     last_updated_date: Optional[datetime]
-    documents: list[FamilyDocumentsResponse]
+    documents: list[FamilyDocumentResponse]
     collections: list[CollectionOverviewResponse]
 
 

--- a/app/db/crud/document.py
+++ b/app/db/crud/document.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import Session
 from app.api.api_v1.schemas.document import (
     CollectionOverviewResponse,
     FamilyAndDocumentsResponse,
-    FamilyDocumentsResponse,
+    FamilyDocumentResponse,
     FamilyEventsResponse,
 )
 from app.db.models.app.users import Organisation
@@ -28,43 +28,54 @@ from app.db.models.law_policy.metadata import FamilyMetadata
 _LOGGER = logging.getLogger(__file__)
 
 
+def get_slugged_objects(db: Session, slug: str) -> tuple[Optional[str], Optional[str]]:
+    """
+    Matches the slug name to a FamilyDocument or Family import_id
+
+    :param Session db: connection to db
+    :param str slug: slug name to match
+    :return tuple[Optional[str], Optional[str]]: the FamilyDocument import id or
+    the Family import_id
+    """
+    return (
+        db.query(Slug.family_document_import_id, Slug.family_import_id).filter(
+            Slug.name == slug
+        )
+    ).one_or_none()
+
+
 def get_family_and_documents(
-    db: Session, slug: str
+    db: Session, import_id: str
 ) -> Optional[FamilyAndDocumentsResponse]:
     """
     Get a document along with the family information.
 
     :param Session db: connection to db
-    :param str slug: id of document
+    :param str import_id: id of document
     :return DocumentWithFamilyResponse: response object
     """
 
     db_objects = (
-        db.query(
-            Family, Geography, Slug, FamilyMetadata, FamilyOrganisation, Organisation
-        )
+        db.query(Family, Geography, FamilyMetadata, FamilyOrganisation, Organisation)
+        .filter(Family.import_id == import_id)
         .filter(Family.geography_id == Geography.id)
-        .filter(Family.import_id == FamilyMetadata.family_import_id)
-        .filter(Family.import_id == Slug.family_import_id)
-        .filter(Family.import_id == FamilyOrganisation.family_import_id)
+        .filter(import_id == FamilyMetadata.family_import_id)
+        .filter(import_id == FamilyOrganisation.family_import_id)
         .filter(FamilyOrganisation.organisation_id == Organisation.id)
-        .filter(Slug.name == slug)
     ).one_or_none()
 
     if not db_objects:
-        _LOGGER.warning("No family found for slug", extra={"slug": slug})
+        _LOGGER.warning("No family found for import_id", extra={"slug": import_id})
         return None
 
     family: Family
     (
         family,
         geography,
-        slug,
         family_metadata,
-        family_organisation,
+        _,
         organisation,
     ) = db_objects
-    import_id = cast(str, family.import_id)
 
     slugs = _get_slugs_for_family_import_id(db, import_id)
     events = _get_events_for_family_import_id(db, import_id)
@@ -139,7 +150,7 @@ def _get_events_for_family_import_id(
 
 def _get_documents_for_family_import_id(
     db: Session, import_id: str
-) -> list[FamilyDocumentsResponse]:
+) -> list[FamilyDocumentResponse]:
     db_documents = (
         db.query(FamilyDocument, PhysicalDocument)
         .filter(FamilyDocument.family_import_id == import_id)
@@ -147,7 +158,7 @@ def _get_documents_for_family_import_id(
     )
 
     documents = [
-        FamilyDocumentsResponse(
+        FamilyDocumentResponse(
             variant=d.variant_name,
             slugs=_get_slugs_for_family_document_import_id(db, d.import_id),
             # What follows is off PhysicalDocument

--- a/app/db/crud/document.py
+++ b/app/db/crud/document.py
@@ -127,6 +127,7 @@ def get_family_and_documents(
 
     return FamilyAndDocumentsResponse(
         organisation=cast(str, organisation.name),
+        import_id=import_id,
         title=cast(str, family.title),
         summary=cast(str, family.description),
         geography=cast(str, geography.value),

--- a/app/db/crud/document.py
+++ b/app/db/crud/document.py
@@ -159,6 +159,7 @@ def _get_documents_for_family_import_id(
 
     documents = [
         FamilyDocumentResponse(
+            import_id=d.import_id,
             variant=d.variant_name,
             slugs=_get_slugs_for_family_document_import_id(db, d.import_id),
             # What follows is off PhysicalDocument

--- a/tests/routes/test_documents.py
+++ b/tests/routes/test_documents.py
@@ -129,7 +129,7 @@ def populate_old_documents(test_db):
     test_db.commit()
 
 
-def test_documents_with_preexisting_objects_not_found(
+def test_documents_family_slug_preexisting_objects_not_found(
     client: TestClient,
     test_db: Session,
     mocker: Callable[..., Generator[MockerFixture, None, None]],
@@ -145,7 +145,7 @@ def test_documents_with_preexisting_objects_not_found(
     assert response.status_code == 404
 
 
-def test_documents_with_preexisting_objects(
+def test_documents_family_slug_preexisting_objects(
     client: TestClient,
     test_db: Session,
     mocker: Callable[..., Generator[MockerFixture, None, None]],
@@ -161,8 +161,9 @@ def test_documents_with_preexisting_objects(
     )
     json_response = response.json()
     assert response.status_code == 200
-    assert len(json_response) == 13
+    assert len(json_response) == 14
     assert json_response["organisation"] == "CCLW"
+    assert json_response["import_id"] == "CCLW.family.1001.0"
     assert json_response["title"] == "Fam1"
     assert json_response["summary"] == "Summary1"
     assert json_response["geography"] == "GEO"
@@ -183,6 +184,7 @@ def test_documents_with_preexisting_objects(
     assert len(json_response["documents"]) == 1
     assert json_response["documents"][0]["title"] == "Title1"
     assert json_response["documents"][0]["slugs"] == ["DocSlug1"]
+    assert json_response["documents"][0]["import_id"] == "CCLW.executive.1.2"
 
     assert len(json_response["collections"]) == 1
     assert json_response["collections"][0]["title"] == "Collection1"
@@ -192,9 +194,10 @@ def test_documents_with_preexisting_objects(
     )
     json_response = response.json()
     assert response.status_code == 200
-    assert len(json_response) == 13
+    assert len(json_response) == 14
     assert json_response["organisation"] == "CCLW"
     assert json_response["title"] == "Fam2"
+    assert json_response["import_id"] == "CCLW.family.2002.0"
     assert json_response["summary"] == "Summary2"
     assert json_response["geography"] == "GEO"
     assert json_response["category"] == "Executive"
@@ -214,6 +217,7 @@ def test_documents_with_preexisting_objects(
     assert len(json_response["documents"]) == 1
     assert json_response["documents"][0]["title"] == "Title2"
     assert json_response["documents"][0]["slugs"] == ["DocSlug2"]
+    assert json_response["documents"][0]["import_id"] == "CCLW.executive.2.2"
 
     assert len(json_response["collections"]) == 1
     assert json_response["collections"][0]["title"] == "Collection2"


### PR DESCRIPTION
# Description
- import_id included for families and documents
- document slug can now be used to return a document object + family context

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
