### PR TITLE
Feature/validate data

### DIFF
--- a/app/api/api_v1/schemas/document.py
+++ b/app/api/api_v1/schemas/document.py
@@ -282,3 +282,17 @@ class ClimateLawsValidationResult(BaseModel):
     all_valid: bool
     no_cdn: list[tuple[Any, Any]]
     no_cdn_count: int
+
+
+class RDSDataValidationResult(BaseModel):
+    """Response for the data validation endpoint for analysing the new and deprecated document data."""
+
+    family_document_ids: list[str]
+    family_document_id_count: int
+    deprecated_document_ids: list[str]
+    deprecated_document_id_count: int
+    family_not_in_deprecated_ids: list[str]
+    family_not_in_deprecated_id_count: int
+    deprecated_not_in_family_ids: list[str]
+    deprecated_not_in_family_id_count: int
+    valid: bool

--- a/app/core/validate.py
+++ b/app/core/validate.py
@@ -6,6 +6,7 @@ from app.db.models.deprecated.document import (
     Document,
 )
 from app.db.models.document import PhysicalDocument
+from app.db.models.law_policy import FamilyDocument, DocumentStatus
 
 
 def physical_document_source_urls(db: Session) -> list[tuple[str, str]]:
@@ -23,3 +24,21 @@ def document_source_urls(db: Session) -> list[tuple[str, str]]:
     documents = (db.query(Document)).all()
 
     return [(document.source_url, document.cdn_object) for document in documents]
+
+
+def family_document_ids(db: Session) -> list[str]:
+    """Get a list of all document IDs for published family documents."""
+    family_documents = (
+        db.query(FamilyDocument).filter(
+            FamilyDocument.document_status == DocumentStatus.PUBLISHED,
+        )
+    ).all()
+
+    return [family_document.import_id for family_document in family_documents]
+
+
+def document_ids(db: Session) -> list[str]:
+    """Get a list of all document IDs for published family documents."""
+    documents = (db.query(Document)).all()
+
+    return [document.import_id for document in documents]


### PR DESCRIPTION
# Description

Please include:
- a summary of the changes
- links to any related issue/ticket
- any additional relevant motivation and context
- details of any dependency updates that are required for this change

## Type of change

Implementing a new endpoint for validation of the old format data vs the new format data in the rds database. 

This is so that we can assert that all documents of the deprecated format exist in the new dfc format. 

https://linear.app/climate-policy-radar/issue/DAT-76/identify-solution-for-validating-the-state-of-the-data

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
