### PR TITLE
Adding one to vespa passage match pages.

### DIFF
--- a/app/api/api_v1/schemas/search.py
+++ b/app/api/api_v1/schemas/search.py
@@ -81,6 +81,15 @@ class SearchResponseDocumentPassage(BaseModel):
     text_block_id: str
     text_block_page: Optional[int]
     text_block_coords: Optional[Sequence[Coord]]
+    
+    @validator("text_block_page", always=True)
+    @classmethod
+    def validate_page(cls, value):
+        """PDF page numbers must be incremented from our 0-indexed values."""
+        if value is None:
+            return None
+        return value + 1
+
 
 
 class OpenSearchResponseMatchBase(BaseModel):

--- a/tests/unit/app/schemas/test_schemas.py
+++ b/tests/unit/app/schemas/test_schemas.py
@@ -1,7 +1,12 @@
 import pytest
 
 from app.api.api_v1.schemas.document import FamilyDocumentResponse
-from app.api.api_v1.schemas.search import SearchResponseFamilyDocument
+from app.api.api_v1.schemas.search import (
+    OpenSearchResponsePassageMatch,
+    SearchResponseDocumentPassage,
+    SearchResponseFamilyDocument,
+    OpenSearchResponseMatchBase,
+)
 
 CLIMATE_LAWS_DOMAIN_PATHS = [
     "climate-laws.org",
@@ -98,3 +103,56 @@ def test_non_climate_laws_source_url_left_in_document(source_domain_path, scheme
         document_role=None,
     )
     assert document_response.source_url == given_url
+
+
+def test_search_responses() -> None:
+    """
+    Test that instantiating Search Response objects is done correctly.
+
+    Particularly testing of the validators.
+    """
+    original_block_page = 0
+
+    original_block_data = {
+        "text": "example text",
+        "text_block_id": "p_0_b_0",
+        "text_block_page": original_block_page,
+        "text_block_coords": None,
+    }
+
+    base_response_data = {
+        "document_name": "Sample Document",
+        "document_geography": "USA",
+        "document_description": "This is a sample document description.",
+        "document_sectors": ["Technology", "Healthcare"],
+        "document_source": "Sample Source",
+        "document_id": "sample_import_id_123",
+        "document_date": "2023-11-22",
+        "document_type": "PDF",
+        "document_source_url": "https://example.com/sample_document",
+        "document_cdn_object": "sample_cdn_object_reference",
+        "document_category": "Sample Category",
+        "document_content_type": "application/pdf",
+        "document_slug": "sample-document",
+    }
+
+    # This is used for vespa responses
+    default_passage_response = SearchResponseDocumentPassage.parse_obj(
+        original_block_data
+    )
+
+    assert default_passage_response.text_block_page != original_block_page
+    assert default_passage_response.text_block_page == original_block_page + 1
+
+    response_base = OpenSearchResponseMatchBase.parse_obj(base_response_data)
+
+    opensearch_passage_response = OpenSearchResponsePassageMatch(
+        **response_base.dict(), **original_block_data
+    )
+
+    assert opensearch_passage_response.text_block_page != original_block_page
+    assert opensearch_passage_response.text_block_page == original_block_page + 1
+
+    assert opensearch_passage_response.text_block_page == (
+        default_passage_response.text_block_page
+    )

--- a/tests/unit/app/schemas/test_schemas.py
+++ b/tests/unit/app/schemas/test_schemas.py
@@ -141,7 +141,6 @@ def test_search_responses() -> None:
         original_block_data
     )
 
-    assert default_passage_response.text_block_page != original_block_page
     assert default_passage_response.text_block_page == original_block_page + 1
 
     response_base = OpenSearchResponseMatchBase.parse_obj(base_response_data)
@@ -150,7 +149,6 @@ def test_search_responses() -> None:
         **response_base.dict(), **original_block_data
     )
 
-    assert opensearch_passage_response.text_block_page != original_block_page
     assert opensearch_passage_response.text_block_page == original_block_page + 1
 
     assert opensearch_passage_response.text_block_page == (


### PR DESCRIPTION
# Description

Updating the pydantic object for a search response that is utilised by the vespa conditional flow for a search response. 
The update is to add a root validator method that increments the passage match page number by one. 

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

Added some explicit tests to assert that the response objects correctly convert the index of the page to the required page number. This should help us should we upgrade pydantic etc. 
The plan is once merged to deploy to staging and verify via the api. 

## Reviewer Checklist

- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
