### PR TITLE
Remove cron from backend

### DIFF
--- a/app/api/api_v1/routers/pipeline_trigger.py
+++ b/app/api/api_v1/routers/pipeline_trigger.py
@@ -49,17 +49,6 @@ def _start_ingest(
         )
 
 
-def start_scheduled_ingest():
-    db = get_db().__next__()
-    s3_client = get_s3_client()
-    s3_prefix = get_new_s3_prefix()
-    _start_ingest(
-        db=db,
-        s3_client=s3_client,
-        s3_prefix=s3_prefix,
-    )
-
-
 @r.post(
     "/start-ingest",
     response_model=BulkIngestResult,

--- a/app/main.py
+++ b/app/main.py
@@ -5,7 +5,6 @@ from contextlib import asynccontextmanager
 
 import json_logging
 import uvicorn
-from apscheduler.schedulers.background import BackgroundScheduler
 from db_client import run_migrations
 from fastapi import APIRouter, Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -20,7 +19,6 @@ from app.api.api_v1.routers.geographies import geographies_router
 from app.api.api_v1.routers.lookups import lookups_router
 from app.api.api_v1.routers.pipeline_trigger import (
     pipeline_trigger_router,
-    start_scheduled_ingest,
 )
 from app.api.api_v1.routers.search import search_router
 from app.api.api_v1.routers.summaries import summary_router
@@ -73,17 +71,6 @@ async def lifespan(app_: FastAPI):
     """Run startup and shutdown events."""
     logger.info("Starting up...")
     run_migrations(engine)
-    scheduler = BackgroundScheduler()
-    scheduler.add_job(
-        start_scheduled_ingest,
-        "cron",
-        id="ingest_trigger",
-        day_of_week="mon",
-        hour=9,
-        minute=15,
-        replace_existing=True,
-    )
-    scheduler.start()
     yield
     logger.info("Shutting down...")
 


### PR DESCRIPTION
We are moving this cron trigger out of the backend because of a problem with cron jobs being duplicated across scaling instances that resulted in multiple ingests being triggered

## Type of change

Please select the option(s) below that are most relevant:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [x] The PR represents a single feature (small driveby fixes are also ok)
- [x] The PR includes tests that are sufficient for the level of risk
- [x] The code is sufficiently commented, particularly in hard-to-understand areas
- [x] Any required documentation updates have been made
- [x] Any TODOs added are captured in future tickets
- [x] No FIXMEs remain
