### PR TITLE
PDCT-196: Fix internal server error when searching html index

### DIFF
--- a/app/api/api_v1/schemas/search.py
+++ b/app/api/api_v1/schemas/search.py
@@ -123,8 +123,16 @@ class OpenSearchResponsePassageMatch(OpenSearchResponseMatchBase):
 
     text: str
     text_block_id: str
-    text_block_page: int
-    text_block_coords: Sequence[Coord]
+    text_block_page: Optional[int]
+    text_block_coords: Optional[Sequence[Coord]]
+
+    @validator("text_block_page", always=True)
+    @classmethod
+    def validate_page(cls, value):
+        """PDF page numbers must be incremented from our 0-indexed values."""
+        if value is None:
+            return None
+        return value + 1
 
 
 class SearchResponseFamilyDocument(BaseModel):

--- a/app/core/search.py
+++ b/app/core/search.py
@@ -699,7 +699,7 @@ def process_search_response_body_families(
                 response_passage = SearchResponseDocumentPassage(
                     text=doc_match.text,
                     text_block_id=doc_match.text_block_id,
-                    text_block_page=doc_match.text_block_page + 1,
+                    text_block_page=doc_match.text_block_page,
                     text_block_coords=doc_match.text_block_coords,
                 )
                 search_response_document.document_passage_matches.append(


### PR DESCRIPTION
# Description

Text page & Coords are not supplied for HTML documents, this was causing internal server errors when searching indices containing information about HTML documents.

## Type of change

Please select the option(s) below that are most relevant:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

Additional test added that queries an HTML index. Confirmed that this test acts as a regression test.

## Reviewer Checklist

- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
