### PR TITLE
Default document type to empty string in pipeline input when not set

### DIFF
--- a/app/core/ingestion/pipeline.py
+++ b/app/core/ingestion/pipeline.py
@@ -47,11 +47,11 @@ def generate_pipeline_ingest_input(db: Session) -> Sequence[DocumentParserInput]
             publication_ts=family.published_date or fallback_date,
             import_id=cast(str, family_document.import_id),
             source_url=(
-                cast(str, family_document.physical_document.source_url) or None
+                cast(str, family_document.physical_document.source_url)
                 if family_document.physical_document is not None
                 else None
             ),
-            type=cast(str, family_document.document_type),
+            type=cast(str, family_document.document_type or ""),
             source=cast(str, organisation.name),
             slug=cast(str, family_document.slugs[-1].name),
             geography=cast(str, geography.value),


### PR DESCRIPTION
# Description

When writing pipeline input, a null document type was causing failures to trigger the pipeline. This change fixes that issue by using a default of `""` if no document type exists.

## Type of change

Please select the option(s) below that are most relevant:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
