### PR TITLE
Adding in the bugfix for the filter fields. 

### DIFF
--- a/app/api/api_v1/routers/search.py
+++ b/app/api/api_v1/routers/search.py
@@ -53,7 +53,7 @@ search_router = APIRouter()
 def _search_request(
     db: Session, search_body: SearchRequestBody, use_vespa: bool = False
 ) -> SearchResponse:
-    if search_body.keyword_filters is not None and use_vespa == False:
+    if search_body.keyword_filters is not None and use_vespa is False:
         search_body.keyword_filters = process_search_keyword_filters(
             db,
             search_body.keyword_filters,

--- a/app/api/api_v1/routers/search.py
+++ b/app/api/api_v1/routers/search.py
@@ -11,7 +11,7 @@ from io import BytesIO
 from typing import Mapping, Sequence
 
 from cpr_data_access.search_adaptors import VespaSearchAdapter
-from cpr_data_access.exceptions import QueryError 
+from cpr_data_access.exceptions import QueryError
 from fastapi import APIRouter, Depends, HTTPException, status, Request
 from fastapi.responses import StreamingResponse
 from sqlalchemy.orm import Session
@@ -53,7 +53,7 @@ search_router = APIRouter()
 def _search_request(
     db: Session, search_body: SearchRequestBody, use_vespa: bool = False
 ) -> SearchResponse:
-    if search_body.keyword_filters is not None:
+    if search_body.keyword_filters is not None and not use_vespa:
         search_body.keyword_filters = process_search_keyword_filters(
             db,
             search_body.keyword_filters,
@@ -211,5 +211,4 @@ def process_search_keyword_filters(
             # Be consistent in ordering for search
             values = sorted(list(set(values)))
             filter_map[field] = values
-
     return filter_map

--- a/app/api/api_v1/routers/search.py
+++ b/app/api/api_v1/routers/search.py
@@ -53,7 +53,7 @@ search_router = APIRouter()
 def _search_request(
     db: Session, search_body: SearchRequestBody, use_vespa: bool = False
 ) -> SearchResponse:
-    if search_body.keyword_filters is not None and not use_vespa:
+    if search_body.keyword_filters is not None and use_vespa == False:
         search_body.keyword_filters = process_search_keyword_filters(
             db,
             search_body.keyword_filters,

--- a/app/core/search.py
+++ b/app/core/search.py
@@ -16,6 +16,7 @@ from cpr_data_access.models.search import Family as DataAccessResponseFamily
 from cpr_data_access.models.search import Passage as DataAccessResponsePassage
 from cpr_data_access.models.search import SearchParameters as DataAccessSearchParams
 from cpr_data_access.models.search import SearchResponse as DataAccessSearchResponse
+from cpr_data_access.models.search import filter_fields
 from opensearchpy import JSONSerializer as jss
 from opensearchpy import OpenSearch
 from sqlalchemy.orm import Session
@@ -1037,15 +1038,15 @@ def _convert_sort_order(sort_order: SortOrder) -> str:
 
 def _convert_filter_field(filter_field: FilterField) -> str:
     if filter_field == FilterField.CATEGORY:
-        return "category"
+        return filter_fields["category"]
     if filter_field == FilterField.COUNTRY:
-        return "geography"
+        return filter_fields["geography"]
     if filter_field == FilterField.REGION:
-        return "geography"
+        return filter_fields["geography"]
     if filter_field == FilterField.LANGUAGE:
-        return "language"
+        return filter_fields["language"]
     if filter_field == FilterField.SOURCE:
-        return "source"
+        return filter_fields["source"]
 
 
 def _convert_filters(
@@ -1054,7 +1055,6 @@ def _convert_filters(
 ) -> Optional[Mapping[str, Sequence[str]]]:
     if keyword_filters is None:
         return None
-
     new_keyword_filters = {}
     for field, values in keyword_filters.items():
         new_field = _convert_filter_field(field)
@@ -1072,6 +1072,7 @@ def _convert_filters(
         else:
             new_values = values
         new_keyword_filters[new_field] = new_values
+
     return new_keyword_filters
 
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -622,8 +622,8 @@ vespa = ["pyvespa (>=0.37.1,<0.38.0)", "pyyaml (>=6.0.1,<7.0.0)", "sentence-tran
 [package.source]
 type = "git"
 url = "https://github.com/climatepolicyradar/data-access.git"
-reference = "0.4.3"
-resolved_reference = "8ac8b0fc8c733d58be0b9d6c1f4a8cc56ab196cf"
+reference = "a44692e4bfbd511fae424ed204ed48524981cb5f"
+resolved_reference = "a44692e4bfbd511fae424ed204ed48524981cb5f"
 
 [[package]]
 name = "cryptography"
@@ -4249,4 +4249,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "407e79c449765f970e11ebefd4679168ada53e2d7c6651b1cc18d38e1c69def6"
+content-hash = "27e88b7783f41856641a79981c898a03868b208cb83ae8ff92b502273d356fb2"

--- a/poetry.lock
+++ b/poetry.lock
@@ -622,8 +622,8 @@ vespa = ["pyvespa (>=0.37.1,<0.38.0)", "pyyaml (>=6.0.1,<7.0.0)", "sentence-tran
 [package.source]
 type = "git"
 url = "https://github.com/climatepolicyradar/data-access.git"
-reference = "a44692e4bfbd511fae424ed204ed48524981cb5f"
-resolved_reference = "a44692e4bfbd511fae424ed204ed48524981cb5f"
+reference = "34785d6bb3eb1776a175129c8e79deac7b635036"
+resolved_reference = "34785d6bb3eb1776a175129c8e79deac7b635036"
 
 [[package]]
 name = "cryptography"
@@ -4249,4 +4249,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "27e88b7783f41856641a79981c898a03868b208cb83ae8ff92b502273d356fb2"
+content-hash = "6f11f32c56bcaf5aa28f2bcd56f7a5aa2e81444147b10d7c2dec1bbc3e9d692f"

--- a/poetry.lock
+++ b/poetry.lock
@@ -622,8 +622,8 @@ vespa = ["pyvespa (>=0.37.1,<0.38.0)", "pyyaml (>=6.0.1,<7.0.0)", "sentence-tran
 [package.source]
 type = "git"
 url = "https://github.com/climatepolicyradar/data-access.git"
-reference = "34785d6bb3eb1776a175129c8e79deac7b635036"
-resolved_reference = "34785d6bb3eb1776a175129c8e79deac7b635036"
+reference = "0.4.4"
+resolved_reference = "b7e1585ec4dce8d0bf65197824975446f23798b5"
 
 [[package]]
 name = "cryptography"
@@ -4249,4 +4249,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "6f11f32c56bcaf5aa28f2bcd56f7a5aa2e81444147b10d7c2dec1bbc3e9d692f"
+content-hash = "722b96f4c0d30e6b00ba909e236d43d86c2c1d3f06c8caee203e83318b76b3ef"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ alembic = "^1.7.6"
 Authlib = "^0.15.5"
 bcrypt = "^3.2.0"
 boto3 = "^1.26"
-cpr-data-access = {git = "https://github.com/climatepolicyradar/data-access.git", rev = "a44692e4bfbd511fae424ed204ed48524981cb5f", extras = ["vespa"]}
+cpr-data-access = {git = "https://github.com/climatepolicyradar/data-access.git", rev = "34785d6bb3eb1776a175129c8e79deac7b635036", extras = ["vespa"]}
 fastapi = "^0.103.2"
 fastapi-health = "^0.4.0"
 fastapi-pagination = { extras = ["sqlalchemy"], version = "^0.9.1" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ alembic = "^1.7.6"
 Authlib = "^0.15.5"
 bcrypt = "^3.2.0"
 boto3 = "^1.26"
-cpr-data-access = {git = "https://github.com/climatepolicyradar/data-access.git", tag = "0.4.3", extras = ["vespa"]}
+cpr-data-access = {git = "https://github.com/climatepolicyradar/data-access.git", rev = "a44692e4bfbd511fae424ed204ed48524981cb5f", extras = ["vespa"]}
 fastapi = "^0.103.2"
 fastapi-health = "^0.4.0"
 fastapi-pagination = { extras = ["sqlalchemy"], version = "^0.9.1" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ alembic = "^1.7.6"
 Authlib = "^0.15.5"
 bcrypt = "^3.2.0"
 boto3 = "^1.26"
-cpr-data-access = {git = "https://github.com/climatepolicyradar/data-access.git", rev = "34785d6bb3eb1776a175129c8e79deac7b635036", extras = ["vespa"]}
+cpr-data-access = {git = "https://github.com/climatepolicyradar/data-access.git", tag = "0.4.4", extras = ["vespa"]}
 fastapi = "^0.103.2"
 fastapi-health = "^0.4.0"
 fastapi-pagination = { extras = ["sqlalchemy"], version = "^0.9.1" }

--- a/tests/core/test_search.py
+++ b/tests/core/test_search.py
@@ -11,7 +11,7 @@ from cpr_data_access.models.search import (
     Hit as DataAccessHit,
     Passage as DataAccessPassage,
     SearchResponse as DataAccessSearchResponse,
-    filter_fields as data_access_filter_fields,
+    filter_fields,
 )
 from sqlalchemy.orm import Session
 
@@ -213,7 +213,7 @@ def test__convert_filters(test_db, filters):
 
     if converted_filters not in [None, []]:
         assert isinstance(converted_filters, dict)
-        assert set(converted_filters.keys()).issubset(data_access_filter_fields)
+        assert set(converted_filters.keys()).issubset(filter_fields.values())
 
         expected_languages = filters.get(FilterField.LANGUAGE)
         expected_categories = filters.get(FilterField.CATEGORY)
@@ -227,10 +227,10 @@ def test__convert_filters(test_db, filters):
         else:
             expected_countries = None
 
-        assert expected_countries == converted_filters.get("geography")
-        assert expected_languages == converted_filters.get("language")
-        assert expected_sources == converted_filters.get("source")
-        assert expected_categories == converted_filters.get("category")
+        assert expected_countries == converted_filters.get(filter_fields["geography"])
+        assert expected_languages == converted_filters.get(filter_fields["language"])
+        assert expected_sources == converted_filters.get(filter_fields["source"])
+        assert expected_categories == converted_filters.get(filter_fields["category"])
 
 
 @dataclass

--- a/tests/core/test_search.py
+++ b/tests/core/test_search.py
@@ -197,6 +197,7 @@ def _get_expected_countries(db: Session, slugs: Sequence[str]) -> Sequence[str]:
         {FilterField.SOURCE: ["CCLW"]},
         {FilterField.REGION: ["europe-central-asia"]},
         {FilterField.COUNTRY: ["france", "germany"]},
+        {FilterField.COUNTRY: ["cambodia"]},
         {FilterField.REGION: ["south_america"], FilterField.COUNTRY: ["france"]},
     ],
 )
@@ -204,13 +205,14 @@ def test__convert_filters(test_db, filters):
     db_setup(test_db)
     converted_filters = _convert_filters(test_db, filters)
 
-    if filters is None:
-        assert converted_filters is None
+    if filters in [None, []]:
+        assert converted_filters in [None, []]
 
-    if filters is not None:
-        assert converted_filters is not None
+    if filters not in [None, []]:
+        assert converted_filters not in [None, []]
 
-    if converted_filters is not None:
+    if converted_filters not in [None, []]:
+        assert isinstance(converted_filters, dict)
         assert set(converted_filters.keys()).issubset(data_access_filter_fields)
 
         expected_languages = filters.get(FilterField.LANGUAGE)

--- a/tests/routes/test_admin_unfccc.py
+++ b/tests/routes/test_admin_unfccc.py
@@ -320,7 +320,9 @@ def test_start_unfccc_ingest(
     content = json.load(documents_call.kwargs["bytes_content"])
     content = json.dumps(content, sort_keys=True, indent=2).split("\n")
 
-    expected = json.dumps(json.loads(EXPECTED_DOCUMENTS), sort_keys=True, indent=2).split("\n")
+    expected = json.dumps(
+        json.loads(EXPECTED_DOCUMENTS), sort_keys=True, indent=2
+    ).split("\n")
 
     for line in range(len(expected)):
         assert content[line] == expected[line]


### PR DESCRIPTION
# Description

This is a bug relating to QueryErrors being thrown when a country or other filter is used against the api. 

This fix incorporates a new version of the dal that has been updated to expect a different set of filter fields. 

These fields effectively are what is actually used in vespa. 

This means we have to update the filter fields prior to validation of the SearchParameter object. 

## Type of change

Please select the option(s) below that are most relevant:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

- [x] Fix failing tests in dal and backend 
- [ ] Deploy to staging and test against the vespa instance (currently no vespa search tests in the backend)  

## Reviewer Checklist

- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
