### PR TITLE
Handle vespa search errors from families with no events 

### DIFF
--- a/app/core/search.py
+++ b/app/core/search.py
@@ -1156,8 +1156,16 @@ def _process_vespa_search_response_families(
                     family_name=hit.family_name,
                     family_description=hit.family_description or "",
                     family_category=hit.family_category,
-                    family_date=db_family.published_date.isoformat(),
-                    family_last_updated_date=db_family.last_updated_date.isoformat(),
+                    family_date=(
+                        db_family.published_date.isoformat()
+                        if db_family.published_date is not None
+                        else ""
+                    ),
+                    family_last_updated_date=(
+                        db_family.last_updated_date.isoformat()
+                        if db_family.last_updated_date is not None
+                        else ""
+                    ),
                     family_source=hit.family_source,
                     family_description_match=False,
                     family_title_match=False,


### PR DESCRIPTION
# Description
Three families with zero events currently exist in the database. The opensearch version of this code handles this scenario, this adds the same for Vespa. See Linear for details on which families.

[
](https://linear.app/climate-policy-radar/issue/PDCT-609/fix-500-errors-for-certain-search-terms-with-vespa)

Please include:
- a summary of the changes
- links to any related issue/ticket
- any additional relevant motivation and context
- details of any dependency updates that are required for this change

## Type of change

Please select the option(s) below that are most relevant:

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?
I recreated the issue locally by amending the test database setup and running `test_process_vespa_search_response` with no events. I wanted to leave a test covering this but havent been able to as the database setup is not flexible enough for doing this without major refactoring, there is also no direct test yet for the quite large function `_process_vespa_search_response_families` (150 lines of code), instead its tested via `process_vespa_search_response`. Future work might consider adding a db setup factory that can test more specific database scenarios, as well as breaking up and testing individually the components of `_process_vespa_search_response_families`. This is a low risk change as it is only used by vespa, which is not live yet

## Reviewer Checklist

- [X] The PR represents a single feature (small driveby fixes are also ok)
- [X] The PR includes tests that are sufficient for the level of risk
- [X] The code is sufficiently commented, particularly in hard-to-understand areas
- [X] Any required documentation updates have been made
- [X] Any TODOs added are captured in future tickets
- [X] No FIXMEs remain
