### PR TITLE
Move cron job to startup

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -73,6 +73,17 @@ async def lifespan(app_: FastAPI):
     """Run startup and shutdown events."""
     logger.info("Starting up...")
     run_migrations(engine)
+    scheduler = BackgroundScheduler()
+    scheduler.add_job(
+        start_scheduled_ingest,
+        "cron",
+        id="ingest_trigger",
+        day_of_week="mon",
+        hour=9,
+        minute=15,
+        replace_existing=True,
+    )
+    scheduler.start()
     yield
     logger.info("Shutting down...")
 
@@ -143,16 +154,6 @@ app.include_router(geographies_router, prefix="/api/v1", tags=["Geographies"])
 
 # add pagination support to all routes that ask for it
 add_pagination(app)
-
-scheduler = BackgroundScheduler()
-scheduler.add_job(
-    start_scheduled_ingest,
-    "cron",
-    day_of_week="mon",
-    hour=9,
-    minute=15,
-)
-scheduler.start()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
We had the problem where three of these jobs started at the same time,
likely because there where three backend instances running at the time
due to the backend being at its scaling limit. The thinking is when the
parent process forks it is also brings the cron job with it.

The hope here is that moving it to the startup will cause it to only run
once. As an extra check this also adds an id and sets the job to replace
any existing jobs with that id.

It's hard to test this to know if it will work for sure, but it is
already broken, and if it turns out this still doesnt work I'll just
switch back to triggering it manually until there is enough time to do a
better solution

## Type of change

Please select the option(s) below that are most relevant:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
