### PR TITLE
Make filters exclusive to each other

### DIFF
--- a/app/core/search.py
+++ b/app/core/search.py
@@ -11,7 +11,7 @@ from cpr_data_access.models.search import Family as DataAccessResponseFamily
 from cpr_data_access.models.search import Passage as DataAccessResponsePassage
 from cpr_data_access.models.search import SearchParameters as DataAccessSearchParams
 from cpr_data_access.models.search import SearchResponse as DataAccessSearchResponse
-from cpr_data_access.models.search import filter_fields
+from cpr_data_access.models.search import filter_fields, KeywordFilters
 from sqlalchemy.orm import Session
 
 from app.api.api_v1.schemas.search import (
@@ -310,24 +310,38 @@ def _convert_filters(
     if keyword_filters is None:
         return None
     new_keyword_filters = {}
+    regions = []
+    countries = []
     for field, values in keyword_filters.items():
         new_field = _convert_filter_field(field)
         if field == FilterField.REGION:
-            new_values = new_keyword_filters.get(new_field, [])
             for region in values:
-                new_values.extend(
+                regions.extend(
                     [country.value for country in get_countries_for_region(db, region)]
                 )
         elif field == FilterField.COUNTRY:
-            new_values = new_keyword_filters.get(new_field, [])
-            new_values.extend(
+            countries.extend(
                 [country.value for country in get_countries_for_slugs(db, values)]
             )
         else:
             new_values = values
-        new_keyword_filters[new_field] = new_values
+            new_keyword_filters[new_field] = new_values
 
-    return new_keyword_filters
+    # Regions and countries filters should only include the overlap
+    geo_field = filter_fields["geography"]
+    if regions and countries:
+        values = list(set(countries).intersection(regions))
+        if values:
+            new_keyword_filters[geo_field] = values
+    elif regions:
+        new_keyword_filters[geo_field] = regions
+    elif countries:
+        new_keyword_filters[geo_field] = countries
+
+    if len(new_keyword_filters) > 0:
+        return new_keyword_filters
+    else:
+        return None
 
 
 def _process_vespa_search_response_families(
@@ -508,7 +522,11 @@ def create_vespa_search_params(db: Session, search_body: SearchRequestBody):
     search_body.max_passages_per_doc = min(
         search_body.max_passages_per_doc, VESPA_SEARCH_MATCHES_PER_DOC
     )
-
+    converted_filters = _convert_filters(db, search_body.keyword_filters)
+    if converted_filters:
+        filters = KeywordFilters.model_validate(converted_filters)
+    else:
+        filters = None
     return DataAccessSearchParams(
         query_string=search_body.query_string,
         exact_match=search_body.exact_match,
@@ -516,7 +534,7 @@ def create_vespa_search_params(db: Session, search_body: SearchRequestBody):
         max_hits_per_family=search_body.max_passages_per_doc,
         family_ids=search_body.family_ids,
         document_ids=search_body.document_ids,
-        keyword_filters=_convert_filters(db, search_body.keyword_filters),
+        keyword_filters=filters,
         year_range=search_body.year_range,
         sort_by=_convert_sort_field(search_body.sort_field),
         sort_order=_convert_sort_order(search_body.sort_order),

--- a/poetry.lock
+++ b/poetry.lock
@@ -679,8 +679,8 @@ vespa = ["pyvespa (>=0.37.1,<0.38.0)", "pyyaml (>=6.0.1,<7.0.0)", "sentence-tran
 [package.source]
 type = "git"
 url = "https://github.com/climatepolicyradar/data-access.git"
-reference = "v0.4.8"
-resolved_reference = "70a28a5afe354bb3cab8a6340c8647a17d7e18ee"
+reference = "v0.4.9"
+resolved_reference = "165748ef612345e497447b6db3216f9bff730737"
 
 [[package]]
 name = "cryptography"
@@ -4418,4 +4418,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "409a04b0687a8e31693cad57a524797ef9eea8486280a8cf81e4d1b444100d2c"
+content-hash = "a55d6a4e7e61a164bcbee10954ca4d103fdeef73fbae47cdedcd5681e19f6650"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ python = "^3.9"
 Authlib = "^0.15.5"
 bcrypt = "^3.2.0"
 boto3 = "^1.26"
-cpr-data-access = {git = "https://github.com/climatepolicyradar/data-access.git", tag = "v0.4.8", extras = ["vespa"]}
+cpr-data-access = {git = "https://github.com/climatepolicyradar/data-access.git", tag = "v0.4.9", extras = ["vespa"]}
 fastapi = "^0.103.2"
 fastapi-health = "^0.4.0"
 fastapi-pagination = { extras = ["sqlalchemy"], version = "^0.9.1" }

--- a/tests/routes/test_vespasearch.py
+++ b/tests/routes/test_vespasearch.py
@@ -375,6 +375,29 @@ def test_keyword_region_filters(
 
 @pytest.mark.search
 @pytest.mark.parametrize("label,query", [("search", "the"), ("browse", "")])
+def test_keyword_region_and_country_filters(
+    label, query, test_vespa, data_client, data_db, monkeypatch
+):
+    monkeypatch.setattr(search, "_VESPA_CONNECTION", test_vespa)
+    _populate_db_families(data_db)
+
+    # Filtering on one region and one country should return the one match
+    base_params = {
+        "query_string": query,
+        "keyword_filters": {
+            "regions": ["east-asia-pacific"],
+            "countries": ["NIU"],
+        },
+    }
+
+    body = _make_search_request(data_client, params=base_params)
+
+    assert len(body["families"]) == 1
+    assert body["families"][0]["family_name"] == "Agriculture Sector Plan 2015-2019"
+
+
+@pytest.mark.search
+@pytest.mark.parametrize("label,query", [("search", "the"), ("browse", "")])
 def test_invalid_keyword_filters(
     label, query, test_vespa, data_db, monkeypatch, data_client
 ):


### PR DESCRIPTION
This surfaces the changes from the data access library: https://github.com/climatepolicyradar/data-access/pull/141

As part of that it also fixes an issue with country & region searches, where country codes from both would be combined into one, so we'd always get the whole region, rather refining within it.

Note that there was two functions handling this logic, one for search and another for browse (which had no tests), I've partially consolidated them but had to add a workaround until we come back and do this properly.

# Description

Please include:
- a summary of the changes
- links to any related issue/ticket
- any additional relevant motivation and context
- details of any dependency updates that are required for this change

## Type of change

Please select the option(s) below that are most relevant:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
