### PR TITLE
Reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ RUN apt update && \
 # Install pip and poetry
 RUN pip install --no-cache --upgrade pip
 RUN pip install --no-cache "poetry==1.3.2"
-RUN pip install --no-cache "poetry-plugin-export==1.6.0"
 
 # Create layer for dependencies
 # TODO: refine this as part of CI & test updates
@@ -18,9 +17,13 @@ COPY poetry.lock pyproject.toml ./
 # Create a requirements file so we can install with minimal caching
 # See: https://github.com/python-poetry/poetry-plugin-export
 RUN poetry export --with dev \
-    --without-hashes \
-    --format=requirements.txt \
-    --output=requirements.txt
+    | grep -v '\--hash' \
+    | grep -v '^torch' \
+    | grep -v '^triton' \
+    | grep -v '^nvidia' \
+    | sed -e 's/ \\$//' \
+    | sed -e 's/^[[:alpha:]]\+\[\([[:alpha:]]\+\[[[:alpha:]]\+\]\)\]/\1/' \
+    > requirements.txt
 
 # Install torch-cpu with pip
 RUN pip3 install --no-cache "torch==2.0.0+cpu" "torchvision==0.15.1+cpu" -f https://download.pytorch.org/whl/torch_stable.html


### PR DESCRIPTION
The previous change to the poetry export command inadvertently bloated the image, because it allows a gpu version of torch, and other bloating dependencies, to sneak back in

# Description

Please include:
- a summary of the changes
- links to any related issue/ticket
- any additional relevant motivation and context
- details of any dependency updates that are required for this change

## Type of change

Please select the option(s) below that are most relevant:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [x] The PR represents a single feature (small driveby fixes are also ok)
- [x] The PR includes tests that are sufficient for the level of risk
- [x] The code is sufficiently commented, particularly in hard-to-understand areas
- [x] Any required documentation updates have been made
- [x] Any TODOs added are captured in future tickets
- [x] No FIXMEs remain
