### PR TITLE
Allow setting `max_hits` and `limit` for vespa

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -63,9 +63,9 @@ OPENSEARCH_INDEX_TEXT_BLOCK_KEY: str = os.getenv(
 OPENSEARCH_JIT_MAX_DOC_COUNT: int = int(os.getenv("OPENSEARCH_JIT_MAX_DOC_COUNT", "20"))
 
 # Vespa Config
-VESPA_SEARCH_LIMIT: int = int(os.getenv("VESPA_SEARCH_LIMIT", "150"))
+VESPA_SEARCH_LIMIT: int = int(os.getenv("VESPA_SEARCH_LIMIT", "500"))
 VESPA_SEARCH_MATCHES_PER_DOC: int = int(
-    os.getenv("VESPA_SEARCH_MAX_MATCHES_PER_DOC", "20")
+    os.getenv("VESPA_SEARCH_MAX_MATCHES_PER_DOC", "100")
 )
 VESPA_SECRETS_LOCATION: str = os.getenv("VESPA_SECRETS_LOCATION", "/secrets")
 VESPA_URL: str = os.getenv("VESPA_URL", "")

--- a/app/core/search.py
+++ b/app/core/search.py
@@ -1251,11 +1251,16 @@ def process_vespa_search_response(
 
 def create_vespa_search_params(db: Session, search_body: SearchRequestBody):
     """Create Vespa search parameters from a F/E search request body"""
+    search_body.limit = min(search_body.limit, VESPA_SEARCH_LIMIT)
+    search_body.max_passages_per_doc = min(
+        search_body.max_passages_per_doc, VESPA_SEARCH_MATCHES_PER_DOC
+    )
+
     return DataAccessSearchParams(
         query_string=search_body.query_string,
         exact_match=search_body.exact_match,
-        limit=VESPA_SEARCH_LIMIT,
-        max_hits_per_family=VESPA_SEARCH_MATCHES_PER_DOC,
+        limit=search_body.limit,
+        max_hits_per_family=search_body.max_passages_per_doc,
         keyword_filters=_convert_filters(db, search_body.keyword_filters),
         year_range=search_body.year_range,
         sort_by=_convert_sort_field(search_body.sort_field),


### PR DESCRIPTION
These values where previously hardcoded, so despite this being supported by the data access library interface with vespa, and the backend api accepting parameters for these, they would nevertheless always get set to the same values.

This passes those api parameters through to the data access library, and uses the previous set values as actual upper limits —— which we still need because of limiting excessive compute and avoiding timeouts.

See notion page for more context: https://www.notion.so/climatepolicyradar/Brief-10-matches-per-doc-100-documents-per-search-8f440121f9f44907b6ab99060f757412

# Description

Please include:
- a summary of the changes
- links to any related issue/ticket
- any additional relevant motivation and context
- details of any dependency updates that are required for this change

## Type of change

Please select the option(s) below that are most relevant:

- [X] Bug fix
- [X] New feature
- [ ] Breaking change

## How Has This Been Tested?

Updated the relevant test to include coverage for these values

## Reviewer Checklist

- [X] The PR represents a single feature (small driveby fixes are also ok)
- [X] The PR includes tests that are sufficient for the level of risk
- [X] The code is sufficiently commented, particularly in hard-to-understand areas
- [X] Any required documentation updates have been made
- [X] Any TODOs added are captured in future tickets
- [X] No FIXMEs remain
