### PR TITLE
Allow downloading >100 results in CSV

### DIFF
--- a/app/api/api_v1/routers/search.py
+++ b/app/api/api_v1/routers/search.py
@@ -119,7 +119,8 @@ def download_search_documents(
     )
     # Always download all results
     search_body.offset = 0
-    search_body.limit = 100  # TODO: configure this value
+    # TODO: properly configure the limit - for now we override if under 100 or not set
+    search_body.limit = max(search_body.limit, 100)
     is_browse = not bool(search_body.query_string)
 
     _LOGGER.info(

--- a/tests/routes/test_search.py
+++ b/tests/routes/test_search.py
@@ -1470,7 +1470,7 @@ def test_csv_content(
 
 @pytest.mark.search
 @pytest.mark.parametrize("query_string", ["", "greenhouse"])
-@pytest.mark.parametrize("limit", [1, 10, 35])
+@pytest.mark.parametrize("limit", [1, 10, 35, 150])
 @pytest.mark.parametrize("offset", [0, 5, 10, 80])
 def test_csv_download_no_limit(
     query_string,
@@ -1507,5 +1507,5 @@ def test_csv_download_no_limit(
         actual_search_req = query_spy.mock_calls[0].kwargs["req"]
 
     # Make sure we overrode the search request content to produce the CSV download
-    assert actual_search_req.limit == 100
+    assert actual_search_req.limit == max(limit, 100)
     assert actual_search_req.offset == 0


### PR DESCRIPTION
# Description

To support generating a CSV of the entire db, support a download request with >100 limit.

## Type of change

Please select the option(s) below that are most relevant:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

Extended existing test to verify behaviour.

## Reviewer Checklist

- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
