### PR TITLE
BAK-1330 Add document role, add values in init_data

### DIFF
--- a/alembic/versions/0013_families_and_collections.py
+++ b/alembic/versions/0013_families_and_collections.py
@@ -29,6 +29,11 @@ def upgrade():
     sa.Column('description', sa.Text(), nullable=False),
     sa.PrimaryKeyConstraint('name', name=op.f('pk_family_document_type'))
     )
+    op.create_table('family_document_role',
+    sa.Column('name', sa.Text(), nullable=False),
+    sa.Column('description', sa.Text(), nullable=False),
+    sa.PrimaryKeyConstraint('name', name=op.f('pk_family_document_role'))
+    )
     op.create_table('family_event_type',
     sa.Column('name', sa.Text(), nullable=False),
     sa.Column('description', sa.Text(), nullable=False),
@@ -82,8 +87,10 @@ def upgrade():
     sa.Column('import_id', sa.Text(), nullable=False),
     sa.Column('variant_name', sa.Text(), nullable=False),
     sa.Column('document_status', sa.Enum('CREATED', 'PUBLISHED', 'DELETED', name='documentstatus'), nullable=False),
-    sa.Column('document_type', sa.Text(), nullable=False),
+    sa.Column('document_type', sa.Text(), nullable=True),
+    sa.Column('document_role', sa.Text(), nullable=True),
     sa.ForeignKeyConstraint(['document_type'], ['family_document_type.name'], name=op.f('fk_family_document__document_type__family_document_type')),
+    sa.ForeignKeyConstraint(['document_role'], ['family_document_role.name'], name=op.f('fk_family_document__document_role__family_document_role')),
     sa.ForeignKeyConstraint(['family_import_id'], ['family.import_id'], name=op.f('fk_family_document__family_import_id__family')),
     sa.ForeignKeyConstraint(['physical_document_id'], ['physical_document.id'], name=op.f('fk_family_document__physical_document_id__physical_document')),
     sa.ForeignKeyConstraint(['variant_name'], ['variant.variant_name'], name=op.f('fk_family_document__variant_name__variant')),

--- a/app/core/ingestion/metadata.py
+++ b/app/core/ingestion/metadata.py
@@ -18,9 +18,7 @@ MAP_OF_LIST_VALUES = {
     "keyword": "keywords",
 }
 
-MAP_OF_STR_VALUES = {
-    "document_type": "document_type",
-}
+MAP_OF_STR_VALUES = {}
 
 
 @dataclass(config=ConfigDict(validate_assignment=True, extra=Extra.forbid))

--- a/app/core/ingestion/metadata.py
+++ b/app/core/ingestion/metadata.py
@@ -75,26 +75,6 @@ def build_metadata(
             detail_list.append(result.details)
             num_fails += 1
 
-    for tax_key, row_key in MAP_OF_STR_VALUES.items():
-        row_value = getattr(row, row_key)
-        allowed_values = taxonomy[tax_key].allowed_values
-        result = Result()
-        if row_value in allowed_values:
-            value[tax_key] = row_value
-        else:
-            suggestion = match_unknown_value(row_value, set(allowed_values))
-            if not suggestion:
-                result.type = ResultType.ERROR
-                detail_list.append(
-                    f"Found no matches for {row_value} in {allowed_values}"
-                )
-                num_fails += 1
-            else:
-                value[tax_key] = suggestion
-                result.type = ResultType.RESOLVED
-                detail_list.append(f"Resolved {row_value} to {suggestion}")
-                num_resolved += 1
-
     row_result_type = ResultType.OK
     if num_resolved:
         row_result_type = ResultType.RESOLVED

--- a/app/data_migrations/__init__.py
+++ b/app/data_migrations/__init__.py
@@ -1,6 +1,7 @@
 # Pre-populate all fixed metadata tables
 from .populate_category import populate_category
 from .populate_document_type import populate_document_type
+from .populate_document_role import populate_document_role
 from .populate_event_type import populate_event_type
 from .populate_framework import populate_framework
 from .populate_geo_statistics import populate_geo_statistics

--- a/app/data_migrations/data/document_role_data.json
+++ b/app/data_migrations/data/document_role_data.json
@@ -1,0 +1,162 @@
+[
+  {
+    "name": "Accord",
+    "description": "Accord"
+  },
+  {
+    "name": "Act",
+    "description": "Act"
+  },
+  {
+    "name": "Action Plan",
+    "description": "Action Plan"
+  },
+  {
+    "name": "Agenda",
+    "description": "Agenda"
+  },
+  {
+    "name": "Annex",
+    "description": "Annex"
+  },
+  {
+    "name": "Assessment",
+    "description": "Assessment"
+  },
+  {
+    "name": "Bill",
+    "description": "Bill"
+  },
+  {
+    "name": "Constitution",
+    "description": "Constitution"
+  },
+  {
+    "name": "Criteria",
+    "description": "Criteria"
+  },
+  {
+    "name": "Decision",
+    "description": "Decision"
+  },
+  {
+    "name": "Decision and Plan",
+    "description": "Decision and Plan"
+  },
+  {
+    "name": "Decree",
+    "description": "Decree"
+  },
+  {
+    "name": "Decree Law",
+    "description": "Decree Law"
+  },
+  {
+    "name": "Directive",
+    "description": "Directive"
+  },
+  {
+    "name": "Discussion Paper",
+    "description": "Discussion Paper"
+  },
+  {
+    "name": "Edict",
+    "description": "Edict"
+  },
+  {
+    "name": "EU Decision",
+    "description": "EU Decision"
+  },
+  {
+    "name": "EU Directive",
+    "description": "EU Directive"
+  },
+  {
+    "name": "EU Regulation",
+    "description": "EU Regulation"
+  },
+  {
+    "name": "Executive Order",
+    "description": "Executive Order"
+  },
+  {
+    "name": "Framework",
+    "description": "Framework"
+  },
+  {
+    "name": "Law",
+    "description": "Law"
+  },
+  {
+    "name": "Law and Plan",
+    "description": "Law and Plan"
+  },
+  {
+    "name": "Order",
+    "description": "Order"
+  },
+  {
+    "name": "Ordinance",
+    "description": "Ordinance"
+  },
+  {
+    "name": "Plan",
+    "description": "Plan"
+  },
+  {
+    "name": "Policy",
+    "description": "Policy"
+  },
+  {
+    "name": "Press Release",
+    "description": "Press Release"
+  },
+  {
+    "name": "Programme",
+    "description": "Programme"
+  },
+  {
+    "name": "Protocol",
+    "description": "Protocol"
+  },
+  {
+    "name": "Roadmap",
+    "description": "Roadmap"
+  },
+  {
+    "name": "Regulation",
+    "description": "Regulation"
+  },
+  {
+    "name": "Resolution",
+    "description": "Resolution"
+  },
+  {
+    "name": "Royal Decree",
+    "description": "Royal Decree"
+  },
+  {
+    "name": "Rules",
+    "description": "Rules"
+  },
+  {
+    "name": "Statement",
+    "description": "Statement"
+  },
+  {
+    "name": "Strategic Assessment",
+    "description": "Strategic Assessment"
+  },
+  {
+    "name": "Strategy",
+    "description": "Strategy"
+  },
+  {
+    "name": "Summary",
+    "description": "Summary"
+  },
+  {
+    "name": "Vision",
+    "description": "Vision"
+  }
+]

--- a/app/data_migrations/data/document_role_data.json
+++ b/app/data_migrations/data/document_role_data.json
@@ -1,162 +1,42 @@
 [
   {
-    "name": "Accord",
-    "description": "Accord"
+    "name": "MAIN",
+    "description": "MAIN"
   },
   {
-    "name": "Act",
-    "description": "Act"
+    "name": "AMENDMENT",
+    "description": "AMENDMENT"
   },
   {
-    "name": "Action Plan",
-    "description": "Action Plan"
+    "name": "SUPPORTING LEGISLATION",
+    "description": "SUPPORTING LEGISLATION"
   },
   {
-    "name": "Agenda",
-    "description": "Agenda"
+    "name": "SUMMARY",
+    "description": "SUMMARY"
   },
   {
-    "name": "Annex",
-    "description": "Annex"
+    "name": "PREVIOUS VERSION",
+    "description": "PREVIOUS VERSION"
   },
   {
-    "name": "Assessment",
-    "description": "Assessment"
+    "name": "ANNEX",
+    "description": "ANNEX"
   },
   {
-    "name": "Bill",
-    "description": "Bill"
+    "name": "SUPPORTING DOCUMENTATION",
+    "description": "SUPPORTING DOCUMENTATION"
   },
   {
-    "name": "Constitution",
-    "description": "Constitution"
+    "name": "INFORMATION WEBPAGE",
+    "description": "INFORMATION WEBPAGE"
   },
   {
-    "name": "Criteria",
-    "description": "Criteria"
+    "name": "PRESS RELEASE",
+    "description": "PRESS RELEASE"
   },
   {
-    "name": "Decision",
-    "description": "Decision"
-  },
-  {
-    "name": "Decision and Plan",
-    "description": "Decision and Plan"
-  },
-  {
-    "name": "Decree",
-    "description": "Decree"
-  },
-  {
-    "name": "Decree Law",
-    "description": "Decree Law"
-  },
-  {
-    "name": "Directive",
-    "description": "Directive"
-  },
-  {
-    "name": "Discussion Paper",
-    "description": "Discussion Paper"
-  },
-  {
-    "name": "Edict",
-    "description": "Edict"
-  },
-  {
-    "name": "EU Decision",
-    "description": "EU Decision"
-  },
-  {
-    "name": "EU Directive",
-    "description": "EU Directive"
-  },
-  {
-    "name": "EU Regulation",
-    "description": "EU Regulation"
-  },
-  {
-    "name": "Executive Order",
-    "description": "Executive Order"
-  },
-  {
-    "name": "Framework",
-    "description": "Framework"
-  },
-  {
-    "name": "Law",
-    "description": "Law"
-  },
-  {
-    "name": "Law and Plan",
-    "description": "Law and Plan"
-  },
-  {
-    "name": "Order",
-    "description": "Order"
-  },
-  {
-    "name": "Ordinance",
-    "description": "Ordinance"
-  },
-  {
-    "name": "Plan",
-    "description": "Plan"
-  },
-  {
-    "name": "Policy",
-    "description": "Policy"
-  },
-  {
-    "name": "Press Release",
-    "description": "Press Release"
-  },
-  {
-    "name": "Programme",
-    "description": "Programme"
-  },
-  {
-    "name": "Protocol",
-    "description": "Protocol"
-  },
-  {
-    "name": "Roadmap",
-    "description": "Roadmap"
-  },
-  {
-    "name": "Regulation",
-    "description": "Regulation"
-  },
-  {
-    "name": "Resolution",
-    "description": "Resolution"
-  },
-  {
-    "name": "Royal Decree",
-    "description": "Royal Decree"
-  },
-  {
-    "name": "Rules",
-    "description": "Rules"
-  },
-  {
-    "name": "Statement",
-    "description": "Statement"
-  },
-  {
-    "name": "Strategic Assessment",
-    "description": "Strategic Assessment"
-  },
-  {
-    "name": "Strategy",
-    "description": "Strategy"
-  },
-  {
-    "name": "Summary",
-    "description": "Summary"
-  },
-  {
-    "name": "Vision",
-    "description": "Vision"
+    "name": "DOCUMENT(S) STORED ON WEBPAGE",
+    "description": "DOCUMENT(S) STORED ON WEBPAGE"
   }
 ]

--- a/app/data_migrations/populate_document_role.py
+++ b/app/data_migrations/populate_document_role.py
@@ -1,0 +1,17 @@
+import json
+
+from sqlalchemy.orm import Session
+
+from app.db.models.law_policy import FamilyDocumentRole
+from .utils import has_rows, load_list
+
+
+def populate_document_role(db: Session) -> None:
+    """Populates the document_type table with pre-defined data."""
+
+    if has_rows(db, FamilyDocumentRole):
+        return
+
+    with open("app/data_migrations/data/document_role_data.json") as document_role_file:
+        document_role_data = json.load(document_role_file)
+        load_list(db, FamilyDocumentRole, document_role_data)

--- a/app/data_migrations/populate_document_type.py
+++ b/app/data_migrations/populate_document_type.py
@@ -3,15 +3,23 @@ import json
 from sqlalchemy.orm import Session
 
 from app.db.models.deprecated import DocumentType
+from app.db.models.law_policy import FamilyDocumentType
 from .utils import has_rows, load_list
 
 
 def populate_document_type(db: Session) -> None:
     """Populates the document_type table with pre-defined data."""
 
-    if has_rows(db, DocumentType):
+    populate_old_schema = not has_rows(db, DocumentType)
+    populate_new_schema = not has_rows(db, FamilyDocumentType)
+
+    if not populate_old_schema and not populate_new_schema:
         return
 
     with open("app/data_migrations/data/document_type_data.json") as document_type_file:
         document_type_data = json.load(document_type_file)
-        load_list(db, DocumentType, document_type_data)
+        # TODO: Remove the following line when old schema is removed
+        if populate_old_schema:
+            load_list(db, DocumentType, document_type_data)
+        if populate_new_schema:
+            load_list(db, FamilyDocumentType, document_type_data)

--- a/app/data_migrations/populate_taxonomy.py
+++ b/app/data_migrations/populate_taxonomy.py
@@ -59,12 +59,6 @@ TAXONOMY_DATA = [
         "file_key_path": "name",
         "allow_blanks": True,
     },
-    {
-        "key": "document_type",
-        "filename": "app/data_migrations/data/document_type_data.json",
-        "file_key_path": "name",
-        "allow_blanks": True,
-    },
 ]
 
 

--- a/app/db/models/law_policy/__init__.py
+++ b/app/db/models/law_policy/__init__.py
@@ -5,6 +5,7 @@ from .family import (
     Family,
     FamilyDocument,
     FamilyDocumentType,
+    FamilyDocumentRole,
     FamilyEvent,
     FamilyEventType,
     FamilyOrganisation,

--- a/app/db/models/law_policy/family.py
+++ b/app/db/models/law_policy/family.py
@@ -109,6 +109,18 @@ class DocumentStatus(_BaseModelEnum):
     DELETED = "Deleted"
 
 
+class FamilyDocumentRole(Base):
+    """
+    A document type.
+
+    E.g. Main, Press Release, Amendment etc
+    """
+
+    __tablename__ = "family_document_role"
+    name = sa.Column(sa.Text, primary_key=True)
+    description = sa.Column(sa.Text, nullable=False)
+
+
 class FamilyDocumentType(Base):
     """
     A document type.
@@ -140,7 +152,8 @@ class FamilyDocument(Base):
         default=DocumentStatus.CREATED,
         nullable=False,
     )
-    document_type = sa.Column(sa.ForeignKey(FamilyDocumentType.name), nullable=False)
+    document_type = sa.Column(sa.ForeignKey(FamilyDocumentType.name), nullable=True)
+    document_role = sa.Column(sa.ForeignKey(FamilyDocumentRole.name), nullable=True)
 
     slugs: list["Slug"] = relationship("Slug", lazy="joined")
     physical_document: Optional[PhysicalDocument] = relationship(

--- a/app/initial_data.py
+++ b/app/initial_data.py
@@ -15,6 +15,7 @@ from app.db.session import SessionLocal
 from app.data_migrations import (
     populate_category,
     populate_document_type,
+    populate_document_role,
     populate_event_type,
     populate_framework,
     populate_geo_statistics,
@@ -38,6 +39,7 @@ def run_data_migrations(db):
 
     populate_category(db)
     populate_document_type(db)
+    populate_document_role(db)
     populate_event_type(db)
     populate_framework(db)
     populate_geography(db)

--- a/tests/core/ingestion/test_metadata.py
+++ b/tests/core/ingestion/test_metadata.py
@@ -7,9 +7,7 @@ from app.core.organisation import get_organisation_taxonomy
 from app.core.ingestion.utils import ResultType
 from tests.core.ingestion.helpers import get_doc_ingest_row_data, init_for_ingest
 
-METADATA_KEYS = set(
-    ["topic", "hazard", "sector", "keyword", "framework", "instrument", "document_type"]
-)
+METADATA_KEYS = set(["topic", "hazard", "sector", "keyword", "framework", "instrument"])
 
 
 def test_build_metadata__all_fields(test_db):
@@ -41,7 +39,6 @@ def test_build_metadata__all_fields(test_db):
     assert metadata["keyword"] == ["Hydrogen"]
     assert metadata["framework"] == ["Adaptation"]
     assert metadata["instrument"] == ["Other|Governance"]
-    assert metadata["document_type"] == "Act"
 
 
 def test_get_org_taxonomy__has_metadata_keys(test_db: Session):

--- a/tests/routes/test_config.py
+++ b/tests/routes/test_config.py
@@ -69,7 +69,6 @@ def test_endpoint_returns_taxonomy(client, test_db):
         "instrument",
         "keyword",
         "sector",
-        "document_type",
         "topic",
         "framework",
         "hazard",

--- a/tests/routes/test_documents.py
+++ b/tests/routes/test_documents.py
@@ -22,6 +22,7 @@ from app.db.models.document.physical_document import Language, PhysicalDocument
 from app.db.models.law_policy.family import Family, FamilyEvent
 from app.db.models.law_policy.geography import Geography
 
+METADATA_COUNT = 6
 
 ONE_DFC_ROW = """ID,Document ID,CCLW Description,Part of collection?,Create new family/ies?,Collection ID,Collection name,Collection summary,Document title,Family name,Family summary,Family ID,Document role,Applies to ID,Geography ISO,Documents,Category,Events,Sectors,Instruments,Frameworks,Responses,Natural Hazards,Document Type,Year,Language,Keywords,Geography,Parent Legislation,Comment,CPR Document ID,CPR Family ID,CPR Collection ID,CPR Family Slug,CPR Document Slug
 1001,0,Test1,FALSE,FALSE,N/A,Collection1,CollectionSummary1,Title1,Fam1,Summary1,,MAIN,,GEO,http://somewhere|en,executive,02/02/2014|Law passed,Energy,,,Mitigation,,Order,,,Energy Supply,Algeria,,,CCLW.executive.1.2,CCLW.family.1001.0,CPR.Collection.1,FamSlug1,DocSlug1
@@ -172,7 +173,7 @@ def test_documents_family_slug_preexisting_objects(
     assert json_response["published_date"] == "2019-12-25T00:00:00+00:00"
     assert json_response["last_updated_date"] == "2019-12-25T00:00:00+00:00"
 
-    assert len(json_response["metadata"]) == 6
+    assert len(json_response["metadata"]) == METADATA_COUNT
     assert json_response["metadata"]["keyword"] == ["Energy Supply"]
 
     assert len(json_response["slugs"]) == 1
@@ -205,7 +206,7 @@ def test_documents_family_slug_preexisting_objects(
     assert json_response["published_date"] == "2019-12-25T00:00:00+00:00"
     assert json_response["last_updated_date"] == "2019-12-25T00:00:00+00:00"
 
-    assert len(json_response["metadata"]) == 7
+    assert len(json_response["metadata"]) == METADATA_COUNT
     assert json_response["metadata"]["keyword"] == ["Energy Supply"]
 
     assert len(json_response["slugs"]) == 1

--- a/tests/routes/test_documents.py
+++ b/tests/routes/test_documents.py
@@ -172,7 +172,7 @@ def test_documents_family_slug_preexisting_objects(
     assert json_response["published_date"] == "2019-12-25T00:00:00+00:00"
     assert json_response["last_updated_date"] == "2019-12-25T00:00:00+00:00"
 
-    assert len(json_response["metadata"]) == 7
+    assert len(json_response["metadata"]) == 6
     assert json_response["metadata"]["keyword"] == ["Energy Supply"]
 
     assert len(json_response["slugs"]) == 1


### PR DESCRIPTION
# Description

- change the schema with the new table FamilyDocumentRole
- populate the values in `init_data`
- also populate the values for FamilyDocumentType
- relax the FK to be nullable for both type and role

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
