### PR TITLE
Add previous `continuation_token` to search response

### DIFF
--- a/app/api/api_v1/schemas/search.py
+++ b/app/api/api_v1/schemas/search.py
@@ -119,6 +119,7 @@ class SearchResponseFamily(BaseModel):
     total_passage_hits: int
     family_documents: list[SearchResponseFamilyDocument]
     continuation_token: Optional[str] = None
+    prev_continuation_token: Optional[str] = None
 
 
 class SearchResponse(BaseModel):
@@ -130,6 +131,7 @@ class SearchResponse(BaseModel):
     total_time_ms: int
     continuation_token: Optional[str] = None
     this_continuation_token: Optional[str] = None
+    prev_continuation_token: Optional[str] = None
 
     families: Sequence[SearchResponseFamily]
 

--- a/app/core/search.py
+++ b/app/core/search.py
@@ -439,6 +439,7 @@ def _process_vespa_search_response_families(
                     family_title_match=False,
                     total_passage_hits=vespa_family.total_passage_hits,
                     continuation_token=vespa_family.continuation_token,
+                    prev_continuation_token=vespa_family.prev_continuation_token,
                     family_documents=[],
                     family_geography=hit.family_geography,
                     family_metadata=cast(dict, db_family_metadata.value),
@@ -512,6 +513,7 @@ def process_vespa_search_response(
         total_time_ms=vespa_search_response.total_time_ms or 0,
         continuation_token=vespa_search_response.continuation_token,
         this_continuation_token=vespa_search_response.this_continuation_token,
+        prev_continuation_token=vespa_search_response.prev_continuation_token,
         families=_process_vespa_search_response_families(
             db,
             vespa_search_response.families,

--- a/poetry.lock
+++ b/poetry.lock
@@ -649,8 +649,8 @@ vespa = ["pyvespa (>=0.37.1,<0.38.0)", "pyyaml (>=6.0.1,<7.0.0)", "sentence-tran
 [package.source]
 type = "git"
 url = "https://github.com/climatepolicyradar/data-access.git"
-reference = "v0.5.2"
-resolved_reference = "9ffbc334d9f721e554336553e2fa7ef17cd4af7d"
+reference = "v0.5.3"
+resolved_reference = "32beab111d0d2560b933e50d1dd268152f4f9fc6"
 
 [[package]]
 name = "cryptography"
@@ -4359,4 +4359,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "a766024ec5e2339aa683e17de334fb369cb5bfbb4b4f7ffa02634c22ecdb22fb"
+content-hash = "62b9b6b26668da137d54b966ea5a7d0560a01da18fdd4a7e0ae0a3c49848b4fa"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ python = "^3.9"
 Authlib = "^0.15.5"
 bcrypt = "^3.2.0"
 boto3 = "^1.26"
-cpr-data-access = {git = "https://github.com/climatepolicyradar/data-access.git",  tag="v0.5.2", extras = ["vespa"]}
+cpr-data-access = {git = "https://github.com/climatepolicyradar/data-access.git", tag="v0.5.3", extras = ["vespa"]}
 fastapi = "^0.104.1"
 fastapi-health = "^0.4.0"
 fastapi-pagination = { extras = ["sqlalchemy"], version = "^0.12.19" }

--- a/tests/core/test_search.py
+++ b/tests/core/test_search.py
@@ -568,6 +568,8 @@ def _generate_search_response(specs: Sequence[FamSpec]) -> DataAccessSearchRespo
         total_time_ms=95 * len(specs),
         families=families,
         continuation_token="ABCXYZ",
+        this_continuation_token="",
+        prev_continuation_token="ABCDEFXYZ",
     )
 
 
@@ -737,6 +739,14 @@ def test_process_vespa_search_response(
     assert search_response.total_time_ms == vespa_response.total_time_ms
     assert search_response.total_family_hits == vespa_response.total_family_hits
     assert search_response.continuation_token == vespa_response.continuation_token
+    assert (
+        search_response.this_continuation_token
+        == vespa_response.this_continuation_token
+    )
+    assert (
+        search_response.prev_continuation_token
+        == vespa_response.prev_continuation_token
+    )
 
     # Now validate family results
     for i, fam_spec in enumerate(fam_specs[offset : offset + limit]):


### PR DESCRIPTION
See DAL changes for more: https://github.com/climatepolicyradar/data-access/compare/v0.5.2...v0.5.3

Note that the DAL release also includes an update that improves search sorting by switching it to use vespa instead of post processing the results

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [x] The PR represents a single feature (small driveby fixes are also ok)
- [x] The PR includes tests that are sufficient for the level of risk
- [x] The code is sufficiently commented, particularly in hard-to-understand areas
- [x] Any required documentation updates have been made
- [x] Any TODOs added are captured in future tickets
- [x] No FIXMEs remain
