### PR TITLE
Set default document cache timeout to 1-day rather than 1-minute

### DIFF
--- a/app/db/crud/document.py
+++ b/app/db/crud/document.py
@@ -36,7 +36,8 @@ from app.core.util import to_cdn_url
 
 _LOGGER = logging.getLogger(__file__)
 
-_DOCUMENT_CACHE_TTL: int = int(os.environ.get("DOCUMENT_CACHE_TTL_MS", "60000"))
+# Set default cache timeout to 1-day, this can be revisited later.
+_DOCUMENT_CACHE_TTL: int = int(os.environ.get("DOCUMENT_CACHE_TTL_MS", "86400000"))
 
 
 def get_slugged_objects(db: Session, slug: str) -> tuple[Optional[str], Optional[str]]:


### PR DESCRIPTION
# Description

Sets default document cache timeout to 1-day rather than 1-minute. This should reduce the huge overhead on search requests that we've been seeing.

## Type of change

Please select the option(s) below that are most relevant:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
