### PR TITLE
Order family events in API response & remove unnecessary queries

### DIFF
--- a/app/db/models/law_policy/family.py
+++ b/app/db/models/law_policy/family.py
@@ -70,7 +70,11 @@ class Family(Base):
     )
 
     slugs: list["Slug"] = relationship("Slug", lazy="joined")
-    events: list["FamilyEvent"] = relationship("FamilyEvent", lazy="joined")
+    events: list["FamilyEvent"] = relationship(
+        "FamilyEvent",
+        lazy="joined",
+        order_by="FamilyEvent.date",
+    )
 
     @hybrid_property
     def published_date(self) -> Optional[datetime]:
@@ -156,7 +160,7 @@ class FamilyDocument(Base):
     document_role = sa.Column(sa.ForeignKey(FamilyDocumentRole.name), nullable=True)
 
     slugs: list["Slug"] = relationship("Slug", lazy="joined")
-    physical_document: Optional[PhysicalDocument] = relationship(
+    physical_document: PhysicalDocument = relationship(
         PhysicalDocument,
         lazy="joined",
     )


### PR DESCRIPTION
# Description

This change orders events according to their date, and removes a few db queries that have subsequently become unnecessary after ORM changes.

## Type of change

Please select the option(s) below that are most relevant:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

Any regressions are already covered by existing tests, although an explicit test for event ordering might be useful.

## Reviewer Checklist

- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
