### PR TITLE
PDCT-179: Ensure search does not return families that are not Published

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,8 @@ BACKEND_DATABASE_URL=postgresql://${BACKEND_POSTGRES_USER}:${BACKEND_POSTGRES_PA
 # Fastapi settings
 ENABLE_API_DOCS=False
 
+DOCUMENT_CACHE_TTL_MS=0
+
 # Opensearch connection settings
 OPENSEARCH_USER=admin
 OPENSEARCH_PASSWORD=admin

--- a/app/api/api_v1/routers/search.py
+++ b/app/api/api_v1/routers/search.py
@@ -72,6 +72,7 @@ def _search_request(db: Session, search_body: SearchRequestBody) -> SearchRespon
                 keyword_filters = dict(search_body.keyword_filters)
                 keyword_filters[FilterField.CATEGORY] = fixed_categories
                 search_body.keyword_filters = keyword_filters
+        # filter families not published
         return _OPENSEARCH_CONNECTION.query_families(
             search_request_body=search_body,
             opensearch_internal_config=_OPENSEARCH_INDEX_CONFIG,

--- a/app/api/api_v1/routers/search.py
+++ b/app/api/api_v1/routers/search.py
@@ -72,7 +72,6 @@ def _search_request(db: Session, search_body: SearchRequestBody) -> SearchRespon
                 keyword_filters = dict(search_body.keyword_filters)
                 keyword_filters[FilterField.CATEGORY] = fixed_categories
                 search_body.keyword_filters = keyword_filters
-        # filter families not published
         return _OPENSEARCH_CONNECTION.query_families(
             search_request_body=search_body,
             opensearch_internal_config=_OPENSEARCH_INDEX_CONFIG,

--- a/app/core/search.py
+++ b/app/core/search.py
@@ -703,8 +703,17 @@ def process_search_response_body_families(
                 continue
 
             family_id = document_extra_info[doc_match.document_id]["family_import_id"]
+            family_status = document_extra_info[doc_match.document_id]["family_status"]
+            document_status = document_extra_info[doc_match.document_id][
+                "document_status"
+            ]
+            document_id = document_extra_info[doc_match.document_id]["document_id"]
+            print("*" * 80)
+            print(family_id, family_status)
+            print(document_id, document_status)
+
             search_response_family = families.get(family_id)
-            if search_response_family is None:
+            if search_response_family is None and family_status == "Published":
                 search_response_family = create_search_response_family(
                     doc_match,
                     document_extra_info,

--- a/app/core/search.py
+++ b/app/core/search.py
@@ -704,13 +704,6 @@ def process_search_response_body_families(
 
             family_id = document_extra_info[doc_match.document_id]["family_import_id"]
             family_status = document_extra_info[doc_match.document_id]["family_status"]
-            document_status = document_extra_info[doc_match.document_id][
-                "document_status"
-            ]
-            document_id = document_extra_info[doc_match.document_id]["document_id"]
-            print("*" * 80)
-            print(family_id, family_status)
-            print(document_id, document_status)
 
             search_response_family = families.get(family_id)
             if search_response_family is None and family_status == "Published":

--- a/app/db/crud/document.py
+++ b/app/db/crud/document.py
@@ -264,15 +264,19 @@ class DocumentExtraCache:
             .join(Family, FamilyDocument.family_import_id == Family.import_id)
             .all()
         )
+        _LOGGER.info("##############################################")
         return {
             family_document.import_id: {
                 "slug": family_document.slugs[-1].name,
+                "document_status": family_document.document_status,
+                "document_id": family_document.import_id,
                 "title": family_document.physical_document.title,
                 "family_slug": family.slugs[-1].name,
                 "family_import_id": family.import_id,
                 "family_title": family.title,
                 "family_description": family.description,
                 "family_category": family.family_category,
+                "family_status": family.family_status,
                 "family_published_date": (
                     family.published_date.isoformat()
                     if family.published_date is not None

--- a/tests/routes/test_search.py
+++ b/tests/routes/test_search.py
@@ -403,6 +403,7 @@ def test_families_search_with_deleted(test_opensearch, monkeypatch, client, test
             .values(document_status="Deleted")
         )
 
+    test_db.commit()
     print(f"********* Import id: {family.import_id}")
     for doc in family.family_documents:
         print(doc.import_id)
@@ -420,6 +421,7 @@ def test_families_search_with_deleted(test_opensearch, monkeypatch, client, test
             "exact_match": True,
         },
     )
+
     assert response.status_code == 200
 
     # Check the correct number of hits is returned

--- a/tests/routes/test_search.py
+++ b/tests/routes/test_search.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any, Mapping, Sequence, cast
 
 import pytest
+from sqlalchemy import update
 from sqlalchemy.orm import Session
 
 from app.api.api_v1.routers import search
@@ -48,6 +49,9 @@ from app.initial_data import populate_geography, populate_language, populate_tax
 
 SEARCH_ENDPOINT = "/api/v1/searches"
 CSV_DOWNLOAD_ENDPOINT = "/api/v1/searches/download-csv"
+_EXPECTED_FAMILY_TITLE = (
+    "Spanish Climate Change And Clean Energy Strategy Horizon 2007- 2012 -2020"
+)
 
 
 def _populate_search_db_families(db: Session) -> None:
@@ -341,11 +345,23 @@ def test_search_body_valid(exact_match, test_opensearch, monkeypatch, client, te
     assert response.status_code == 200
 
 
-@pytest.mark.search
+@pytest.mark.search2
 def test_families_search(test_opensearch, monkeypatch, client, test_db, mocker):
     monkeypatch.setattr(search, "_OPENSEARCH_CONNECTION", test_opensearch)
     _populate_search_db_families(test_db)
 
+    expected_config = OpenSearchQueryConfig()
+    expected_search_body = SearchRequestBody(
+        query_string="climate",
+        exact_match=True,
+        max_passages_per_doc=10,
+        keyword_filters=None,
+        year_range=None,
+        sort_field=None,
+        sort_order=SortOrder.DESCENDING,
+        limit=10,
+        offset=0,
+    )
     query_spy = mocker.spy(search._OPENSEARCH_CONNECTION, "query_families")
 
     response = client.post(
@@ -360,24 +376,58 @@ def test_families_search(test_opensearch, monkeypatch, client, test_db, mocker):
     assert query_spy.call_count == 1  # Called once as not using jit search
 
     actual_search_body = query_spy.mock_calls[0].kwargs["search_request_body"]
-
-    expected_search_body = SearchRequestBody(
-        query_string="climate",
-        exact_match=True,
-        max_passages_per_doc=10,
-        keyword_filters=None,
-        year_range=None,
-        sort_field=None,
-        sort_order=SortOrder.DESCENDING,
-        limit=10,
-        offset=0,
-    )
     assert actual_search_body == expected_search_body
 
     # Check default config is used
     actual_config = query_spy.mock_calls[0].kwargs["opensearch_internal_config"]
-    expected_config = OpenSearchQueryConfig()
     assert actual_config == expected_config
+
+    # Check the correct number of hits is returned
+    data = response.json()
+    assert data["hits"] == 3
+    assert len(data["families"]) == 3
+
+    names_returned = [f["family_name"] for f in data["families"]]
+    assert _EXPECTED_FAMILY_TITLE in names_returned
+
+
+@pytest.mark.search2
+def test_families_search_with_deleted(test_opensearch, monkeypatch, client, test_db):
+    monkeypatch.setattr(search, "_OPENSEARCH_CONNECTION", test_opensearch)
+    _populate_search_db_families(test_db)
+    family = test_db.query(Family).filter(Family.title == _EXPECTED_FAMILY_TITLE).one()
+    for doc in family.family_documents:
+        test_db.execute(
+            update(FamilyDocument)
+            .where(FamilyDocument.import_id == doc.import_id)
+            .values(document_status="Deleted")
+        )
+
+    print(f"********* Import id: {family.import_id}")
+    for doc in family.family_documents:
+        print(doc.import_id)
+        print(
+            test_db.query(FamilyDocument)
+            .filter(FamilyDocument.import_id == doc.import_id)
+            .one()
+            .document_status
+        )
+
+    response = client.post(
+        SEARCH_ENDPOINT,
+        json={
+            "query_string": "climate",
+            "exact_match": True,
+        },
+    )
+    assert response.status_code == 200
+
+    # Check the correct number of hits is returned
+    data = response.json()
+    assert data["hits"] == 2
+    assert len(data["families"]) == 2
+    names_returned = [f["family_name"] for f in data["families"]]
+    assert _EXPECTED_FAMILY_TITLE not in names_returned
 
 
 @pytest.mark.search

--- a/tests/routes/test_search.py
+++ b/tests/routes/test_search.py
@@ -832,9 +832,10 @@ def test_punctuation_ignored(test_opensearch, monkeypatch, client, test_db):
 
 
 @pytest.mark.search
-def test_sensitive_queries(test_opensearch, monkeypatch, client):
+def test_sensitive_queries(test_db, test_opensearch, monkeypatch, client):
     """Make sure that queries in the list of sensitive queries only return results containing that term, and not KNN results."""
     monkeypatch.setattr(search, "_OPENSEARCH_CONNECTION", test_opensearch)
+    _populate_search_db_families(test_db)
 
     response1 = client.post(
         SEARCH_ENDPOINT,
@@ -888,9 +889,10 @@ def test_sensitive_queries(test_opensearch, monkeypatch, client):
 
 
 @pytest.mark.search
-def test_accents_ignored(test_opensearch, monkeypatch, client):
+def test_accents_ignored(test_db, test_opensearch, monkeypatch, client):
     """Make sure that accents in query strings are ignored."""
     monkeypatch.setattr(search, "_OPENSEARCH_CONNECTION", test_opensearch)
+    _populate_search_db_families(test_db)
 
     response1 = client.post(
         SEARCH_ENDPOINT,

--- a/tests/routes/test_search.py
+++ b/tests/routes/test_search.py
@@ -345,7 +345,7 @@ def test_search_body_valid(exact_match, test_opensearch, monkeypatch, client, te
     assert response.status_code == 200
 
 
-@pytest.mark.search2
+@pytest.mark.search
 def test_families_search(test_opensearch, monkeypatch, client, test_db, mocker):
     monkeypatch.setattr(search, "_OPENSEARCH_CONNECTION", test_opensearch)
     _populate_search_db_families(test_db)
@@ -391,7 +391,7 @@ def test_families_search(test_opensearch, monkeypatch, client, test_db, mocker):
     assert _EXPECTED_FAMILY_TITLE in names_returned
 
 
-@pytest.mark.search2
+@pytest.mark.search
 def test_families_search_with_deleted(test_opensearch, monkeypatch, client, test_db):
     monkeypatch.setattr(search, "_OPENSEARCH_CONNECTION", test_opensearch)
     _populate_search_db_families(test_db)
@@ -401,17 +401,6 @@ def test_families_search_with_deleted(test_opensearch, monkeypatch, client, test
             update(FamilyDocument)
             .where(FamilyDocument.import_id == doc.import_id)
             .values(document_status="Deleted")
-        )
-
-    test_db.commit()
-    print(f"********* Import id: {family.import_id}")
-    for doc in family.family_documents:
-        print(doc.import_id)
-        print(
-            test_db.query(FamilyDocument)
-            .filter(FamilyDocument.import_id == doc.import_id)
-            .one()
-            .document_status
         )
 
     response = client.post(


### PR DESCRIPTION
# Description

- Makes the DocumentExtraCache TTL configurable
- Extends an existing tests and adds a new one to test when documents are marked as deleted
- Does not return families that are not Published

Also fixes tests that don't re-create the db ...
- tests/routes/test_search.py::test_sensitive_queries 
- tests/routes/test_search.py::test_accents_ignored

## Type of change

Please select the option(s) below that are most relevant:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
