### PR TITLE
Making updates to handle different iso codes.

### DIFF
--- a/app/api/api_v1/routers/admin.py
+++ b/app/api/api_v1/routers/admin.py
@@ -83,7 +83,12 @@ async def update_document(
     if meta_data.languages is not None:
         _LOGGER.info(
             "Adding meta_data object languages to the database.",
-            extra={"props": {"meta_data_languages": meta_data.languages}},
+            extra={
+                "props": {
+                    "meta_data_languages": meta_data.languages,
+                    "import_id_or_slug": import_id_or_slug,
+                }
+            },
         )
 
         physical_document_languages = (
@@ -97,23 +102,40 @@ async def update_document(
         }
 
         for language in meta_data.languages:
-            if len(language) == 2:
-                # The part1_code is the iso639-1 two letter language code.
-                # This is the way languages are detected in the pipeline.
+            if len(language) == 2:  # iso639-1 two letter language code
                 lang = (
                     db.query(Language)
                     .filter(Language.part1_code == language)
                     .one_or_none()
                 )
-            elif len(language) == 3:
+            elif len(language) == 3:  # iso639-2/3 three letter language code
                 lang = (
                     db.query(Language)
                     .filter(Language.language_code == language)
                     .one_or_none()
                 )
             else:
+                _LOGGER.warning(
+                    "Retrieved no language from database for meta_data object language.",
+                    extra={
+                        "props": {
+                            "metadata_language": language,
+                            "import_id_or_slug": import_id_or_slug,
+                        }
+                    },
+                )
                 lang = None
 
+            _LOGGER.info(
+                "Retrieved language from database for meta_data object language.",
+                extra={
+                    "props": {
+                        "metadata_language": language,
+                        "db_language": (None if lang is None else lang.language_code),
+                        "import_id_or_slug": import_id_or_slug,
+                    }
+                },
+            )
             if lang is not None and language not in existing_language_codes:
                 physical_document_language = PhysicalDocumentLanguage(
                     language_id=lang.id, document_id=physical_document.id

--- a/app/api/api_v1/routers/admin.py
+++ b/app/api/api_v1/routers/admin.py
@@ -97,11 +97,23 @@ async def update_document(
         }
 
         for language in meta_data.languages:
-            lang = (
-                db.query(Language)
-                .filter(Language.language_code == language)
-                .one_or_none()
-            )
+            if len(language) == 2:
+                # The part1_code is the iso639-1 two letter language code.
+                # This is the way languages are detected in the pipeline.
+                lang = (
+                    db.query(Language)
+                    .filter(Language.part1_code == language)
+                    .one_or_none()
+                )
+            elif len(language) == 3:
+                lang = (
+                    db.query(Language)
+                    .filter(Language.language_code == language)
+                    .one_or_none()
+                )
+            else:
+                lang = None
+
             if lang is not None and language not in existing_language_codes:
                 physical_document_language = PhysicalDocumentLanguage(
                     language_id=lang.id, document_id=physical_document.id

--- a/app/db/models/document/physical_document.py
+++ b/app/db/models/document/physical_document.py
@@ -6,6 +6,8 @@ from sqlalchemy.orm import relationship
 from app.db.session import Base
 
 
+# TODO Our current process for updating languages in the database relies on all the part1_code's being unique/null.
+#  Thus, we should enforce null or uniqueness on part1_code's in the database.
 class Language(Base):
     """
     A language used to identify the content of a document.

--- a/tests/routes/test_document_families.py
+++ b/tests/routes/test_document_families.py
@@ -523,6 +523,114 @@ def test_update_document__works_on_new_language(
         "UNFCCC.non-party.2.2",
     ],
 )
+def test_update_document__works_on_new_iso_639_1_language(
+    client: TestClient,
+    superuser_token_headers: dict[str, str],
+    test_db: Session,
+    mocker: Callable[..., Generator[MockerFixture, None, None]],
+    import_id: str,
+):
+    """Send two payloads in series to assert that languages are additive and we don't remove existing languages."""
+    setup_with_multiple_docs(
+        test_db, mocker, doc_data=TWO_DFC_ROW_DIFFERENT_ORG, event_data=TWO_EVENT_ROWS
+    )
+
+    # ADD THE FIRST LANGUAGE
+    payload = {
+        "md5_sum": "c184214e-4870-48e0-adab-3e064b1b0e76",
+        "content_type": "updated/content_type",
+        "cdn_object": "folder/file",
+        "languages": ["bo"],
+    }
+
+    response = client.put(
+        f"/api/v1/admin/documents/{import_id}",
+        headers=superuser_token_headers,
+        json=payload,
+    )
+
+    assert response.status_code == 200
+    json_object = response.json()
+    assert json_object["md5_sum"] == "c184214e-4870-48e0-adab-3e064b1b0e76"
+    assert json_object["content_type"] == "updated/content_type"
+    assert json_object["cdn_object"] == "folder/file"
+    assert {language["language_code"] for language in json_object["languages"]} == {
+        "bod"
+    }
+
+    # Now Check the db
+    doc = (
+        test_db.query(FamilyDocument)
+        .filter(FamilyDocument.import_id == import_id)
+        .one()
+        .physical_document
+    )
+    assert doc.md5_sum == "c184214e-4870-48e0-adab-3e064b1b0e76"
+    assert doc.content_type == "updated/content_type"
+    assert doc.cdn_object == "folder/file"
+
+    languages = (
+        test_db.query(PhysicalDocumentLanguage)
+        .filter(PhysicalDocumentLanguage.document_id == doc.id)
+        .all()
+    )
+    assert len(languages) == 1
+    lang = test_db.query(Language).filter(Language.id == languages[0].language_id).one()
+    assert lang.language_code == "bod"
+
+    # NOW ADD A NEW LANGUAGE TO CHECK THAT THE UPDATE IS ADDITIVE
+    payload = {
+        "md5_sum": "c184214e-4870-48e0-adab-3e064b1b0e76",
+        "content_type": "updated/content_type",
+        "cdn_object": "folder/file",
+        "languages": ["el"],
+    }
+
+    response = client.put(
+        f"/api/v1/admin/documents/{import_id}",
+        headers=superuser_token_headers,
+        json=payload,
+    )
+
+    assert response.status_code == 200
+    json_object = response.json()
+    assert json_object["md5_sum"] == "c184214e-4870-48e0-adab-3e064b1b0e76"
+    assert json_object["content_type"] == "updated/content_type"
+    assert json_object["cdn_object"] == "folder/file"
+    expected_languages = {"ell", "bod"}
+    assert {
+        lang["language_code"] for lang in json_object["languages"]
+    } == expected_languages
+
+    # Now Check the db
+    doc = (
+        test_db.query(FamilyDocument)
+        .filter(FamilyDocument.import_id == import_id)
+        .one()
+        .physical_document
+    )
+    assert doc.md5_sum == "c184214e-4870-48e0-adab-3e064b1b0e76"
+    assert doc.content_type == "updated/content_type"
+    assert doc.cdn_object == "folder/file"
+
+    doc_languages = (
+        test_db.query(PhysicalDocumentLanguage)
+        .filter(PhysicalDocumentLanguage.document_id == doc.id)
+        .all()
+    )
+    assert len(doc_languages) == 2
+    for doc_lang in doc_languages:
+        lang = test_db.query(Language).filter(Language.id == doc_lang.language_id).one()
+        assert lang.language_code in expected_languages
+
+
+@pytest.mark.parametrize(
+    "import_id",
+    [
+        "CCLW.executive.1.2",
+        "UNFCCC.non-party.2.2",
+    ],
+)
 @pytest.mark.parametrize(
     "languages",
     [[], None],

--- a/tests/routes/test_document_families.py
+++ b/tests/routes/test_document_families.py
@@ -669,7 +669,7 @@ def test_update_document__logs_warning_on_four_letter_language(
     assert {language["language_code"] for language in json_object["languages"]} == set()
 
     assert log_spy.call_args_list[0].args[0] == "Retrieved no language from database for meta_data object " \
-                                                "language. "
+                                                "language."
     assert len(log_spy.call_args_list) == 1
 
     # Now Check the db

--- a/tests/routes/test_document_families.py
+++ b/tests/routes/test_document_families.py
@@ -689,8 +689,6 @@ def test_update_document__logs_warning_on_four_letter_language(
         .all()
     )
     assert len(languages) == 0
-    lang = test_db.query(Language).filter(Language.id == languages[0].language_id).one_or_none()
-    assert lang is None
 
 
 @pytest.mark.parametrize(

--- a/tests/routes/test_document_families.py
+++ b/tests/routes/test_document_families.py
@@ -689,7 +689,7 @@ def test_update_document__logs_warning_on_four_letter_language(
         .all()
     )
     assert len(languages) == 0
-    lang = test_db.query(Language).filter(Language.id == languages[0].language_id).one()
+    lang = test_db.query(Language).filter(Language.id == languages[0].language_id).one_or_none()
     assert lang is None
 
 


### PR DESCRIPTION
# Description

The current backend code assumes that language codes send to the update document endpoint will be if the for iso-639-3. This is a three letter representation of the language. 

The pipeline identifies languages as iso-639-1 which is a two letter representation. 

Thus, the endpoint is updated to handle the differing language codes. A unit test is also added to check functionality. 

NOTE: 
Should we update the languages table to enforce part1_codes being unique and len(2) as the functionality will rely on that an in practice the two letter codes should be unique and two letters (the same of language codes and three letters)? 
Should we also at least log when we pass over a language update due to it not existing in the database? 


[Linear Ticket](https://linear.app/climate-policy-radar/issue/PDCT-200/bugfixhandle-iso-639-1-language-codes)

## Type of change

Please select the option(s) below that are most relevant:

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

Unit test in the PR 

## Reviewer Checklist

- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
