### PR TITLE
Search results need to be in opensearch format for non-grouped results

### DIFF
--- a/app/core/search.py
+++ b/app/core/search.py
@@ -885,9 +885,7 @@ def create_search_response_document(
         document_geography=opensearch_match.document_geography,
         document_sectors=opensearch_match.document_sectors,
         document_source=opensearch_match.document_source,
-        document_date=datetime.strptime(
-            opensearch_match.document_date, "%d/%m/%Y"
-        ).isoformat(),
+        document_date=opensearch_match.document_date,
         document_id=opensearch_match.document_id,
         document_type=opensearch_match.document_type,
         document_category=opensearch_match.document_category,

--- a/tests/routes/test_search.py
+++ b/tests/routes/test_search.py
@@ -807,7 +807,7 @@ def test_result_order_date(
         if group_documents:
             new_dt = datetime.fromisoformat(e["family_date"])
         else:
-            new_dt = datetime.fromisoformat(e["document_date"])
+            new_dt = datetime.strptime(e["document_date"], "%d/%m/%Y")
         if dt is not None:
             if order == SortOrder.DESCENDING:
                 assert new_dt <= dt


### PR DESCRIPTION
# Description

Search results need to be in opensearch format for non-grouped results

## Type of change

Please select the option(s) below that are most relevant:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
