### PR TITLE
Filter climate-laws.org source URLs that will no longer work from responses

### DIFF
--- a/app/api/api_v1/schemas/__init__.py
+++ b/app/api/api_v1/schemas/__init__.py
@@ -1,0 +1,3 @@
+import re
+
+CLIMATE_LAWS_MATCH = re.compile(r"^https?://(.+\.)?climate-laws.org(/|$)")

--- a/app/api/api_v1/schemas/document.py
+++ b/app/api/api_v1/schemas/document.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Any, Mapping, Optional, Sequence
 
-from pydantic import BaseModel
+from pydantic import BaseModel, validator
 from app.api.api_v1.schemas.metadata import (
     Category,
     Event,
@@ -16,6 +16,7 @@ from app.api.api_v1.schemas.metadata import (
     Source,
     Topic,
 )
+from . import CLIMATE_LAWS_MATCH
 
 
 class DocumentOverviewResponse(BaseModel):  # noqa: D101
@@ -79,6 +80,13 @@ class FamilyDocumentResponse(BaseModel):
     document_type: Optional[str]
     document_role: Optional[str]
 
+    @validator("source_url")
+    def _filter_climate_laws_url_from_source(cls, v):
+        """Make sure we do not return climate-laws.org source URLs to the frontend"""
+        if v is None or CLIMATE_LAWS_MATCH.match(v) is not None:
+            return None
+        return v
+
 
 class FamilyContext(BaseModel):
     """Used to given the family context when returning a FamilyDocument"""
@@ -118,6 +126,7 @@ class FamilyAndDocumentsResponse(BaseModel):
     collections: list[CollectionOverviewResponse]
 
 
+# DEPRECATED
 class DocumentDetailResponse(BaseModel):
     """A response containing detailed information about a document."""
 
@@ -154,6 +163,7 @@ class DocumentDetailResponse(BaseModel):
         frozen = True
 
 
+# DEPRECATED
 class DocumentUploadRequest(BaseModel):
     """Details of a file we wish to upload."""
 
@@ -161,6 +171,7 @@ class DocumentUploadRequest(BaseModel):
     overwrite: Optional[bool] = False
 
 
+# DERECATED
 class DocumentUploadResponse(BaseModel):
     """Details required to upload a document to our backend storage."""
 

--- a/app/api/api_v1/schemas/search.py
+++ b/app/api/api_v1/schemas/search.py
@@ -1,9 +1,10 @@
 from enum import Enum
 from typing import Mapping, Optional, Sequence, Union
 
-from pydantic import BaseModel, conlist
+from pydantic import BaseModel, conlist, validator
 
 from app.db.models.law_policy import FamilyCategory
+from . import CLIMATE_LAWS_MATCH
 
 
 Coord = tuple[float, float]
@@ -151,6 +152,13 @@ class SearchResponseFamilyDocument(BaseModel):
     document_url: Optional[str]
     document_content_type: Optional[str]
     document_passage_matches: list[SearchResponseDocumentPassage]
+
+    @validator("document_source_url")
+    def _filter_climate_laws_url_from_source(cls, v):
+        """Make sure we do not return climate-laws.org source URLs to the frontend"""
+        if v is None or CLIMATE_LAWS_MATCH.match(v) is not None:
+            return None
+        return v
 
 
 ############### NEW #####################  # noqa: E266

--- a/tests/unit/app/schemas/test_schemas.py
+++ b/tests/unit/app/schemas/test_schemas.py
@@ -1,0 +1,100 @@
+import pytest
+
+from app.api.api_v1.schemas.document import FamilyDocumentResponse
+from app.api.api_v1.schemas.search import SearchResponseFamilyDocument
+
+CLIMATE_LAWS_DOMAIN_PATHS = [
+    "climate-laws.org",
+    "climate-laws.org/path",
+    "climate-laws.org/path/multiple/elements/",
+    "anything.climate-laws.org/",
+    "anything.climate-laws.org/path/",
+    "anything.climate-laws.org/path/multiple/elemeents",
+]
+NON_CLIMATE_LAWS_DOMAIN_PATHS = [
+    None,
+    "",
+    "not-climate-laws.org/",
+    "sub.not-climate-laws.org",
+    "example.com/path",
+    "not-climate-laws.org/path/multiple/elements/",
+]
+SCHEMES = ["http", "https"]
+
+
+@pytest.mark.parametrize("source_domain_path", CLIMATE_LAWS_DOMAIN_PATHS)
+@pytest.mark.parametrize("scheme", SCHEMES)
+def test_climate_laws_source_url_filtered_from_search(source_domain_path, scheme):
+    search_document = SearchResponseFamilyDocument(
+        document_title="title",
+        document_slug="title_abcd",
+        document_type="document_type",
+        document_source_url=f"{scheme}://{source_domain_path}",
+        document_url="https://cdn.climatepolicyradar.org/title_hash",
+        document_content_type=None,
+        document_passage_matches=[],
+    )
+    assert search_document.document_source_url is None
+
+
+@pytest.mark.parametrize("source_domain_path", NON_CLIMATE_LAWS_DOMAIN_PATHS)
+@pytest.mark.parametrize("scheme", SCHEMES)
+def test_non_climate_laws_source_url_left_in_search(source_domain_path, scheme):
+    if source_domain_path:
+        given_url = f"{scheme}://{source_domain_path}"
+    else:
+        given_url = source_domain_path
+    search_document = SearchResponseFamilyDocument(
+        document_title="title",
+        document_slug="title_abcd",
+        document_type="document_type",
+        document_source_url=given_url,
+        document_url="https://cdn.climatepolicyradar.org/title_hash",
+        document_content_type=None,
+        document_passage_matches=[],
+    )
+    assert search_document.document_source_url == given_url
+
+
+@pytest.mark.parametrize("source_domain_path", CLIMATE_LAWS_DOMAIN_PATHS)
+@pytest.mark.parametrize("scheme", SCHEMES)
+def test_climate_laws_source_url_filtered_from_document(source_domain_path, scheme):
+    document_response = FamilyDocumentResponse(
+        import_id="import_id",
+        variant=None,
+        slug="import_id_abcd",
+        title="title",
+        md5_sum=None,
+        cdn_object=None,
+        source_url=f"{scheme}://{source_domain_path}",
+        content_type=None,
+        language="",
+        languages=[],
+        document_type=None,
+        document_role=None,
+    )
+    assert document_response.source_url is None
+
+
+@pytest.mark.parametrize("source_domain_path", NON_CLIMATE_LAWS_DOMAIN_PATHS)
+@pytest.mark.parametrize("scheme", SCHEMES)
+def test_non_climate_laws_source_url_left_in_document(source_domain_path, scheme):
+    if source_domain_path:
+        given_url = f"{scheme}://{source_domain_path}"
+    else:
+        given_url = source_domain_path
+    document_response = FamilyDocumentResponse(
+        import_id="import_id",
+        variant=None,
+        slug="import_id_abcd",
+        title="title",
+        md5_sum=None,
+        cdn_object=None,
+        source_url=given_url,
+        content_type=None,
+        language="",
+        languages=[],
+        document_type=None,
+        document_role=None,
+    )
+    assert document_response.source_url == given_url


### PR DESCRIPTION
# Description

Do not return climate-laws.org source URLs from API responses because they will no longer work after domain switch

## Type of change

Please select the option(s) below that are most relevant:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

Response models have been tested to confirm that relevant URLs are removed

## Reviewer Checklist

- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
