### PR TITLE
Add "navigator/" prefix to CDN URLs

### DIFF
--- a/app/core/util.py
+++ b/app/core/util.py
@@ -26,7 +26,7 @@ def to_cdn_url(s3_object_key: Optional[str]) -> Optional[str]:
     """
     if s3_object_key is None:
         return None
-    return f"https://{CDN_DOMAIN}/{s3_object_key}"
+    return f"https://{CDN_DOMAIN}/navigator/{s3_object_key}"
 
 
 def random_string(length=12):


### PR DESCRIPTION
# Description

Add "navigator/" prefix to CDN object names when building complete URLs to match the new document bucket structure.

## Type of change

Please select the option(s) below that are most relevant:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
