### PR TITLE
Write document state to s3 to trigger pipeline

### DIFF
--- a/app/api/api_v1/schemas/document.py
+++ b/app/api/api_v1/schemas/document.py
@@ -73,6 +73,8 @@ class FamilyDocumentResponse(BaseModel):
     cdn_object: Optional[str]
     source_url: Optional[str]
     content_type: Optional[str]
+    # TODO: Remove after transition to multiple languages
+    language: str
     languages: Sequence[str]
     document_type: Optional[str]
     document_role: Optional[str]

--- a/app/api/api_v1/schemas/document.py
+++ b/app/api/api_v1/schemas/document.py
@@ -73,7 +73,7 @@ class FamilyDocumentResponse(BaseModel):
     cdn_object: Optional[str]
     source_url: Optional[str]
     content_type: Optional[str]
-    language: str
+    languages: Sequence[str]
     document_type: Optional[str]
     document_role: Optional[str]
 

--- a/app/core/ingestion/ingest_row.py
+++ b/app/core/ingestion/ingest_row.py
@@ -138,7 +138,7 @@ class DocumentIngestRow(BaseIngestRow):
     natural_hazards: list[str]  # METADATA - hazard
     keywords: list[str]
     document_type: str
-    language: str
+    language: list[str]
     geography: str
     cpr_document_id: str
     cpr_family_id: str

--- a/app/core/ingestion/physical_document.py
+++ b/app/core/ingestion/physical_document.py
@@ -32,14 +32,21 @@ def create_physical_document_from_row(
     db.flush()
     result["physical_document"] = to_dict(physical_document)
 
-    lang = db.query(Language).filter(Language.name == row.language).one_or_none()
-    if lang is not None:
-        result["language"] = to_dict(lang)
-        physical_document_language = PhysicalDocumentLanguage(
-            language_id=lang.id, document_id=physical_document.id
-        )
-        db.add(physical_document_language)
-        db.flush()
-        result["physical_document_language"] = to_dict(physical_document_language)
+    for language in row.language:
+        lang = db.query(Language).filter(Language.name == language).one_or_none()
+        if lang is not None:
+            doc_languages = result.get("language", [])
+            doc_languages.append(to_dict(lang))
+            result["language"] = doc_languages
+
+            physical_document_language = PhysicalDocumentLanguage(
+                language_id=lang.id, document_id=physical_document.id
+            )
+            db.add(physical_document_language)
+            db.flush()
+
+            phys_doc_languages = result.get("physical_document_language", [])
+            phys_doc_languages.append(to_dict(physical_document_language))
+            result["physical_document_language"] = phys_doc_languages
 
     return physical_document

--- a/app/core/ingestion/pipeline.py
+++ b/app/core/ingestion/pipeline.py
@@ -1,0 +1,77 @@
+from typing import Sequence, Tuple, cast
+
+from sqlalchemy.orm import Session
+
+from app.api.api_v1.schemas.document import DocumentParserInput
+from app.db.models.app.users import Organisation
+from app.db.models.law_policy.family import (
+    Family,
+    FamilyDocument,
+    FamilyOrganisation,
+    Geography,
+    DocumentStatus,
+    FamilyStatus,
+)
+
+
+def generate_pipeline_ingest_input(db: Session) -> Sequence[DocumentParserInput]:
+    """Generates a complete view of the current document database as pipeline input"""
+    query = (
+        db.query(Family, FamilyDocument, Geography, Organisation)
+        .join(Family, Family.import_id == FamilyDocument.family_import_id)
+        .join(
+            FamilyOrganisation, FamilyOrganisation.family_import_id == Family.import_id
+        )
+        .join(Organisation, Organisation.id == FamilyOrganisation.organisation_id)
+        .join(Geography, Geography.id == Family.geography_id)
+        .filter(
+            Family.family_status.in_([FamilyStatus.PUBLISHED, FamilyStatus.CREATED])
+        )
+        .filter(
+            FamilyDocument.document_status.in_(
+                [DocumentStatus.CREATED, DocumentStatus.PUBLISHED]
+            )
+        )
+    )
+
+    query_result = cast(
+        Sequence[Tuple[Family, FamilyDocument, Geography, Organisation]], query.all()
+    )
+    documents: Sequence[DocumentParserInput] = [
+        DocumentParserInput(
+            name=family.name,  # All documents in a family are indexed by family name
+            description=cast(str, family.description),
+            category=str(family.family_category),
+            publication_ts=family.published_date,
+            import_id=cast(str, family_document.import_id),
+            source_url=(
+                cast(str, family_document.physical_document.source_url)
+                if family_document.physical_document is not None
+                else None
+            ),
+            type=cast(str, family_document.document_type),
+            source=cast(str, organisation.name),
+            slug=family_document.slugs[-1],
+            geography=cast(str, geography.value),
+            languages=[
+                cast(str, lang.name)
+                for lang in (
+                    family_document.physical_document.languages
+                    if family_document.physical_document is not None
+                    else []
+                )
+            ],
+            # TODO: the following are not used & should be removed
+            events=[],
+            frameworks=[],
+            hazards=[],
+            instruments=[],
+            keywords=[],
+            postfix=None,
+            sectors=[],
+            topics=[],
+        )
+        for family, family_document, geography, organisation in query_result
+    ]
+
+    return documents

--- a/app/core/search.py
+++ b/app/core/search.py
@@ -758,7 +758,7 @@ def create_search_response_family_document(
 ) -> SearchResponseFamilyDocument:
     document_info = document_family_info[opensearch_match.document_id]
     return SearchResponseFamilyDocument(
-        document_title=opensearch_match.document_name,
+        document_title=document_info["title"],
         document_type=opensearch_match.document_type,
         document_source_url=opensearch_match.document_source_url,
         document_url=to_cdn_url(opensearch_match.document_cdn_object),

--- a/app/core/validation/util.py
+++ b/app/core/validation/util.py
@@ -78,9 +78,12 @@ def write_documents_to_s3(
     :param [Sequence[DocumentCreateRequest]] documents: a sequence of document
         specifications to write to S3
     """
-    json_content = json.dumps([d.to_json() for d in documents], indent=2)
+    json_content = json.dumps(
+        {d.import_id: d.to_json() for d in documents},
+        indent=2,
+    )
     bytes_content = BytesIO(json_content.encode("utf8"))
-    documents_object_key = f"{s3_prefix}/documents.json"
+    documents_object_key = f"{s3_prefix}/input.json"
     _LOGGER.info("Writing Documents file into S3")
     return _write_content_to_s3(
         s3_client=s3_client,

--- a/app/db/crud/document.py
+++ b/app/db/crud/document.py
@@ -19,11 +19,7 @@ from app.api.api_v1.schemas.document import (
     LinkableFamily,
 )
 from app.db.models.app.users import Organisation
-from app.db.models.document.physical_document import (
-    PhysicalDocument,
-    PhysicalDocumentLanguage,
-    Language,
-)
+from app.db.models.document.physical_document import PhysicalDocument
 from app.db.models.law_policy.collection import Collection, CollectionFamily
 from app.db.models.law_policy.family import (
     Family,
@@ -92,7 +88,12 @@ def get_family_document_and_context(
         cdn_object=to_cdn_url(physical_document.cdn_object),
         source_url=physical_document.source_url,
         content_type=physical_document.content_type,
-        languages=_get_languages_for_phys_doc(db, physical_document.id),
+        language=(
+            _get_languages_for_phys_doc(physical_document)[0]
+            if physical_document.languages
+            else ""
+        ),
+        languages=_get_languages_for_phys_doc(physical_document),
         document_type=document.document_type,
         document_role=document.document_role,
     )
@@ -100,19 +101,8 @@ def get_family_document_and_context(
     return FamilyDocumentWithContextResponse(family=family, document=response)
 
 
-def _get_languages_for_phys_doc(
-    db: Session, physical_document_id: str
-) -> Sequence[str]:
-    languages = (
-        db.query(Language)
-        .join(
-            PhysicalDocumentLanguage,
-            PhysicalDocumentLanguage.language_id == Language.id,
-        )
-        .filter(PhysicalDocumentLanguage.document_id == physical_document_id)
-    ).all()
-
-    return [cast(str, lang.language_code) for lang in languages]
+def _get_languages_for_phys_doc(physical_document: PhysicalDocument) -> Sequence[str]:
+    return [cast(str, lang.language_code) for lang in physical_document.languages]
 
 
 def get_family_and_documents(
@@ -238,7 +228,6 @@ def _get_documents_for_family_import_id(
         .filter(FamilyDocument.family_import_id == import_id)
         .filter(FamilyDocument.physical_document_id == PhysicalDocument.id)
     )
-
     documents = [
         FamilyDocumentResponse(
             import_id=d.import_id,
@@ -250,7 +239,8 @@ def _get_documents_for_family_import_id(
             cdn_object=to_cdn_url(pd.cdn_object),
             source_url=pd.source_url,
             content_type=pd.content_type,
-            languages=_get_languages_for_phys_doc(db, pd.id),
+            language=_get_languages_for_phys_doc(pd)[0] if pd.languages else "",
+            languages=_get_languages_for_phys_doc(pd),
             document_type=d.document_type,
             document_role=d.document_role,
         )

--- a/app/db/models/document/physical_document.py
+++ b/app/db/models/document/physical_document.py
@@ -1,5 +1,25 @@
+from typing import Sequence
+
 import sqlalchemy as sa
+from sqlalchemy.orm import relationship
+
 from app.db.session import Base
+
+
+class Language(Base):
+    """
+    A language used to identify the content of a document.
+
+    Note: moved from deprecated.
+    """
+
+    __tablename__ = "language"
+
+    id = sa.Column(sa.Integer, primary_key=True)
+    language_code = sa.Column(sa.CHAR(length=3), nullable=False, unique=True)
+    part1_code = sa.Column(sa.CHAR(length=2))
+    part2_code = sa.Column(sa.CHAR(length=3))
+    name = sa.Column(sa.Text)
 
 
 class PhysicalDocument(Base):
@@ -19,21 +39,14 @@ class PhysicalDocument(Base):
     source_url = sa.Column(sa.Text, nullable=True)
     content_type = sa.Column(sa.Text, nullable=True)
 
-
-class Language(Base):
-    """
-    A language used to identify the content of a document.
-
-    Note: moved from deprecated.
-    """
-
-    __tablename__ = "language"
-
-    id = sa.Column(sa.Integer, primary_key=True)
-    language_code = sa.Column(sa.CHAR(length=3), nullable=False, unique=True)
-    part1_code = sa.Column(sa.CHAR(length=2))
-    part2_code = sa.Column(sa.CHAR(length=3))
-    name = sa.Column(sa.Text)
+    languages: Sequence[Language] = relationship(
+        Language,
+        secondary="physical_document_language",
+        primaryjoin="PhysicalDocument.id == PhysicalDocumentLanguage.document_id",
+        secondaryjoin="PhysicalDocumentLanguage.language_id == Language.id",
+        viewonly=True,
+        lazy="joined",
+    )
 
 
 class PhysicalDocumentLanguage(Base):

--- a/app/db/models/law_policy/family.py
+++ b/app/db/models/law_policy/family.py
@@ -79,7 +79,7 @@ class Family(Base):
             return None
         date = None
         for event in self.events:
-            if event.event_type_name == "Approved/Published":
+            if event.event_type_name == "Passed/Approved":
                 return cast(datetime, event.date)
             if date is None:
                 date = cast(datetime, event.date)

--- a/tests/core/ingestion/test_physical_document.py
+++ b/tests/core/ingestion/test_physical_document.py
@@ -14,7 +14,7 @@ from tests.core.ingestion.helpers import (
 def test_physical_document_from_row(test_db: Session):
     populate_for_ingest(test_db)
     row = DocumentIngestRow.from_row(1, get_doc_ingest_row_data(0))
-    row.language = "English"
+    row.language = ["English", "German"]
     result = {}
 
     phys_doc = create_physical_document_from_row(test_db, row, result)
@@ -34,5 +34,13 @@ def test_physical_document_from_row(test_db: Session):
     # Check objects were created ...
     assert test_db.query(PhysicalDocument).filter_by(title=DOCUMENT_TITLE).one()
     assert (
-        test_db.query(PhysicalDocumentLanguage).filter_by(document_id=phys_doc.id).one()
+        len(
+            test_db.query(PhysicalDocumentLanguage)
+            .filter_by(document_id=phys_doc.id)
+            .all()
+        )
+        == 2
     )
+
+    assert len(phys_doc.languages) == 2
+    assert set([lang.language_code for lang in phys_doc.languages]) == {"eng", "deu"}

--- a/tests/core/ingestion/test_pipeline.py
+++ b/tests/core/ingestion/test_pipeline.py
@@ -1,0 +1,118 @@
+import json
+from datetime import datetime, timezone
+from typing import Optional
+
+import pytest
+
+from sqlalchemy.orm import Session
+from app.core.ingestion.ingest_row import DocumentIngestRow, EventIngestRow
+from app.core.ingestion.pipeline import generate_pipeline_ingest_input
+from app.core.ingestion.processor import get_dfc_ingestor, get_event_ingestor
+from app.core.ingestion.reader import read
+from app.core.ingestion.utils import IngestContext
+from tests.core.ingestion.helpers import (
+    FOUR_EVENT_ROWS,
+    THREE_DOC_ROWS,
+    get_doc_ingest_row_data,
+    get_event_ingest_row_data,
+    populate_for_ingest,
+)
+
+
+def _populate_db_for_test(
+    test_db: Session,
+    ingest_doc_content: str,
+    ingest_event_content: Optional[str] = None,
+) -> None:
+    populate_for_ingest(test_db)
+    test_db.commit()
+    context = IngestContext()
+    document_ingestor = get_dfc_ingestor(test_db)
+    event_ingestor = get_event_ingestor(test_db)
+
+    read(ingest_doc_content, context, DocumentIngestRow, document_ingestor)
+    if ingest_event_content is not None:
+        read(ingest_event_content, context, EventIngestRow, event_ingestor)
+
+    test_db.commit()
+    test_db.flush()
+
+
+def _get_published_date_for_id(id: str, event_content: str) -> datetime:
+    row = 0
+    while event_data := get_event_ingest_row_data(0 + row, event_content):
+        row += 1
+        if (
+            event_data.get("CPR Family ID") == id
+            and event_data["Event type"] == "Passed/Approved"
+        ):
+            return datetime.strptime(event_data["Date"], "%Y-%m-%d").replace(
+                tzinfo=timezone.utc
+            )
+
+    raise Exception(f"No published date found for '{id}'")
+
+
+def test_generate_pipeline_input_document_count(test_db: Session):
+    _populate_db_for_test(test_db, THREE_DOC_ROWS)
+
+    documents = generate_pipeline_ingest_input(test_db)
+    assert len(documents) == 3
+
+
+def test_generate_pipeline_input_document_content(test_db: Session):
+    _populate_db_for_test(test_db, THREE_DOC_ROWS)
+
+    documents = generate_pipeline_ingest_input(test_db)
+    documents_s3_object = {doc.import_id: doc for doc in documents}
+
+    count = 0
+    while csv_doc_row := get_doc_ingest_row_data(0 + count, contents=THREE_DOC_ROWS):
+        count += 1
+        document = documents_s3_object[csv_doc_row["CPR Document ID"]]
+        assert document.import_id == csv_doc_row["CPR Document ID"]
+        assert document.category == csv_doc_row["Category"].title()
+        assert document.description == csv_doc_row["Family summary"]
+        assert document.geography == csv_doc_row["Geography ISO"]
+        assert document.languages == (
+            [csv_doc_row["Language"]] if csv_doc_row["Language"] else []
+        )
+        assert document.name == csv_doc_row["Family name"]
+        assert document.publication_ts == datetime(1900, 1, 1, tzinfo=timezone.utc)
+        assert document.slug == csv_doc_row["CPR Document Slug"]
+        assert document.source == "CCLW"
+        assert document.source_url == csv_doc_row["Documents"].split("|")[0]
+
+    assert count == len(documents)
+
+
+def test_generate_pipeline_input_document_content_with_events(test_db: Session):
+    _populate_db_for_test(test_db, THREE_DOC_ROWS, FOUR_EVENT_ROWS)
+
+    documents = generate_pipeline_ingest_input(test_db)
+    documents_s3_object = {doc.import_id: doc for doc in documents}
+
+    count = 0
+    while csv_doc_row := get_doc_ingest_row_data(0 + count, contents=THREE_DOC_ROWS):
+        count += 1
+        document = documents_s3_object[csv_doc_row["CPR Document ID"]]
+        assert document.import_id == csv_doc_row["CPR Document ID"]
+        assert document.name == csv_doc_row["Family name"]
+        assert document.description == csv_doc_row["Family summary"]
+        assert document.publication_ts == _get_published_date_for_id(
+            csv_doc_row["CPR Family ID"], FOUR_EVENT_ROWS
+        )
+
+    assert count == len(documents)
+
+
+@pytest.mark.parametrize("input_content", [THREE_DOC_ROWS])
+def test_generate_pipeline_input_json(input_content, test_db):
+    _populate_db_for_test(test_db, input_content)
+
+    documents = generate_pipeline_ingest_input(test_db)
+    json_content = json.dumps(
+        {d.import_id: d.to_json() for d in documents},
+        indent=2,
+    )
+    assert json_content

--- a/tests/core/validation/test_util.py
+++ b/tests/core/validation/test_util.py
@@ -147,11 +147,11 @@ def test_write_documents_to_s3(test_s3_client, mocker):
     write_documents_to_s3(test_s3_client, test_s3_prefix, documents=[d])
     upload_file_mock.assert_called_once_with(
         bucket=PIPELINE_BUCKET,
-        key=f"{test_s3_prefix}/documents.json",
+        key=f"{test_s3_prefix}/input.json",
         content_type="application/json",
         fileobj=mock.ANY,
     )
     uploaded_json_documents = json.loads(
         upload_file_mock.mock_calls[0].kwargs["fileobj"].read().decode("utf8")
     )
-    assert uploaded_json_documents == [d.to_json()]
+    assert uploaded_json_documents == {d.import_id: d.to_json()}

--- a/tests/routes/document_helpers.py
+++ b/tests/routes/document_helpers.py
@@ -36,6 +36,14 @@ TWO_DFC_ROW = """ID,Document ID,CCLW Description,Part of collection?,Create new 
 2002,0,Test2,FALSE,FALSE,N/A,Collection1,CollectionSummary1,Title2,Fam2,Summary2,,MAIN,,GEO,http://another_somewhere|en,executive,03/03/2024|Law passed,Energy,,,Mitigation,,Order,,,Energy Supply,Algeria,,,CCLW.executive.2.2,CCLW.family.2002.0,CPR.Collection.1,FamSlug2,DocSlug2,
 """
 
+ONE_DFC_ROW_TWO_LANGUAGES = """ID,Document ID,CCLW Description,Part of collection?,Create new family/ies?,Collection ID,Collection name,Collection summary,Document title,Family name,Family summary,Family ID,Document role,Applies to ID,Geography ISO,Documents,Category,Events,Sectors,Instruments,Frameworks,Responses,Natural Hazards,Document Type,Year,Language,Keywords,Geography,Parent Legislation,Comment,CPR Document ID,CPR Family ID,CPR Collection ID,CPR Family Slug,CPR Document Slug,Document variant
+1001,0,Test1,FALSE,FALSE,N/A,Collection1,CollectionSummary1,Title1,Fam1,Summary1,,MAIN,,GEO,http://somewhere|en,executive,02/02/2014|Law passed,Energy,,,Mitigation,,Order,,French;English,Energy Supply,Algeria,,,CCLW.executive.1.2,CCLW.family.1001.0,CPR.Collection.1,FamSlug1,DocSlug1,Translation
+"""
+
+ONE_EVENT_ROW = """Id,Eventable type,Eventable Id,Eventable name,Event type,Title,Description,Date,Url,CPR Event ID,CPR Family ID,Event Status
+1101,Legislation,1001,Title1,Passed/Approved,Published,,2019-12-25,,CCLW.legislation_event.1101.0,CCLW.family.1001.0,OK
+"""
+
 TWO_DFC_ROW_ONE_LANGUAGE = """ID,Document ID,CCLW Description,Part of collection?,Create new family/ies?,Collection ID,Collection name,Collection summary,Document title,Family name,Family summary,Family ID,Document role,Applies to ID,Geography ISO,Documents,Category,Events,Sectors,Instruments,Frameworks,Responses,Natural Hazards,Document Type,Year,Language,Keywords,Geography,Parent Legislation,Comment,CPR Document ID,CPR Family ID,CPR Collection ID,CPR Family Slug,CPR Document Slug,Document variant
 1001,0,Test1,FALSE,FALSE,N/A,Collection1,CollectionSummary1,Title1,Fam1,Summary1,,MAIN,,GEO,http://somewhere|en,executive,02/02/2014|Law passed,Energy,,,Mitigation,,Order,,English,Energy Supply,Algeria,,,CCLW.executive.1.2,CCLW.family.1001.0,CPR.Collection.1,FamSlug1,DocSlug1,
 2002,0,Test2,FALSE,FALSE,N/A,Collection2,CollectionSummary2,Title2,Fam2,Summary2,,MAIN,,GEO,http://another_somewhere|en,executive,03/03/2024|Law passed,Energy,,,Mitigation,,Order,,,Energy Supply,Algeria,,,CCLW.executive.2.2,CCLW.family.2002.0,CPR.Collection.2,FamSlug2,DocSlug2,

--- a/tests/routes/test_documents.py
+++ b/tests/routes/test_documents.py
@@ -17,7 +17,7 @@ from tests.routes.document_helpers import (
 N_METADATA_KEYS = 6
 N_FAMILY_KEYS = 14
 N_FAMILY_OVERVIEW_KEYS = 7
-N_DOCUMENT_KEYS = 11
+N_DOCUMENT_KEYS = 12
 
 
 def test_documents_family_slug_returns_not_found(
@@ -162,6 +162,7 @@ def test_documents_doc_slug_preexisting_objects(
     assert doc["cdn_object"] is None
     assert doc["content_type"] is None
     assert doc["source_url"] == "http://another_somewhere"
+    assert doc["language"] == ""
     assert doc["languages"] == []
     assert doc["document_type"] == "Order"
     assert doc["document_role"] == "MAIN"

--- a/tests/routes/test_documents.py
+++ b/tests/routes/test_documents.py
@@ -4,6 +4,8 @@ from fastapi.testclient import TestClient
 from pytest_mock import MockerFixture
 from app.db.models.law_policy.family import Family, FamilyDocument, FamilyEvent
 from tests.routes.document_helpers import (
+    ONE_DFC_ROW_TWO_LANGUAGES,
+    ONE_EVENT_ROW,
     TWO_DFC_ROW_ONE_LANGUAGE,
     TWO_EVENT_ROWS,
     populate_languages,
@@ -160,7 +162,7 @@ def test_documents_doc_slug_preexisting_objects(
     assert doc["cdn_object"] is None
     assert doc["content_type"] is None
     assert doc["source_url"] == "http://another_somewhere"
-    assert doc["language"] == ""
+    assert doc["languages"] == []
     assert doc["document_type"] == "Order"
     assert doc["document_role"] == "MAIN"
 
@@ -183,7 +185,7 @@ def test_physical_doc_languages(
 
     assert response.status_code == 200
     print(json_response)
-    assert document["language"] == "eng"
+    assert document["languages"] == ["eng"]
 
     response = client.get(
         "/api/v1/documents/DocSlug2?group_documents=True",
@@ -192,7 +194,28 @@ def test_physical_doc_languages(
     document = json_response["document"]
 
     assert response.status_code == 200
-    assert document["language"] == ""
+    assert document["languages"] == []
+
+
+def test_physical_doc_multiple_languages(
+    client: TestClient,
+    test_db: Session,
+    mocker: Callable[..., Generator[MockerFixture, None, None]],
+):
+    populate_languages(test_db)
+    setup_with_multiple_docs(
+        test_db, mocker, doc_data=ONE_DFC_ROW_TWO_LANGUAGES, event_data=ONE_EVENT_ROW
+    )
+
+    response = client.get(
+        "/api/v1/documents/DocSlug1?group_documents=True",
+    )
+    json_response = response.json()
+    document = json_response["document"]
+
+    assert response.status_code == 200
+    print(json_response)
+    assert set(document["languages"]) == set(["fra", "eng"])
 
 
 def test_update_document__is_secure(


### PR DESCRIPTION
# Description

Generate a full view of the current document database that should be visible in Opensearch. This is used to detect changes & update indexed information used in searches.

Also includes a change to provide multiple document languages to the frontend.

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## How Has This Been Tested?

Existing tests updated & extended, new tests for generated document list.

## Reviewer Checklist

- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
