### PR TITLE
Browse without grouping should return opensearch formatted dates

### DIFF
--- a/app/core/browse.py
+++ b/app/core/browse.py
@@ -154,7 +154,7 @@ def to_search_resp_doc(row: dict) -> SearchDocumentResponse:
         document_slug=row["slug"],
         document_name=row["name"],
         document_description=row["description"],
-        document_date=row["publication_ts"].isoformat(),
+        document_date=row["publication_ts"].strftime("%d/%m/%Y"),
         document_category=row["category"],
         document_geography=row["country_code"],
         # ↓ Stuff we don't currently use for search ↓

--- a/tests/routes/test_search.py
+++ b/tests/routes/test_search.py
@@ -1217,7 +1217,7 @@ def test_browse_order_by_date(
                 new_dt = datetime.fromisoformat(e["family_date"]).isoformat()
         else:
             if e["document_date"]:
-                new_dt = datetime.fromisoformat(e["document_date"]).isoformat()
+                new_dt = datetime.strptime(e["document_date"], "%d/%m/%Y").isoformat()
         if dt is not None and new_dt is not None:
             if order == SortOrder.DESCENDING:
                 assert new_dt <= dt


### PR DESCRIPTION
# Description

Browse without grouping should return opensearch formatted dates

## Type of change

Please select the option(s) below that are most relevant:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
