### PR TITLE
Fix ID match regex in backend

### DIFF
--- a/app/core/validation/__init__.py
+++ b/app/core/validation/__init__.py
@@ -2,4 +2,4 @@ import os
 import re
 
 PIPELINE_BUCKET = os.environ["PIPELINE_BUCKET"]
-IMPORT_ID_MATCHER = re.compile(r"\w+\.\w+\.\w+\.\w+")
+IMPORT_ID_MATCHER = re.compile(r"\w+\.[\w\-]+\.\w+\.\w+")


### PR DESCRIPTION
# Description

Update ID match regex to match non party doc ids (e.g. `UNFCCC.non-party.123.0`)

## Type of change

Please select the option(s) below that are most relevant:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
