### PR TITLE
Bug fix for page numbers 

### DIFF
--- a/app/core/search.py
+++ b/app/core/search.py
@@ -716,7 +716,6 @@ def process_search_response_body_families(
                         doc_match,
                         document_extra_info,
                     )
-
                 response_passage = SearchResponseDocumentPassage(
                     text=doc_match.text,
                     text_block_id=doc_match.text_block_id,


### PR DESCRIPTION
# Description

This is a bug fix for the page numbers that are returned for document passage matches by the backend. 

I believe what is happening is that the validators on the pydantic objects were being called multiple times due to the code flow. 

Thus, I've moved this increment of the page number to the search response object that is the final object that is instantiated and returned. 

Please include:
- a summary of the changes
- links to any related issue/ticket
- any additional relevant motivation and context
- details of any dependency updates that are required for this change

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
