### PR TITLE
SOF-41 Add document & language metadata to config endpoint

### DIFF
--- a/app/api/api_v1/schemas/metadata.py
+++ b/app/api/api_v1/schemas/metadata.py
@@ -9,5 +9,9 @@ TaxonomyData = Mapping[str, Mapping[str, Union[str, Sequence[str]]]]
 class ApplicationConfig(BaseModel):
     """Definition of the new Config which just includes taxonomy."""
 
-    geographies: list[dict]
+    geographies: Sequence[dict]
     taxonomies: Mapping[str, TaxonomyData]
+    languages: Mapping[str, str]
+    document_roles: Sequence[str]
+    document_types: Sequence[str]
+    document_variants: Sequence[str]

--- a/app/core/lookups.py
+++ b/app/core/lookups.py
@@ -6,18 +6,39 @@ from app.core.organisation import get_organisation_taxonomy_by_name
 
 from app.core.util import tree_table_to_json
 from app.db.models.app.users import Organisation
-from app.db.models.law_policy import Geography
+from app.db.models.document.physical_document import Language
+from app.db.models.law_policy import (
+    Geography,
+    FamilyDocumentRole,
+    FamilyDocumentType,
+    Variant,
+)
 
 
 def get_config(db: Session) -> ApplicationConfig:
-    org_names = db.query(Organisation.name).all()
-
     return ApplicationConfig(
         geographies=tree_table_to_json(table=Geography, db=db),
         taxonomies={
-            org_name[0]: get_organisation_taxonomy_by_name(db=db, org_name=org_name[0])
-            for org_name in org_names
+            org.name: get_organisation_taxonomy_by_name(db=db, org_name=org.name)
+            for org in db.query(Organisation).all()
         },
+        languages={lang.language_code: lang.name for lang in db.query(Language).all()},
+        document_roles=[
+            doc_role.name
+            for doc_role in db.query(FamilyDocumentRole)
+            .order_by(FamilyDocumentRole.name)
+            .all()
+        ],
+        document_types=[
+            doc_type.name
+            for doc_type in db.query(FamilyDocumentType)
+            .order_by(FamilyDocumentType.name)
+            .all()
+        ],
+        document_variants=[
+            variant.variant_name
+            for variant in db.query(Variant).order_by(Variant.variant_name).all()
+        ],
     )
 
 


### PR DESCRIPTION
# Description

Adds document & language metadata to config endpoint, fixing a regression introduced by the DFC work.

## Type of change

Please select the option(s) below that are most relevant:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

Existing tests have been extended to validate the new data.

## Reviewer Checklist

- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
