### PR TITLE
Add family and passage counts to backend response

### DIFF
--- a/app/api/api_v1/schemas/search.py
+++ b/app/api/api_v1/schemas/search.py
@@ -118,6 +118,7 @@ class SearchResponseFamily(BaseModel):
     family_metadata: dict
     family_title_match: bool
     family_description_match: bool
+    total_passage_hits: int
     family_documents: list[SearchResponseFamilyDocument]
 
 
@@ -125,6 +126,7 @@ class SearchResponse(BaseModel):
     """The response body produced by the search API endpoint."""
 
     hits: int
+    total_family_hits: int
     query_time_ms: int
     total_time_ms: int
     continuation_token: Optional[str] = None

--- a/app/core/browse.py
+++ b/app/core/browse.py
@@ -63,8 +63,8 @@ def to_search_response_family(
         family_geography=cast(str, geography.value),
         family_title_match=False,
         family_description_match=False,
-        # TODO: Remove unused fields below?
-        # ↓ Stuff we don't currently use for search ↓
+        # ↓ Stuff we don't currently use for browse ↓
+        total_passage_hits=0,
         family_metadata={},
         family_documents=[],
     )
@@ -142,6 +142,7 @@ def browse_rds_families(
 
     return SearchResponse(
         hits=len(families),
+        total_family_hits=len(families),
         query_time_ms=time_taken,
         total_time_ms=time_taken,
         families=families[offset : offset + limit],

--- a/app/core/search.py
+++ b/app/core/search.py
@@ -437,6 +437,7 @@ def _process_vespa_search_response_families(
                     family_source=hit.family_source,
                     family_description_match=False,
                     family_title_match=False,
+                    total_passage_hits=vespa_family.total_passage_hits,
                     family_documents=[],
                     family_geography=hit.family_geography,
                     family_metadata=cast(dict, db_family_metadata.value),
@@ -505,6 +506,7 @@ def process_vespa_search_response(
 
     return SearchResponse(
         hits=len(vespa_search_response.families),
+        total_family_hits=vespa_search_response.total_family_hits,
         query_time_ms=vespa_search_response.query_time_ms or 0,
         total_time_ms=vespa_search_response.total_time_ms or 0,
         continuation_token=vespa_search_response.continuation_token,

--- a/tests/routes/test_vespasearch.py
+++ b/tests/routes/test_vespasearch.py
@@ -140,6 +140,7 @@ def test_search_body_valid(exact_match, test_vespa, data_client, data_db, monkey
         "families",
         "hits",
         "query_time_ms",
+        "total_family_hits",
         "total_time_ms",
     ]
     assert isinstance(body["families"], list)

--- a/tests/unit/app/schemas/test_schemas.py
+++ b/tests/unit/app/schemas/test_schemas.py
@@ -114,6 +114,7 @@ def test_search_response() -> None:
     """
     search_response = SearchResponse(
         hits=1,
+        total_family_hits=1,
         query_time_ms=1,
         total_time_ms=1,
         families=[
@@ -133,6 +134,7 @@ def test_search_response() -> None:
                 family_metadata={"key1": "value1", "key2": "value2"},
                 family_title_match=True,
                 family_description_match=False,
+                total_passage_hits=1,
                 family_documents=[
                     SearchResponseFamilyDocument(
                         document_title="Document Title",


### PR DESCRIPTION
`total_family_hits` at the root of the response object is the full amount of families matched in vespa. Each family then has `total_passage_hits`, which is all the text matches

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
