### PR TITLE
Add family slugs as a property on collections

### DIFF
--- a/app/api/api_v1/schemas/document.py
+++ b/app/api/api_v1/schemas/document.py
@@ -35,13 +35,21 @@ class DocumentOverviewResponse(BaseModel):  # noqa: D101
         frozen = True
 
 
+class LinkableFamily(BaseModel):
+    """For the frontend the minimum information to link to a family"""
+
+    title: str
+    slug: str
+    description: str
+
+
 class CollectionOverviewResponse(BaseModel):
     """Response for a Collection - without families"""
 
     import_id: str
     title: str
     description: str
-    families: list[str]
+    families: list[LinkableFamily]
 
 
 class FamilyEventsResponse(BaseModel):

--- a/app/api/api_v1/schemas/document.py
+++ b/app/api/api_v1/schemas/document.py
@@ -41,6 +41,7 @@ class CollectionOverviewResponse(BaseModel):
     import_id: str
     title: str
     description: str
+    families: list[str]
 
 
 class FamilyEventsResponse(BaseModel):

--- a/app/db/crud/document.py
+++ b/app/db/crud/document.py
@@ -187,7 +187,17 @@ def _get_collections_for_family_import_id(
 
     return [
         CollectionOverviewResponse(
-            title=c.title, description=c.description, import_id=c.import_id
+            title=c.title,
+            description=c.description,
+            import_id=c.import_id,
+            families=[
+                name[0]
+                for name in db.query(Slug.name)
+                .filter(Slug.family_import_id == Family.import_id)
+                .filter(CollectionFamily.family_import_id == Family.import_id)
+                .filter(CollectionFamily.collection_import_id == c.import_id)
+                .all()
+            ],
         )
         for c in db_collections
     ]

--- a/app/db/crud/document.py
+++ b/app/db/crud/document.py
@@ -13,6 +13,7 @@ from app.api.api_v1.schemas.document import (
     FamilyDocumentResponse,
     FamilyDocumentWithContextResponse,
     FamilyEventsResponse,
+    LinkableFamily,
 )
 from app.db.models.app.users import Organisation
 from app.db.models.document.physical_document import (
@@ -191,8 +192,8 @@ def _get_collections_for_family_import_id(
             description=c.description,
             import_id=c.import_id,
             families=[
-                name[0]
-                for name in db.query(Slug.name)
+                LinkableFamily(slug=data[0], title=data[1], description=data[2])
+                for data in db.query(Slug.name, Family.title, Family.description)
                 .filter(Slug.family_import_id == Family.import_id)
                 .filter(CollectionFamily.family_import_id == Family.import_id)
                 .filter(CollectionFamily.collection_import_id == c.import_id)

--- a/tests/routes/test_documents.py
+++ b/tests/routes/test_documents.py
@@ -190,10 +190,6 @@ def test_documents_family_slug_preexisting_objects(
     assert len(json_response["collections"]) == 1
     assert json_response["collections"][0]["title"] == "Collection1"
 
-    import json
-
-    print(json.dumps(json_response))
-    assert 0
     assert json_response["collections"][0]["families"] == [
         {"title": "Fam1", "slug": "FamSlug1", "description": "Summary1"},
         {"title": "Fam2", "slug": "FamSlug2", "description": "Summary2"},

--- a/tests/routes/test_documents.py
+++ b/tests/routes/test_documents.py
@@ -19,7 +19,6 @@ from app.db.models.deprecated.document import (
 )
 from app.db.models.deprecated.source import Source
 from app.db.models.document.physical_document import Language, PhysicalDocument
-from app.db.models.law_policy.collection import Collection
 from app.db.models.law_policy.family import Family, FamilyEvent
 from app.db.models.law_policy.geography import Geography
 
@@ -155,8 +154,6 @@ def test_documents_family_slug_preexisting_objects(
     assert test_db.query(PhysicalDocument).count() == 2
     assert test_db.query(Family).count() == 2
     assert test_db.query(FamilyEvent).count() == 2
-    print(test_db.query(Collection).all())
-    assert test_db.query(Collection).count() == 1
 
     # Test associations
     response = client.get(

--- a/tests/routes/test_documents.py
+++ b/tests/routes/test_documents.py
@@ -189,9 +189,14 @@ def test_documents_family_slug_preexisting_objects(
 
     assert len(json_response["collections"]) == 1
     assert json_response["collections"][0]["title"] == "Collection1"
+
+    import json
+
+    print(json.dumps(json_response))
+    assert 0
     assert json_response["collections"][0]["families"] == [
-        "FamSlug1",
-        "FamSlug2",
+        {"title": "Fam1", "slug": "FamSlug1", "description": "Summary1"},
+        {"title": "Fam2", "slug": "FamSlug2", "description": "Summary2"},
     ]
 
     # Ensure a different family is returned


### PR DESCRIPTION
# Description
- Return a list of family slugs that are in a collection - when the `/documents` endpoint is called with a doc slug
### Example response:
```
{
  "organisation": "CCLW",
  "import_id": "CCLW.family.1001.0",
  "title": "Fam1",
  "summary": "Summary1",
  "geography": "GEO",
  "category": "Executive",
  "status": "Published",
  "metadata": {
    "topic": [
      "Mitigation"
    ],
    "hazard": [],
    "sector": [
      "Energy"
    ],
    "keyword": [
      "Energy Supply"
    ],
    "framework": [],
    "instrument": [],
    "document_type": "Order"
  },
  "slugs": [
    "FamSlug1"
  ],
  "events": [
    {
      "title": "Published",
      "date": "2019-12-25T00:00:00+00:00",
      "event_type": "Passed/Approved",
      "status": "Ok"
    }
  ],
  "published_date": "2019-12-25T00:00:00+00:00",
  "last_updated_date": "2019-12-25T00:00:00+00:00",
  "documents": [
    {
      "import_id": "CCLW.executive.1.2",
      "variant": "MAIN",
      "slugs": [
        "DocSlug1"
      ],
      "title": "Title1",
      "md5_sum": null,
      "cdn_object": "https://cdn.climatepolicyradar.org/",
      "source_url": "http://somewhere",
      "content_type": null,
      "language": "",
      "document_type": "Order"
    }
  ],
  "collections": [
    {
      "import_id": "CPR.Collection.1",
      "title": "Collection1",
      "description": "CollectionSummary1",
      "families": [
        {
          "title": "Fam1",
          "slug": "FamSlug1",
          "description": "Summary1"
        },
        {
          "title": "Fam2",
          "slug": "FamSlug2",
          "description": "Summary2"
        }
      ]
    }
  ]
}

```
## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [x] The PR represents a single feature (small driveby fixes are also ok)
- [x] The PR includes tests that are sufficient for the level of risk
- [x] The code is sufficiently commented, particularly in hard-to-understand areas
- [x] Any required documentation updates have been made
- [x] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
