### PR TITLE
Bugfix - Fixing Attribute Error 

### DIFF
--- a/app/db/crud/document.py
+++ b/app/db/crud/document.py
@@ -102,9 +102,7 @@ def _get_language_for_phys_doc(db: Session, physical_document_id: str) -> str:
         .filter(Language.id == PhysicalDocumentLanguage.language_id)
     ).one_or_none()
 
-    # I do not fully understand why the strip() below is required, but without it
-    # we see trailing spaces on the language code.
-    return str(language.language_code).strip() if language is not None else ""
+    return cast(str, language.language_code) if language is not None else ""
 
 
 def get_family_and_documents(

--- a/app/db/crud/document.py
+++ b/app/db/crud/document.py
@@ -102,7 +102,7 @@ def _get_language_for_phys_doc(db: Session, physical_document_id: str) -> str:
         .filter(Language.id == PhysicalDocumentLanguage.language_id)
     ).one_or_none()
 
-    return cast(str, language.code) if hasattr(language, "code") else ""
+    return cast(str, language.language_code) if language is not None else ""
 
 
 def get_family_and_documents(

--- a/app/db/crud/document.py
+++ b/app/db/crud/document.py
@@ -102,7 +102,7 @@ def _get_language_for_phys_doc(db: Session, physical_document_id: str) -> str:
         .filter(Language.id == PhysicalDocumentLanguage.language_id)
     ).one_or_none()
 
-    return cast(str, language.code) if language else ""
+    return cast(str, language.code) if hasattr(language, "code") else ""
 
 
 def get_family_and_documents(

--- a/app/db/crud/document.py
+++ b/app/db/crud/document.py
@@ -102,7 +102,9 @@ def _get_language_for_phys_doc(db: Session, physical_document_id: str) -> str:
         .filter(Language.id == PhysicalDocumentLanguage.language_id)
     ).one_or_none()
 
-    return cast(str, language.language_code) if language is not None else ""
+    # I do not fully understand why the strip() below is required, but without it
+    # we see trailing spaces on the language code.
+    return str(language.language_code).strip() if language is not None else ""
 
 
 def get_family_and_documents(

--- a/tests/routes/test_documents.py
+++ b/tests/routes/test_documents.py
@@ -139,8 +139,8 @@ def populate_old_documents(test_db):
 
 
 def populate_languages(test_db):
-    test_db.add(Language(language_code="en", name="English"))
-    test_db.add(Language(language_code="fr", name="French"))
+    test_db.add(Language(language_code="eng", name="English"))
+    test_db.add(Language(language_code="fra", name="French"))
     test_db.commit()
 
 
@@ -320,7 +320,7 @@ def test_physical_doc_languages(
 
     assert response.status_code == 200
     print(json_response)
-    assert document["language"] == "en"
+    assert document["language"] == "eng"
 
     response = client.get(
         "/api/v1/documents/DocSlug2?group_documents=True",

--- a/tests/routes/test_documents.py
+++ b/tests/routes/test_documents.py
@@ -1,5 +1,7 @@
 from datetime import datetime
 from typing import Callable, Generator
+
+import pytest
 from sqlalchemy.orm import Session
 
 from fastapi.testclient import TestClient
@@ -36,6 +38,11 @@ TWO_DFC_ROW = """ID,Document ID,CCLW Description,Part of collection?,Create new 
 2002,0,Test2,FALSE,FALSE,N/A,Collection2,CollectionSummary2,Title2,Fam2,Summary2,,MAIN,,GEO,http://another_somewhere|en,executive,03/03/2024|Law passed,Energy,,,Mitigation,,Order,,,Energy Supply,Algeria,,,CCLW.executive.2.2,CCLW.family.2002.0,CPR.Collection.2,FamSlug2,DocSlug2
 """
 
+TWO_DFC_ROW_ONE_LANGUAGE = """ID,Document ID,CCLW Description,Part of collection?,Create new family/ies?,Collection ID,Collection name,Collection summary,Document title,Family name,Family summary,Family ID,Document role,Applies to ID,Geography ISO,Documents,Category,Events,Sectors,Instruments,Frameworks,Responses,Natural Hazards,Document Type,Year,Language,Keywords,Geography,Parent Legislation,Comment,CPR Document ID,CPR Family ID,CPR Collection ID,CPR Family Slug,CPR Document Slug
+1001,0,Test1,FALSE,FALSE,N/A,Collection1,CollectionSummary1,Title1,Fam1,Summary1,,MAIN,,GEO,http://somewhere|en,executive,02/02/2014|Law passed,Energy,,,Mitigation,,Order,,en,Energy Supply,Algeria,,,CCLW.executive.1.2,CCLW.family.1001.0,CPR.Collection.1,FamSlug1,DocSlug1
+2002,0,Test2,FALSE,FALSE,N/A,Collection2,CollectionSummary2,Title2,Fam2,Summary2,,MAIN,,GEO,http://another_somewhere|en,executive,03/03/2024|Law passed,Energy,,,Mitigation,,Order,,,Energy Supply,Algeria,,,CCLW.executive.2.2,CCLW.family.2002.0,CPR.Collection.2,FamSlug2,DocSlug2
+"""
+
 TWO_EVENT_ROWS = """Id,Eventable type,Eventable Id,Eventable name,Event type,Title,Description,Date,Url,CPR Event ID,CPR Family ID,Event Status
 1101,Legislation,1001,Title1,Passed/Approved,Published,,2019-12-25,,CCLW.legislation_event.1101.0,CCLW.family.1001.0,OK
 2202,Legislation,2002,Title2,Passed/Approved,Published,,2019-12-25,,CCLW.legislation_event.2202.0,CCLW.family.2002.0,OK
@@ -55,7 +62,9 @@ def setup_with_docs(test_db, mocker):
     test_db.commit()
 
 
-def setup_with_two_docs(test_db, mocker):
+def setup_with_two_docs(
+    test_db, mocker, doc_data=TWO_DFC_ROW, event_data=TWO_EVENT_ROWS
+):
     mock_s3 = mocker.patch("app.core.aws.S3Client")
 
     populate_taxonomy(test_db)
@@ -64,7 +73,7 @@ def setup_with_two_docs(test_db, mocker):
 
     populate_old_documents(test_db)
 
-    _start_ingest(test_db, mock_s3, "s3_prefix", TWO_DFC_ROW, TWO_EVENT_ROWS)
+    _start_ingest(test_db, mock_s3, "s3_prefix", doc_data, event_data)
     test_db.commit()
 
 
@@ -126,6 +135,12 @@ def populate_old_documents(test_db):
             category_id=1,
         )
     )
+    test_db.commit()
+
+
+def populate_languages(test_db):
+    test_db.add(Language(language_code="en", name="English"))
+    test_db.add(Language(language_code="fr", name="French"))
     test_db.commit()
 
 
@@ -281,3 +296,37 @@ def test_documents_doc_slug_preexisting_objects(
     assert doc["source_url"] == "http://another_somewhere"
     assert doc["language"] == ""
     assert doc["document_type"] == "Order"
+
+
+@pytest.mark.languages
+def test_physical_doc_languages(
+    client: TestClient,
+    test_db: Session,
+    mocker: Callable[..., Generator[MockerFixture, None, None]],
+):
+    setup_with_two_docs(test_db, mocker, doc_data=TWO_DFC_ROW_ONE_LANGUAGE)
+    populate_languages(test_db)
+
+    assert test_db.query(Language).count() == 3
+    assert test_db.query(PhysicalDocument).count() == 2
+    assert test_db.query(Family).count() == 2
+    assert test_db.query(FamilyEvent).count() == 2
+
+    response = client.get(
+        "/api/v1/documents/DocSlug1?group_documents=True",
+    )
+    json_response = response.json()
+    document = json_response["document"]
+
+    assert response.status_code == 200
+    print(json_response)
+    assert document["language"] == "en"
+
+    response = client.get(
+        "/api/v1/documents/DocSlug2?group_documents=True",
+    )
+    json_response = response.json()
+    document = json_response["document"]
+
+    assert response.status_code == 200
+    assert document["language"] == ""

--- a/tests/routes/test_documents.py
+++ b/tests/routes/test_documents.py
@@ -39,7 +39,7 @@ TWO_DFC_ROW = """ID,Document ID,CCLW Description,Part of collection?,Create new 
 """
 
 TWO_DFC_ROW_ONE_LANGUAGE = """ID,Document ID,CCLW Description,Part of collection?,Create new family/ies?,Collection ID,Collection name,Collection summary,Document title,Family name,Family summary,Family ID,Document role,Applies to ID,Geography ISO,Documents,Category,Events,Sectors,Instruments,Frameworks,Responses,Natural Hazards,Document Type,Year,Language,Keywords,Geography,Parent Legislation,Comment,CPR Document ID,CPR Family ID,CPR Collection ID,CPR Family Slug,CPR Document Slug
-1001,0,Test1,FALSE,FALSE,N/A,Collection1,CollectionSummary1,Title1,Fam1,Summary1,,MAIN,,GEO,http://somewhere|en,executive,02/02/2014|Law passed,Energy,,,Mitigation,,Order,,en,Energy Supply,Algeria,,,CCLW.executive.1.2,CCLW.family.1001.0,CPR.Collection.1,FamSlug1,DocSlug1
+1001,0,Test1,FALSE,FALSE,N/A,Collection1,CollectionSummary1,Title1,Fam1,Summary1,,MAIN,,GEO,http://somewhere|en,executive,02/02/2014|Law passed,Energy,,,Mitigation,,Order,,English,Energy Supply,Algeria,,,CCLW.executive.1.2,CCLW.family.1001.0,CPR.Collection.1,FamSlug1,DocSlug1
 2002,0,Test2,FALSE,FALSE,N/A,Collection2,CollectionSummary2,Title2,Fam2,Summary2,,MAIN,,GEO,http://another_somewhere|en,executive,03/03/2024|Law passed,Energy,,,Mitigation,,Order,,,Energy Supply,Algeria,,,CCLW.executive.2.2,CCLW.family.2002.0,CPR.Collection.2,FamSlug2,DocSlug2
 """
 
@@ -304,8 +304,8 @@ def test_physical_doc_languages(
     test_db: Session,
     mocker: Callable[..., Generator[MockerFixture, None, None]],
 ):
-    setup_with_two_docs(test_db, mocker, doc_data=TWO_DFC_ROW_ONE_LANGUAGE)
     populate_languages(test_db)
+    setup_with_two_docs(test_db, mocker, doc_data=TWO_DFC_ROW_ONE_LANGUAGE)
 
     assert test_db.query(Language).count() == 3
     assert test_db.query(PhysicalDocument).count() == 2


### PR DESCRIPTION
# Description


Traceback of the error experienced in the backend code: 

          AttributeError: 'Language' object has no attribute 'code'
          
This error comes from the following line:

https://github.com/climatepolicyradar/navigator-backend/blob/main/app/db/crud/document.py#L105 


Please include:
- a summary of the changes
- links to any related issue/ticket
- any additional relevant motivation and context
- details of any dependency updates that are required for this change

## Type of change

Please select the option(s) below that are most relevant:

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
