### PR TITLE
WIP SOF-16 Change tagging to allow blank maturity

### DIFF
--- a/.github/funcs.sh
+++ b/.github/funcs.sh
@@ -25,9 +25,41 @@ get_minor() {
 }
 
 get_patch() {
-    echo "${1}" | cut -d'.' -f3 | cut -d'-' -f1
+    if [[ ${1} == *"-"* ]]; then
+        echo "${1}" | cut -d'.' -f3 | cut -d'-' -f1
+    else
+        echo "${1}" | cut -d'.' -f3
+    fi
 }
 
 get_maturity() {
-    echo "${1}" | cut -d'.' -f3 | cut -d'-' -f2
+    if [[ ${1} == *"-"* ]]; then
+        echo "${1}" | cut -d'.' -f3 | cut -d'-' -f2
+    else
+        echo ""
+    fi
+}
+
+get_docker_tags() { # First arg for array, second arg for semver
+    local -n arr=$1             # use nameref to create values
+    name=$2
+    semver=$3
+
+    major=$(get_major "${semver}")
+    minor=$(get_minor "${semver}")
+    patch=$(get_patch "${semver}")
+    maturity=$(get_maturity "${semver}")
+
+    echo "Detected Version: ${major} . ${minor} . ${patch} [${maturity}]"
+    if [ -z ${maturity} ] ; then
+        full_tag="${name}:${major}.${minor}.${patch}"
+        minor_tag="${name}:${major}.${minor}"
+        major_tag="${name}:${major}"
+    else
+        full_tag="${name}:${major}.${minor}.${patch}-${maturity}"
+        minor_tag="${name}:${major}.${minor}-${maturity}"
+        major_tag="${name}:${major}-${maturity}"
+    fi
+    arr=($full_tag $minor_tag $major_tag)
+    declare -p tag_array
 }

--- a/.github/funcs.sh
+++ b/.github/funcs.sh
@@ -55,12 +55,13 @@ get_docker_tags() {
     patch=$(get_patch "${semver}")
     maturity=$(get_maturity "${semver}")
 
-    echo "Detected Version: ${major} . ${minor} . ${patch} [${maturity}]"
     if [ -z ${maturity} ] ; then
+        echo "Detected Version: ${major} . ${minor} . ${patch}"
         full_tag="${name}:${major}.${minor}.${patch}"
         minor_tag="${name}:${major}.${minor}"
         major_tag="${name}:${major}"
     else
+        echo "Detected Version: ${major} . ${minor} . ${patch} [${maturity}]"
         full_tag="${name}:${major}.${minor}.${patch}-${maturity}"
         minor_tag="${name}:${major}.${minor}-${maturity}"
         major_tag="${name}:${major}-${maturity}"

--- a/.github/funcs.sh
+++ b/.github/funcs.sh
@@ -40,7 +40,12 @@ get_maturity() {
     fi
 }
 
-get_docker_tags() { # First arg for array, second arg for semver
+get_docker_tags() { 
+    # Arguments:
+    #  - Name reference for the array 
+    #  - Name of the docker image
+    #  - The semver we are using to create the tags
+
     local -n arr=$1             # use nameref to create values
     name=$2
     semver=$3
@@ -61,5 +66,4 @@ get_docker_tags() { # First arg for array, second arg for semver
         major_tag="${name}:${major}-${maturity}"
     fi
     arr=($full_tag $minor_tag $major_tag)
-    declare -p tag_array
 }

--- a/.github/retag-and-push.sh
+++ b/.github/retag-and-push.sh
@@ -71,18 +71,13 @@ elif is_tagged_version ${GITHUB_REF} ; then
     # push `semver` tagged image
     semver="${GITHUB_REF/refs\/tags\/v/}"
     echo "Detected Tag: ${semver}"
-    major=$(get_major "${semver}")
-    minor=$(get_minor "${semver}")
-    patch=$(get_patch "${semver}")
-    maturity=$(get_maturity "${semver}")
-    echo "Detected Version: ${major} . ${minor} . ${patch} [${maturity}]"
+    local tag_array
+    get_docker_tags tag_array ${name} ${semver}
 
-    docker_tag "${input_image}" "${name}:${major}.${minor}.${patch}-${maturity}"
-    docker_tag "${input_image}" "${name}:${major}.${minor}-${maturity}"
-    docker_tag "${input_image}" "${name}:${major}-${maturity}"
-    docker push "${name}:${major}.${minor}.${patch}-${maturity}"
-    docker push "${name}:${major}.${minor}-${maturity}"
-    docker push "${name}:${major}-${maturity}"
+    for tag in "${tag_array[@]}" ; do
+        docker_tag "${input_image}" ${tag}
+        docker push "${tag}"
+    done
 else
     echo "${GITHUB_REF} is neither a branch head nor valid semver tag"
     echo "Assuming '${GITHUB_HEAD_REF}' is a branch"

--- a/.github/tests/test_retag_and_push.bats
+++ b/.github/tests/test_retag_and_push.bats
@@ -84,3 +84,62 @@ load '/opt/bats-test-helpers/lox-bats-mock/stub.bash'
   [ "$status" -eq 0 ]
   [ "$output" == "" ]
 }
+
+# ------
+
+@test "regression with missing maturity" {
+  source /code/funcs.sh
+  semver="8.9.7"
+
+  run get_major $semver
+  [ "$status" -eq 0 ]
+  [ "$output" == "8" ]
+  run get_minor $semver
+  [ "$status" -eq 0 ]
+  [ "$output" == "9" ]
+  run get_patch $semver
+  [ "$status" -eq 0 ]
+  [ "$output" == "7" ]
+  run get_maturity $semver
+  [ "$status" -eq 0 ]
+  [ "$output" == "" ]
+}
+
+# ------
+
+@test "get_docker_tags returns correctly with maturity " {
+  source /code/funcs.sh
+  run get_docker_tags tag_array "test" "8.9.7-alpha"
+  [ "$status" -eq 0 ]
+
+  # Note the above "run" command does something unholy - so just execute without it
+  local tag_array
+  get_docker_tags tag_array "test" "8.9.7-alpha"
+
+  # Test we have 3 tags
+  [ ${#tag_array[@]} -eq 3 ]
+
+  [ "${tag_array[0]}" == "test:8.9.7-alpha" ]
+  [ "${tag_array[1]}" == "test:8.9-alpha" ]
+  [ "${tag_array[2]}" == "test:8-alpha" ]
+}
+
+# ------
+
+@test "get_docker_tags returns correctly without maturity " {
+  source /code/funcs.sh
+  run get_docker_tags tag_array "test" "8.9.7"
+  [ "$status" -eq 0 ]
+
+  # Note the above "run" command does something unholy - so just execute without it
+  local tag_array
+  get_docker_tags tag_array "test" "8.9.7"
+
+  # Test we have 3 tags
+  [ ${#tag_array[@]} -eq 3 ]
+
+  [ "${tag_array[0]}" == "test:8.9.7" ]
+  [ "${tag_array[1]}" == "test:8.9" ]
+  [ "${tag_array[2]}" == "test:8" ]
+}
+

--- a/.github/tests/test_retag_and_push.bats
+++ b/.github/tests/test_retag_and_push.bats
@@ -75,3 +75,12 @@ load '/opt/bats-test-helpers/lox-bats-mock/stub.bash'
   [ "$status" -eq 0 ]
   [ "$output" == "alpha" ]
 }
+
+# ------
+
+@test "get_maturity returns empty " {
+  source /code/funcs.sh
+  run get_maturity "8.9.7"
+  [ "$status" -eq 0 ]
+  [ "$output" == "" ]
+}


### PR DESCRIPTION
# Description

- Makes the docker tags that are generated testable - by pulling this out into `funcs.sh` and writing tests for them.
- Fix the docker tag names when there is no maturity in the tag, by checking for this in `get_patch` and `get_maturity`

## Type of change

Please select the option(s) below that are most relevant:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

Using the written tests - **we still need to test on a tag**

## Reviewer Checklist

- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
