### PR TITLE
Pdct 788/redirect to cdn instead of streaming response

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,4 +4,4 @@ include ./makefile-docker.defs
 
 git_hooks:
 	# Install git pre-commit hooks
-	cd backend/; poetry run pre-commit install --install-hooks
+	poetry run pre-commit install --install-hooks

--- a/app/core/aws.py
+++ b/app/core/aws.py
@@ -45,14 +45,13 @@ class S3Document:
 class S3Client:
     """Helper class to connect to S3 and perform actions on buckets and documents."""
 
-    def __init__(self, dev_mode: bool):  # noqa: D107
-        if dev_mode is True:
-            logger.info("***************** IN DEVELOPMENT MODE *****************")
+    def __init__(self, dev_mode: str):  # noqa: D107
+        if dev_mode == "False":
+            logger.info("***************** IN DEPLOYMENT MODE *****************")
             self.client = boto3.client(
                 "s3",
                 aws_access_key_id=os.getenv("AWS_ACCESS_KEY_ID"),
                 aws_secret_access_key=os.getenv("AWS_SECRET_ACCESS_KEY"),
-                aws_session_token=os.getenv("AWS_SESSION_TOKEN"),
                 config=botocore.client.Config(
                     signature_version="s3v4",
                     region_name=AWS_REGION,
@@ -60,11 +59,12 @@ class S3Client:
                 ),
             )
         else:
-            logger.info("***************** IN DEPLOYMENT MODE *****************")
+            logger.info("***************** IN DEVELOPMENT MODE *****************")
             self.client = boto3.client(
                 "s3",
                 aws_access_key_id=os.getenv("AWS_ACCESS_KEY_ID"),
                 aws_secret_access_key=os.getenv("AWS_SECRET_ACCESS_KEY"),
+                aws_session_token=os.getenv("AWS_SESSION_TOKEN"),
                 config=botocore.client.Config(
                     signature_version="s3v4",
                     region_name=AWS_REGION,
@@ -304,5 +304,5 @@ class S3Client:
 
 def get_s3_client():
     """Get s3 client for API."""
-    dev_mode = t.cast(bool, os.getenv("DEVELOPMENT_MODE", "False"))
+    dev_mode = os.getenv("DEVELOPMENT_MODE", "False")
     return S3Client(dev_mode)

--- a/app/core/aws.py
+++ b/app/core/aws.py
@@ -9,7 +9,7 @@ import botocore.client
 from botocore.exceptions import ClientError, UnauthorizedSSOTokenError
 from botocore.response import StreamingBody
 
-from app.core.config import AWS_REGION
+from app.core.config import AWS_REGION, DEVELOPMENT_MODE
 
 logger = logging.getLogger(__name__)
 
@@ -45,8 +45,8 @@ class S3Document:
 class S3Client:
     """Helper class to connect to S3 and perform actions on buckets and documents."""
 
-    def __init__(self, dev_mode: str):  # noqa: D107
-        if dev_mode == "False":
+    def __init__(self, dev_mode: bool):  # noqa: D107
+        if dev_mode is False:
             logger.info("***************** IN DEPLOYMENT MODE *****************")
             self.client = boto3.client(
                 "s3",
@@ -304,5 +304,4 @@ class S3Client:
 
 def get_s3_client():
     """Get s3 client for API."""
-    dev_mode = os.getenv("DEVELOPMENT_MODE", "False")
-    return S3Client(dev_mode)
+    return S3Client(DEVELOPMENT_MODE)

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -76,4 +76,6 @@ INDEX_ENCODER_CACHE_FOLDER: str = os.getenv("INDEX_ENCODER_CACHE_FOLDER", "/mode
 # Whole database dump
 INGEST_CYCLE_START = os.getenv("INGEST_CYCLE_START")
 DOC_CACHE_BUCKET = os.getenv("DOCUMENT_CACHE_BUCKET")
+DEVELOPMENT_MODE = os.getenv("DEVELOPMENT_MODE", False)
 AWS_REGION = os.getenv("AWS_REGION", "eu-west-1")
+CDN_DOMAIN = os.getenv("CDN_DOMAIN")

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -76,6 +76,6 @@ INDEX_ENCODER_CACHE_FOLDER: str = os.getenv("INDEX_ENCODER_CACHE_FOLDER", "/mode
 # Whole database dump
 INGEST_CYCLE_START = os.getenv("INGEST_CYCLE_START")
 DOC_CACHE_BUCKET = os.getenv("DOCUMENT_CACHE_BUCKET")
-DEVELOPMENT_MODE = os.getenv("DEVELOPMENT_MODE", False)
+DEVELOPMENT_MODE: bool = os.getenv("DEVELOPMENT_MODE", "False").lower() == "true"
 AWS_REGION = os.getenv("AWS_REGION", "eu-west-1")
 CDN_DOMAIN = os.getenv("CDN_DOMAIN")

--- a/app/core/download.py
+++ b/app/core/download.py
@@ -268,7 +268,7 @@ def replace_slug_with_qualified_url(
 
 def convert_dump_to_csv(df: pd.DataFrame):
     csv_buffer = BytesIO()
-    df.to_csv(csv_buffer, sep=",", index=False)
+    df.to_csv(csv_buffer, sep=",", index=False, encoding="utf-8")
     return csv_buffer
 
 

--- a/app/core/download.py
+++ b/app/core/download.py
@@ -11,243 +11,239 @@ from app.db.session import get_db
 _LOGGER = getLogger(__name__)
 
 
-def create_query() -> str:
+def create_query(ingest_cycle_start: str) -> str:
     """Browse RDS"""
 
-    query = """
-WITH
-deduplicated_family_slugs as (
-    select
-      distinct ON (slug.family_import_id) slug.family_import_id, slug.created, slug.name
-    from (
-      SELECT
-        slug.family_import_id as "family_import_id",
-        count(*) as count
-        from slug
-        where slug.family_import_id is not null
-        group by slug.family_import_id
-        having count(*) > 1
-    ) duplicates
-    left join slug
-      on duplicates.family_import_id = slug.family_import_id
-    order by slug.family_import_id desc, slug.created desc, slug.ctid desc
-),
-unique_family_slugs as (
-    select
-      distinct ON (slug.family_import_id) slug.family_import_id, slug.created, slug.name
-    from (
-      SELECT
-        slug.family_import_id as "family_import_id",
-        count(*) as count
-        from slug
-        where slug.family_import_id is not null
-        group by slug.family_import_id
-        having count(*) = 1
-    ) non_duplicates
-    left join slug
-      on non_duplicates.family_import_id = slug.family_import_id
-    order by slug.family_import_id desc, slug.created desc, slug.ctid desc
-), most_recent_family_slugs as (
-    select
-        deduplicated_family_slugs.family_import_id as "family_import_id",
-        deduplicated_family_slugs.created as "created",
-        deduplicated_family_slugs.name as "name"
-    from deduplicated_family_slugs
-    UNION ALL
-    select
-        unique_family_slugs.family_import_id as "family_import_id",
-        unique_family_slugs.created as "created",
-        unique_family_slugs.name as "name"
-    from unique_family_slugs
-    order by family_import_id desc, created desc
-), deduplicated_doc_slugs as (
-    select
-      distinct ON (slug.family_document_import_id)
-      slug.family_document_import_id,
-      slug.created,
-      slug.name
-    from (
-      SELECT
-        slug.family_document_import_id as "family_document_import_id",
-        count(*) as count
-        from slug
-        where slug.family_document_import_id is not null
-        group by slug.family_document_import_id
-        having count(*) > 1
-    ) duplicates
-    left join slug
-      on duplicates.family_document_import_id = slug.family_document_import_id
-    order by slug.family_document_import_id desc, slug.created desc, slug.ctid desc
-),
-unique_doc_slugs as (
-    select
-      distinct ON (slug.family_document_import_id)
-      slug.family_document_import_id,
-      slug.created,
-      slug.name
-    from (
-      SELECT
-        slug.family_document_import_id as "family_document_import_id",
-        count(*) as count
-        from slug
-        where slug.family_document_import_id is not null
-        group by slug.family_document_import_id
-        having count(*) = 1
-    ) non_duplicates
-    left join slug
-      on non_duplicates.family_document_import_id = slug.family_document_import_id
-    order by slug.family_document_import_id desc, slug.created desc, slug.ctid desc
-), most_recent_doc_slugs as (
-    select
-        deduplicated_doc_slugs.family_document_import_id as "family_document_import_id",
-        deduplicated_doc_slugs.created,
-        deduplicated_doc_slugs.name
-    from deduplicated_doc_slugs
-    UNION ALL
-    select
-        unique_doc_slugs.family_document_import_id as "family_document_import_id",
-        unique_doc_slugs.created,
-        unique_doc_slugs.name
-    from unique_doc_slugs
-    order by family_document_import_id desc, created desc
-), event_dates as (
-select
-    family_event.family_import_id as family_import_id,
-    min(case
-            when family_event.event_type_name='Passed/Approved' then
-                family_event.date::date
-            else family_event.date::date
-    end) published_date,
-    max(family_event.date::date) last_changed
-from family_event
-group by family_import_id
-)
-
-SELECT
-    ds.name as "Document ID",
-    p.title as "Document Title",
-    fs.name as "Family ID",
-    f.title as "Family Title",
-    f.description as "Family Summary",
-    n1.collection_titles as "Collection Title(s)",
-    n1.collection_descriptions as "Collection Description(s)",
-    INITCAP(d.document_role::TEXT) as "Document Role",
-    d.variant_name as "Document Variant",
-    p.source_url as "Document Content URL",
-    d.document_type as "Document Type",
-    array_to_string(ARRAY(
-        SELECT jsonb_array_elements_text(fm.value->'framework')), ';'
-    ) as "Framework",
-    CASE
-       WHEN f.family_category = 'UNFCCC' THEN 'UNFCCC'
-       ELSE INITCAP(f.family_category::TEXT)
-       END "Category",
-    n2.language as "Language",
-    o.name as "Source",
-    g.value as "Geography ISO",
-    g.display_value as "Geography",
-    array_to_string(ARRAY(
-        SELECT jsonb_array_elements_text(fm.value->'topic')), ';'
-    ) as "Topic/Response",
-    array_to_string(ARRAY(
-        SELECT jsonb_array_elements_text(fm.value->'hazard')), ';'
-    ) as "Hazard",
-    array_to_string(ARRAY(
-        SELECT jsonb_array_elements_text(fm.value->'sector')), ';'
-    ) as "Sector",
-    array_to_string(ARRAY(
-        SELECT jsonb_array_elements_text(fm.value->'keyword')), ';'
-    ) as "Keyword",
-    array_to_string(ARRAY(
-        SELECT jsonb_array_elements_text(fm.value->'instrument')), ';'
-    ) as "Instrument",
-    array_to_string(ARRAY(
-        SELECT jsonb_array_elements_text(fm.value->'author')), ';'
-    ) as "Author",
-    array_to_string(ARRAY(
-        SELECT jsonb_array_elements_text(fm.value->'author_type')), ';'
-    ) as "Author Type",
-    fp.published_date as "First event in timeline",
-    fp.last_changed as "Last event in timeline",
-    n3.event_type_names as "Full timeline of events (types)",
-    n3.event_dates as "Full timeline of events (dates)",
-    d.created::date as "Date Added to System",
-    f.last_modified::date as "Last Modified on System",
-    d.import_id as "Internal Document ID",
-    f.import_id as "Internal Family ID",
-    n1.collection_import_ids as "Internal Collection ID(s)"
-FROM physical_document p
-JOIN family_document d
-    ON p.id = d.physical_document_id
-JOIN family f
-    ON d.family_import_id = f.import_id
-inner join geography g
-    on g.id = f.geography_id
-join family_organisation fo
-    on fo.family_import_id = f.import_id
-join organisation o
-    on o.id = fo.organisation_id
-join family_metadata fm
-    on fm.family_import_id = f.import_id
-
-
-FULL JOIN (
-    SELECT
-        collection_family.family_import_id as "family_import_id",
-        string_agg(collection.import_id, ';') AS collection_import_ids,
-        string_agg(collection.title, ';') AS collection_titles,
-        string_agg(collection.description, ';') AS collection_descriptions
-    FROM
-        collection
-    INNER JOIN collection_family
-    ON collection_family.collection_import_id = collection.import_id
-    GROUP  BY collection_family.family_import_id
-) n1 ON n1.family_import_id=f.import_id
-
-
-left JOIN (
-    SELECT
-        p.id as "id",
-        string_agg(l.name, ';' ORDER BY l.name) AS "language"
-    FROM   physical_document p
-    left join physical_document_language pdl
-        on pdl.document_id = p.id
-    left join language l
-        on l.id = pdl.language_id
-    GROUP  BY p.id
-) n2 ON n2.id=d.physical_document_id
-
-
-FULL JOIN (
-    SELECT
-        family_event.family_import_id,
-        string_agg(family_event.import_id, ';') AS event_import_ids,
-        string_agg(family_event.title, ';') AS event_titles,
-        string_agg(family_event.event_type_name, ';') AS event_type_names,
-        string_agg(family_event.date::date::text, ';') AS event_dates
-    FROM
-        family_event
-    INNER JOIN  family ON family.import_id = family_event.family_import_id
-    GROUP  BY family_event.family_import_id
-) n3 ON n3.family_import_id=f.import_id
-
-
-LEFT JOIN most_recent_doc_slugs ds
-    on ds.family_document_import_id = d.import_id
-LEFT JOIN most_recent_family_slugs fs
-    on fs.family_import_id = f.import_id
-
-LEFT JOIN event_dates fp
-    on fp.family_import_id = f.import_id
-
-ORDER BY d.created desc, n1.family_import_id
-"""
+    query = (
+        "WITH "
+        "deduplicated_family_slugs as ("
+        "select "
+        "distinct ON (slug.family_import_id) "
+        "slug.family_import_id, slug.created, slug.name "
+        "from ("
+        "SELECT "
+        'slug.family_import_id as "family_import_id", '
+        "count(*) as count "
+        "from slug "
+        "where slug.family_import_id is not null "
+        "group by slug.family_import_id "
+        "having count(*) > 1"
+        ") duplicates "
+        "left join slug "
+        "on duplicates.family_import_id = slug.family_import_id "
+        "order by slug.family_import_id desc, slug.created desc, slug.ctid desc "
+        "), "
+        "unique_family_slugs as ("
+        "select "
+        "distinct ON (slug.family_import_id) "
+        "slug.family_import_id, slug.created, slug.name "
+        "from ("
+        "SELECT "
+        'slug.family_import_id as "family_import_id", '
+        "count(*) as count "
+        "from slug "
+        "where slug.family_import_id is not null "
+        "group by slug.family_import_id "
+        "having count(*) = 1"
+        ") non_duplicates "
+        "left join slug "
+        "on non_duplicates.family_import_id = slug.family_import_id "
+        "order by slug.family_import_id desc, slug.created desc, slug.ctid desc "
+        "), most_recent_family_slugs as ("
+        "select "
+        'deduplicated_family_slugs.family_import_id as "family_import_id", '
+        'deduplicated_family_slugs.created as "created", '
+        'deduplicated_family_slugs.name as "name" '
+        "from deduplicated_family_slugs "
+        "UNION ALL "
+        "select "
+        'unique_family_slugs.family_import_id as "family_import_id", '
+        'unique_family_slugs.created as "created", '
+        'unique_family_slugs.name as "name" '
+        "from unique_family_slugs "
+        "order by family_import_id desc, created desc "
+        "), deduplicated_doc_slugs as ("
+        "select "
+        "distinct ON (slug.family_document_import_id) "
+        "slug.family_document_import_id, "
+        "slug.created, "
+        "slug.name "
+        "from ("
+        "SELECT "
+        'slug.family_document_import_id as "family_document_import_id", '
+        "count(*) as count "
+        "from slug "
+        "where slug.family_document_import_id is not null "
+        "group by slug.family_document_import_id "
+        "having count(*) >  1"
+        ") duplicates "
+        "left join slug "
+        "on duplicates.family_document_import_id = slug.family_document_import_id "
+        "order by "
+        "slug.family_document_import_id desc, slug.created desc, slug.ctid desc"
+        "), "
+        "unique_doc_slugs as ("
+        "select "
+        "distinct ON (slug.family_document_import_id) "
+        "slug.family_document_import_id, "
+        "slug.created, "
+        "slug.name "
+        "from ("
+        "SELECT "
+        'slug.family_document_import_id as "family_document_import_id", '
+        "count(*) as count "
+        "from slug "
+        "where slug.family_document_import_id is not null "
+        "group by slug.family_document_import_id "
+        "having count(*) = 1"
+        ") non_duplicates "
+        "left join slug "
+        "on non_duplicates.family_document_import_id = slug.family_document_import_id "
+        "order by  "
+        "slug.family_document_import_id desc, slug.created desc, slug.ctid desc"
+        "), most_recent_doc_slugs as ("
+        "select "
+        "deduplicated_doc_slugs.family_document_import_id "
+        'as "family_document_import_id", '
+        "deduplicated_doc_slugs.created, "
+        "deduplicated_doc_slugs.name "
+        "from deduplicated_doc_slugs "
+        "UNION ALL "
+        "select "
+        'unique_doc_slugs.family_document_import_id as "family_document_import_id", '
+        "unique_doc_slugs.created, "
+        "unique_doc_slugs.name "
+        "from unique_doc_slugs "
+        "order by family_document_import_id desc, created desc"
+        "), event_dates as ("
+        "select "
+        "family_event.family_import_id as family_import_id, "
+        "min(case "
+        "when family_event.event_type_name='Passed/Approved' then "
+        "family_event.date::date "
+        "else family_event.date::date "
+        "end) published_date, "
+        "max(family_event.date::date) last_changed "
+        "from family_event "
+        "group by family_import_id "
+        ") "
+        "SELECT "
+        'ds.name as "Document ID", '
+        'p.title as "Document Title", '
+        'fs.name as "Family ID", '
+        'f.title as "Family Title", '
+        'f.description as "Family Summary", '
+        'n1.collection_titles as "Collection Title(s)", '
+        'n1.collection_descriptions as "Collection Description(s)", '
+        'INITCAP(d.document_role::TEXT) as "Document Role", '
+        'd.variant_name as "Document Variant", '
+        'p.source_url as "Document Content URL", '
+        'd.document_type as "Document Type", '
+        "CASE "
+        "WHEN f.family_category = 'UNFCCC' THEN 'UNFCCC' "
+        "ELSE INITCAP(f.family_category::TEXT) "
+        'END "Category", '
+        "array_to_string(ARRAY("
+        "SELECT jsonb_array_elements_text(fm.value->'framework')), ';') "
+        'as "Framework", '
+        'n2.language as "Language", '
+        'o.name as "Source", '
+        'g.value as "Geography ISO", '
+        'g.display_value as "Geography", '
+        "array_to_string(ARRAY("
+        "SELECT jsonb_array_elements_text(fm.value->'topic')), ';') "
+        'as "Topic/Response", '
+        "array_to_string(ARRAY("
+        "SELECT jsonb_array_elements_text(fm.value->'hazard')), ';') "
+        'as "Hazard", '
+        "array_to_string(ARRAY("
+        "SELECT jsonb_array_elements_text(fm.value->'sector')), ';') "
+        'as "Sector", '
+        "array_to_string(ARRAY("
+        "SELECT jsonb_array_elements_text(fm.value->'keyword')), ';') "
+        'as "Keyword", '
+        "array_to_string(ARRAY("
+        "SELECT jsonb_array_elements_text(fm.value->'instrument')), ';') "
+        'as "Instrument", '
+        "array_to_string(ARRAY("
+        "SELECT jsonb_array_elements_text(fm.value->'author')), ';') "
+        'as "Author", '
+        "array_to_string(ARRAY("
+        "SELECT jsonb_array_elements_text(fm.value->'author_type')), ';') "
+        'as "Author Type", '
+        'fp.published_date as "First event in timeline", '
+        'fp.last_changed as "Last event in timeline", '
+        'n3.event_type_names as "Full timeline of events (types)", '
+        'n3.event_dates as "Full timeline of events (dates)", '
+        'd.created::date as "Date Added to System", '
+        'f.last_modified::date as "Last Modified on System", '
+        'd.import_id as "Internal Document ID", '
+        'f.import_id as "Internal Family ID", '
+        'n1.collection_import_ids as "Internal Collection ID(s)" '
+        "FROM physical_document p "
+        "JOIN family_document d "
+        "    ON p.id = d.physical_document_id "
+        "JOIN family f "
+        "    ON d.family_import_id = f.import_id "
+        "inner join geography g "
+        "    on g.id = f.geography_id "
+        "join family_organisation fo "
+        "    on fo.family_import_id = f.import_id "
+        "join organisation o "
+        "    on o.id = fo.organisation_id "
+        "join family_metadata fm "
+        "    on fm.family_import_id = f.import_id "
+        "FULL JOIN ("
+        "    SELECT "
+        '        collection_family.family_import_id as "family_import_id", '
+        "string_agg(collection.import_id, ';') AS collection_import_ids, "
+        "string_agg(collection.title, ';') AS collection_titles, "
+        "string_agg(collection.description, ';') AS collection_descriptions "
+        "FROM "
+        "    collection "
+        "INNER JOIN collection_family "
+        "ON collection_family.collection_import_id = collection.import_id "
+        "GROUP BY collection_family.family_import_id "
+        ") n1 ON n1.family_import_id=f.import_id "
+        "left JOIN ("
+        "    SELECT "
+        '        p.id as "id", '
+        "string_agg(l.name, ';' ORDER BY l.name) AS language "
+        "FROM physical_document p "
+        "    left join physical_document_language pdl "
+        "        on pdl.document_id = p.id "
+        "    left join language l "
+        "        on l.id = pdl.language_id "
+        "    GROUP  BY p.id "
+        ") n2 ON n2.id=d.physical_document_id "
+        "FULL JOIN ("
+        "    SELECT "
+        "        family_event.family_import_id, "
+        "string_agg(family_event.import_id, ';') AS event_import_ids, "
+        "string_agg(family_event.title, ';') AS event_titles, "
+        "string_agg(family_event.event_type_name, ';') AS event_type_names, "
+        "string_agg(family_event.date::date::text, ';') AS event_dates "
+        "FROM family_event "
+        "    INNER JOIN  family ON family.import_id = family_event.family_import_id "
+        "    GROUP BY family_event.family_import_id "
+        ") n3 ON n3.family_import_id=f.import_id "
+        "LEFT JOIN most_recent_doc_slugs ds "
+        "on ds.family_document_import_id = d.import_id "
+        "LEFT JOIN most_recent_family_slugs fs on fs.family_import_id = f.import_id "
+        "LEFT JOIN event_dates fp on fp.family_import_id = f.import_id "
+        "ORDER BY d.created desc, n1.family_import_id"
+    )
+    # "WHERE d.created < '{}' "
+    # .format(ingest_cycle_start)
+    print(query)
     return query
 
 
-def get_whole_database_dump(db=Depends(get_db)):
-    df = pd.read_sql_query(create_query(), db.bind)
-    return df
+def get_whole_database_dump(ingest_cycle_start: str, db=Depends(get_db)):
+    query = create_query(ingest_cycle_start)
+    with db.connection() as conn:
+        df = pd.read_sql_query(query, conn)
+        return df
 
 
 def replace_slug_with_qualified_url(
@@ -276,6 +272,9 @@ def convert_dump_to_csv(df: pd.DataFrame):
     return csv_buffer
 
 
-def generate_data_dump_as_csv(db=Depends(get_db)):
-    df = get_whole_database_dump(db)
-    return convert_dump_to_csv(df)
+def generate_data_dump_as_csv(ingest_cycle_start: str, db=Depends(get_db)):
+    print(ingest_cycle_start)
+    df = get_whole_database_dump(ingest_cycle_start, db)
+    print(df)
+    csv = convert_dump_to_csv(df)
+    return csv

--- a/app/core/download.py
+++ b/app/core/download.py
@@ -231,11 +231,10 @@ def create_query(ingest_cycle_start: str) -> str:
         "on ds.family_document_import_id = d.import_id "
         "LEFT JOIN most_recent_family_slugs fs on fs.family_import_id = f.import_id "
         "LEFT JOIN event_dates fp on fp.family_import_id = f.import_id "
-        "ORDER BY d.created desc, n1.family_import_id"
-    )
-    # "WHERE d.created < '{}' "
-    # .format(ingest_cycle_start)
-    print(query)
+        "WHERE d.last_modified < '{}' "
+        "ORDER BY "
+        "d.last_modified desc, d.created desc, d.ctid desc, n1.family_import_id"
+    ).format(ingest_cycle_start)
     return query
 
 
@@ -273,8 +272,6 @@ def convert_dump_to_csv(df: pd.DataFrame):
 
 
 def generate_data_dump_as_csv(ingest_cycle_start: str, db=Depends(get_db)):
-    print(ingest_cycle_start)
     df = get_whole_database_dump(ingest_cycle_start, db)
-    print(df)
     csv = convert_dump_to_csv(df)
     return csv

--- a/app/core/health.py
+++ b/app/core/health.py
@@ -5,7 +5,7 @@ from fastapi import Depends
 from requests.compat import urljoin
 from sqlalchemy.orm import Session
 
-from app.core.config import VESPA_URL
+from app.core.config import DEVELOPMENT_MODE, VESPA_URL
 from app.db.session import get_db
 
 _LOGGER = logging.getLogger(__file__)
@@ -24,7 +24,8 @@ def is_vespa_online():
     try:
         response = requests.get(VESPA_HEALTH_ENDPOINT)
     except Exception as e:
-        _LOGGER.error(e)
+        if DEVELOPMENT_MODE == "False":
+            _LOGGER.error(e)
         return False
     return response.ok
 

--- a/app/core/health.py
+++ b/app/core/health.py
@@ -24,7 +24,7 @@ def is_vespa_online():
     try:
         response = requests.get(VESPA_HEALTH_ENDPOINT)
     except Exception as e:
-        if DEVELOPMENT_MODE == "False":
+        if DEVELOPMENT_MODE is False:
             _LOGGER.error(e)
         return False
     return response.ok

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,3 +101,17 @@ line-length = 88
 [tool.ruff.per-file-ignores]
 "__init__.py" = ["F401"]
 "tests/*" = ["E501"]
+
+[tool.pyright]
+include = ["alembic", "app", "scripts", "tests"]
+exclude = [
+    "**/__pycache__",
+]
+ignore = ["scripts/**/*"]
+defineConstant = { DEBUG = true }
+
+reportMissingImports = true
+reportMissingTypeStubs = false
+
+pythonVersion = "3.9"
+pythonPlatform = "Linux"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,7 +31,7 @@ def test_s3_client(s3_document_bucket_names):
     bucket_names = s3_document_bucket_names.values()
 
     with mock_s3():
-        s3_client = S3Client(dev_mode="False")
+        s3_client = S3Client(dev_mode=False)
         for bucket in bucket_names:
             s3_client.client.create_bucket(
                 Bucket=bucket,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,8 @@ import typing as t
 import uuid
 
 import pytest
+from cpr_data_access.embedding import Embedder
+from cpr_data_access.search_adaptors import Vespa, VespaSearchAdapter
 from fastapi.testclient import TestClient
 from moto import mock_s3
 from sqlalchemy import create_engine
@@ -15,9 +17,6 @@ from app.core.search import OpenSearchConfig, OpenSearchConnection
 from app.db.models.app import AppUser
 from app.db.session import Base, get_db
 from app.main import app
-from cpr_data_access.search_adaptors import VespaSearchAdapter
-from cpr_data_access.search_adaptors import Vespa
-from cpr_data_access.embedding import Embedder
 
 
 @pytest.fixture
@@ -32,7 +31,7 @@ def test_s3_client(s3_document_bucket_names):
     bucket_names = s3_document_bucket_names.values()
 
     with mock_s3():
-        s3_client = S3Client(dev_mode=False)
+        s3_client = S3Client(dev_mode="False")
         for bucket in bucket_names:
             s3_client.client.create_bucket(
                 Bucket=bucket,


### PR DESCRIPTION
# Description

- Updated download route to redirect to CDN link instead of returning a streaming response
- Fixed bug where blank file was being uploaded to S3 due to not resetting buffer position
- Return 404 if we can't find the file at the absolute CDN path
- Converted SQL query to use Python string concatenation rather than multi-line string that seemed to be causing empty results
- Added time range to query to only dump documents that were last modified (or created) during all previous ingets cycles, so we exclude the current ingest cycle
- Linear ticket [here](https://linear.app/climate-policy-radar/issue/PDCT-788/redirect-to-cdn-instead-of-streaming-response)

## Type of change

Please select the option(s) below that are most relevant:

- [x] Bug fix
- [x] New feature
- [ ] Breaking change


## Reviewer Checklist

- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
