### PR TITLE
Add tests to covering disparity between databases

### DIFF
--- a/tests/routes/setup_search_tests.py
+++ b/tests/routes/setup_search_tests.py
@@ -68,18 +68,25 @@ def _fixture_docs() -> Iterable[tuple[VespaFixture, VespaFixture]]:
         yield doc, family
 
 
-def _populate_db_families(db: Session) -> None:
+def _populate_db_families(db: Session, max_docs: int = 4) -> None:
+    """
+    Sets up the database using fixtures
+
+    Lower `max_docs` to limit the number of fixtures added to the db.
+    """
     run_data_migrations(db)
     _create_organisation(db)
 
     seen_family_ids = []
-    for doc, family in _fixture_docs():
+    for count, (doc, family) in enumerate(_fixture_docs(), start=1):
         if doc["fields"]["family_document_ref"] not in seen_family_ids:
             _create_family(db, family)
             _create_family_event(db, family)
             _create_family_metadata(db, family)
             seen_family_ids.append(doc["fields"]["family_document_ref"])
         _create_document(db, doc, family)
+        if count == max_docs:
+            return
 
 
 def _create_organisation(db: Session):

--- a/tests/routes/test_vespasearch.py
+++ b/tests/routes/test_vespasearch.py
@@ -164,30 +164,6 @@ def test_no_doc_if_in_postgres_but_not_vespa(test_vespa, client, test_db, monkey
 
 @pytest.mark.search
 @pytest.mark.parametrize("label,query", [("search", "the"), ("browse", "")])
-def test_no_doc_if_in_vespa_but_not_postgres(
-    label, query, test_vespa, monkeypatch, client, test_db
-):
-    # Only add the first document
-    COUNT_OF_POSTGRES_DOCS = 1
-    EXPECTED_FIRST_NAME = "National Environment Policy of Guinea"
-    monkeypatch.setattr(search, "_VESPA_CONNECTION", test_vespa)
-    _populate_db_families(test_db, max_docs=COUNT_OF_POSTGRES_DOCS)
-
-    body = _make_search_request(
-        client,
-        params={
-            "query_string": query,
-        },
-    )
-
-    # When documents are in vespa but not in postgres, we only get the overlap
-    assert len(body["families"]) == COUNT_OF_POSTGRES_DOCS, f"{label} failed"
-    assert body["hits"] == COUNT_OF_POSTGRES_DOCS
-    assert body["families"][0]["family_name"] == EXPECTED_FIRST_NAME, f"{label} failed"
-
-
-@pytest.mark.search
-@pytest.mark.parametrize("label,query", [("search", "the"), ("browse", "")])
 def test_benchmark_families_search(
     label, query, test_vespa, monkeypatch, client, test_db
 ):


### PR DESCRIPTION
# Description

For an upcoming pipeline infrastructure change, we needed to know how the backend might behave if there is data in just one of our two databases. This adds two exploratory tests, one covering when there is a document in postgres but not vespa, and the other checking the reverse — in vespa but not postgres. 

Both scenarios still return the correct documents, and a 200 response code. However, it turns out there is some impact on the backend for each:

### When Postgres has a document but Vespa does not
- The document will still appear in browse (which seems fine)

### When Vespa has a document but Postgres does not
- The hits will still be returned based on vespa content as vespa assumes postgres will find the data. There is potential for this to impact pagination as the frontend uses this number to determine how many pages to display.
- The backend logs errors that look like this: `ERROR    app.core.search:search.py:1116 Could not locate family with import id 'CCLW.family.8633.0'`

The option 'When Postgres has a document but Vespa does not', seems acceptable, and conveniently is how the pipeline would currently be setup.

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
