### PR TITLE
TDD - approach to ingest bug 

### DIFF
--- a/app/core/ingestion/metadata.py
+++ b/app/core/ingestion/metadata.py
@@ -1,4 +1,4 @@
-from typing import Any, Mapping, Sequence, Union
+from typing import Any, Mapping, Sequence, Union, Optional
 
 from pydantic.dataclasses import dataclass
 from pydantic.config import ConfigDict, Extra
@@ -12,8 +12,8 @@ class TaxonomyEntry:
     """Details a single taxonomy field"""
 
     allow_blanks: bool
-    allow_any: bool
     allowed_values: Sequence[str]
+    allow_any: Optional[bool] = False
 
 
 Taxonomy = Mapping[str, TaxonomyEntry]

--- a/tests/routes/test_admin_cclw.py
+++ b/tests/routes/test_admin_cclw.py
@@ -9,6 +9,9 @@ from app.data_migrations import (
     populate_geography,
     populate_taxonomy,
 )
+from app.data_migrations.taxonomy_utils import _load_metadata_type
+from app.db.models.app import Organisation
+from app.db.models.law_policy import MetadataOrganisation, MetadataTaxonomy
 
 
 def test_unauthenticated_ingest(client):
@@ -39,6 +42,97 @@ def test_validate_bulk_ingest_cclw_law_policy(
     test_db,
 ):
     populate_taxonomy(test_db)
+    populate_geography(test_db)
+    populate_document_type(test_db)
+    populate_document_role(test_db)
+    populate_document_variant(test_db)
+    test_db.commit()
+    law_policy_csv_file = BytesIO(ONE_DFC_ROW.encode("utf8"))
+    files = {
+        "law_policy_csv": (
+            "valid_law_policy.csv",
+            law_policy_csv_file,
+            "text/csv",
+            {"Expires": "0"},
+        ),
+    }
+    response = client.post(
+        "/api/v1/admin/bulk-ingest/validate/cclw",
+        files=files,
+        headers=superuser_token_headers,
+    )
+    assert response.status_code == 200
+    response_json = response.json()
+    assert (
+        response_json["message"]
+        == "Law & Policy validation result: 1 Rows, 0 Failures, 0 Resolved"
+    )
+    assert len(response_json["errors"]) == 0
+
+
+def test_validate_bulk_ingest_cclw_law_policy_existing_taxonomy(
+    client,
+    superuser_token_headers,
+    test_db,
+):
+    """Test that the validation step passes when there is existing taxonomy data without the allow_any field."""
+    # Add the taxonomy data, we can't use the standard populate taxonomy function as this enforces the allow_any
+    # field.
+    TAXONOMY = [
+        {
+            "key": "topic",
+            "filename": "app/data_migrations/data/cclw/topic_data.json",
+            "file_key_path": "name",
+            "allow_blanks": True,
+        },
+        {
+            "key": "sector",
+            "filename": "app/data_migrations/data/cclw/sector_data.json",
+            "file_key_path": "node.name",
+            "allow_blanks": True,
+        }
+    ]
+
+    TAXONOMY_DATA = {}
+    for i in TAXONOMY:
+        TAXONOMY_DATA.update(
+            {
+                i["key"]: {
+                    "allowed_values": _load_metadata_type(
+                        i["filename"], i["file_key_path"]
+                    ),
+                    "allow_blanks": i["allow_blanks"],
+                }
+            }
+        )
+
+    # Add the organisation
+    org_name = "CCLW"
+    description = "Climate Change Laws of the World"
+    org_type = "Academic"
+    org = Organisation(
+        name=org_name, description=description, organisation_type=org_type
+    )
+    test_db.add(org)
+    test_db.flush()
+
+    # Now add the taxonomy
+    tax = MetadataTaxonomy(
+        description=f"{org_name} loaded values",
+        valid_metadata=TAXONOMY_DATA,
+    )
+    test_db.add(tax)
+    test_db.flush()
+
+    # Finally the link between the org and the taxonomy.
+    test_db.add(
+        MetadataOrganisation(
+            taxonomy_id=tax.id,
+            organisation_id=org.id,
+        )
+    )
+    test_db.flush()
+
     populate_geography(test_db)
     populate_document_type(test_db)
     populate_document_role(test_db)

--- a/tests/routes/test_admin_cclw.py
+++ b/tests/routes/test_admin_cclw.py
@@ -64,8 +64,8 @@ def test_validate_bulk_ingest_cclw_law_policy(
     assert response.status_code == 200
     response_json = response.json()
     assert (
-            response_json["message"]
-            == "Law & Policy validation result: 1 Rows, 0 Failures, 0 Resolved"
+        response_json["message"]
+        == "Law & Policy validation result: 1 Rows, 0 Failures, 0 Resolved"
     )
     assert len(response_json["errors"]) == 0
 

--- a/tests/routes/test_admin_cclw.py
+++ b/tests/routes/test_admin_cclw.py
@@ -37,9 +37,9 @@ TWO_EVENT_ROWS = """Id,Eventable type,Eventable Id,Eventable name,Event type,Tit
 
 
 def test_validate_bulk_ingest_cclw_law_policy(
-    client,
-    superuser_token_headers,
-    test_db,
+        client,
+        superuser_token_headers,
+        test_db,
 ):
     populate_taxonomy(test_db)
     populate_geography(test_db)
@@ -64,16 +64,16 @@ def test_validate_bulk_ingest_cclw_law_policy(
     assert response.status_code == 200
     response_json = response.json()
     assert (
-        response_json["message"]
-        == "Law & Policy validation result: 1 Rows, 0 Failures, 0 Resolved"
+            response_json["message"]
+            == "Law & Policy validation result: 1 Rows, 0 Failures, 0 Resolved"
     )
     assert len(response_json["errors"]) == 0
 
 
 def test_validate_bulk_ingest_cclw_law_policy_existing_taxonomy(
-    client,
-    superuser_token_headers,
-    test_db,
+        client,
+        superuser_token_headers,
+        test_db,
 ):
     """Test that the validation step passes when there is existing taxonomy data without the allow_any field."""
     # Add the taxonomy data, we can't use the standard populate taxonomy function as this enforces the allow_any
@@ -90,7 +90,31 @@ def test_validate_bulk_ingest_cclw_law_policy_existing_taxonomy(
             "filename": "app/data_migrations/data/cclw/sector_data.json",
             "file_key_path": "node.name",
             "allow_blanks": True,
-        }
+        },
+        {
+            "key": "keyword",
+            "filename": "app/data_migrations/data/cclw/keyword_data.json",
+            "file_key_path": "name",
+            "allow_blanks": True,
+        },
+        {
+            "key": "instrument",
+            "filename": "app/data_migrations/data/cclw/instrument_data.json",
+            "file_key_path": "node.name",
+            "allow_blanks": True,
+        },
+        {
+            "key": "hazard",
+            "filename": "app/data_migrations/data/cclw/hazard_data.json",
+            "file_key_path": "name",
+            "allow_blanks": True,
+        },
+        {
+            "key": "framework",
+            "filename": "app/data_migrations/data/cclw/framework_data.json",
+            "file_key_path": "name",
+            "allow_blanks": True,
+        },
     ]
 
     TAXONOMY_DATA = {}
@@ -155,17 +179,17 @@ def test_validate_bulk_ingest_cclw_law_policy_existing_taxonomy(
     assert response.status_code == 200
     response_json = response.json()
     assert (
-        response_json["message"]
-        == "Law & Policy validation result: 1 Rows, 0 Failures, 0 Resolved"
+            response_json["message"]
+            == "Law & Policy validation result: 1 Rows, 0 Failures, 0 Resolved"
     )
     assert len(response_json["errors"]) == 0
 
 
 def test_bulk_ingest_cclw_law_policy(
-    client,
-    superuser_token_headers,
-    test_db,
-    mocker,
+        client,
+        superuser_token_headers,
+        test_db,
+        mocker,
 ):
     mock_start_import = mocker.patch("app.api.api_v1.routers.cclw_ingest._start_ingest")
     mock_write_csv_to_s3 = mocker.patch(

--- a/tests/routes/test_admin_cclw.py
+++ b/tests/routes/test_admin_cclw.py
@@ -37,9 +37,9 @@ TWO_EVENT_ROWS = """Id,Eventable type,Eventable Id,Eventable name,Event type,Tit
 
 
 def test_validate_bulk_ingest_cclw_law_policy(
-        client,
-        superuser_token_headers,
-        test_db,
+    client,
+    superuser_token_headers,
+    test_db,
 ):
     populate_taxonomy(test_db)
     populate_geography(test_db)
@@ -71,9 +71,9 @@ def test_validate_bulk_ingest_cclw_law_policy(
 
 
 def test_validate_bulk_ingest_cclw_law_policy_existing_taxonomy(
-        client,
-        superuser_token_headers,
-        test_db,
+    client,
+    superuser_token_headers,
+    test_db,
 ):
     """Test that the validation step passes when there is existing taxonomy data without the allow_any field."""
     # Add the taxonomy data, we can't use the standard populate taxonomy function as this enforces the allow_any
@@ -186,10 +186,10 @@ def test_validate_bulk_ingest_cclw_law_policy_existing_taxonomy(
 
 
 def test_bulk_ingest_cclw_law_policy(
-        client,
-        superuser_token_headers,
-        test_db,
-        mocker,
+    client,
+    superuser_token_headers,
+    test_db,
+    mocker,
 ):
     mock_start_import = mocker.patch("app.api.api_v1.routers.cclw_ingest._start_ingest")
     mock_write_csv_to_s3 = mocker.patch(


### PR DESCRIPTION
# Description

When firing a document and event set of csvs at a locally deployed latest version of the backend with the latest production postgres db dump using the cclw ingest end point, the request fails.

This is as the metadata taxonomy values do not have allow_any values in the mapping. Here is an example after loading the latest production db state dump: 
"topic":{"allow_blanks":true,"allowed_values":["Mitigation","Adaptation","Loss And Damage","Disaster Risk Management"]}

This is causing the following error during the cclw ingest: 
```
{
   "written_at":"2023-06-05T12:33:22.085Z",
   "written_ts":1685968402085789000,
   "msg":"Unexpected error, validating law & policy CSV on ingest",
   "type":"log",
   "logger":"app.api.api_v1.routers.cclw_ingest",
   "thread":"AnyIO worker thread",
   "level":"ERROR",
   "module":"cclw_ingest",
   "line_no":230,
   "errors":"__init__() missing 1 required positional argument: 'allow_any'",
   "exc_info":"Traceback (most recent call last):\n  File \"/cpr-backend/app/api/api_v1/routers/cclw_ingest.py\", line 220, in ingest_law_policy\n    documents_file_contents, _ = _validate_cclw_csv(\n  File \"/cpr-backend/app/api/api_v1/routers/cclw_ingest.py\", line 382, in _validate_cclw_csv\n    validator = get_document_validator(db, context)\n  File \"/cpr-backend/app/core/ingestion/processor.py\", line 342, in get_document_validator\n    _, taxonomy = get_organisation_taxonomy(db, context.org_id)\n  File \"/cpr-backend/app/core/organisation.py\", line 33, in get_organisation_taxonomy\n    return taxonomy[0], {k: TaxonomyEntry(**v) for k, v in taxonomy[1].items()}\n  File \"/cpr-backend/app/core/organisation.py\", line 33, in <dictcomp>\n    return taxonomy[0], {k: TaxonomyEntry(**v) for k, v in taxonomy[1].items()}\n  File \"pydantic/dataclasses.py\", line 322, in pydantic.dataclasses._add_pydantic_validation_attributes.new_init\n  File \"pydantic/dataclasses.py\", line 294, in pydantic.dataclasses._add_pydantic_validation_attributes.handle_extra_init\nTypeError: __init__() missing 1 required positional argument: 'allow_any'\n",
   "filename":"cclw_ingest.py",
   "correlation_id":"2896fa38-039d-11ee-a1c4-0242ac130004"
}
```

An example for the UNFCCC can be seen below which does contain the allow_any value as true which explains why that ingest succeeded last week. 
"author":{"allow_any":true,"allow_blanks":false,"allowed_values":[]}}

It would appear that during the tests the test database loads taxonomy values with allow_any for cclw. It is not entirely clear when this happens but logging during the tests proves that the the database does contain allow_any values for the cclw taxonomy. 

## Type of change
This PR updates the json object for the cclw taxonomy to include the allow_any field. From my understanding if we deploy the latest version of the backend and run the make migrations_docker_backend command this should load the updated taxonomy and thus allow the ingest to run successfully. 
We then update the populate taxonomy module to identify if there is a difference between the declared taxonomy in code and that in the database and to update accordingly. 

Please select the option(s) below that are most relevant:

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

Extensive unit tests and running of the csv's locally against the endpoint. 

## Reviewer Checklist

Confirm that allow_any = False as default is correct? 

- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain