### PR TITLE
Feature/pdct 965 parameter handling needs deduplicating

### DIFF
--- a/app/api/api_v1/routers/search.py
+++ b/app/api/api_v1/routers/search.py
@@ -56,9 +56,10 @@ def _search_request(db: Session, search_body: SearchRequestBody) -> SearchRespon
         data_access_search_response = _VESPA_CONNECTION.search(
             parameters=data_access_search_params
         )
-    except QueryError:
+    except QueryError as e:
         raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid Query"
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Invalid Query: {' '.join(e.args)}",
         )
     return process_vespa_search_response(
         db,

--- a/app/api/api_v1/routers/search.py
+++ b/app/api/api_v1/routers/search.py
@@ -5,7 +5,6 @@ All endpoints should perform document searches using the SearchRequestBody as
 its input. The individual endpoints will return different responses tailored
 for the type of document search being performed.
 """
-import json
 import logging
 from io import BytesIO
 
@@ -81,7 +80,7 @@ def search_documents(
         "Search request",
         extra={
             "props": {
-                "search_request": json.loads(search_body.json()),
+                "search_request": search_body.model_dump(),
             }
         },
     )
@@ -103,7 +102,7 @@ def download_search_documents(
         "Search download request",
         extra={
             "props": {
-                "search_request": json.loads(search_body.json()),
+                "search_request": search_body.model_dump(),
             }
         },
     )

--- a/app/api/api_v1/routers/search.py
+++ b/app/api/api_v1/routers/search.py
@@ -52,7 +52,6 @@ def _search_request(db: Session, search_body: SearchRequestBody) -> SearchRespon
         search_body.all_results = True
         search_body.exact_match = False
     data_access_search_params = create_vespa_search_params(db, search_body)
-    # TODO: we may wish to cache responses to improve pagination performance
     try:
         data_access_search_response = _VESPA_CONNECTION.search(
             parameters=data_access_search_params
@@ -64,7 +63,7 @@ def _search_request(db: Session, search_body: SearchRequestBody) -> SearchRespon
     return process_vespa_search_response(
         db,
         data_access_search_response,
-        limit=search_body.limit,
+        limit=search_body._page_size,
         offset=search_body.offset,
     ).increment_pages()
 

--- a/app/api/api_v1/schemas/search.py
+++ b/app/api/api_v1/schemas/search.py
@@ -35,17 +35,6 @@ class FilterField(str, Enum):
     LANGUAGE = "languages"
 
 
-class IncludedResults(str, Enum):
-    """Filter field to exclude specific results from search based on search indices."""
-
-    PDFS_TRANSLATED = "pdfsTranslated"
-    HTMLS_NON_TRANSLATED = "htmlsNonTranslated"
-    HTMLS_TRANSLATED = "htmlsTranslated"
-
-
-IncludedResultsList = Optional[Annotated[List[IncludedResults], Field(min_length=1)]]
-
-
 class SearchRequestBody(BaseModel):
     """The request body expected by the search API endpoint."""
 

--- a/app/core/search.py
+++ b/app/core/search.py
@@ -10,7 +10,8 @@ from cpr_data_access.models.search import Document as DataAccessResponseDocument
 from cpr_data_access.models.search import Family as DataAccessResponseFamily
 from cpr_data_access.models.search import Passage as DataAccessResponsePassage
 from cpr_data_access.models.search import SearchResponse as DataAccessSearchResponse
-from cpr_data_access.models.search import filter_fields, KeywordFilters
+from cpr_data_access.models.search import Filters as DataAccessKeywordFilters
+from cpr_data_access.models.search import filter_fields
 from sqlalchemy.orm import Session
 
 from app.api.api_v1.schemas.search import (
@@ -505,7 +506,7 @@ def create_vespa_search_params(
     """Create Vespa search parameters from a F/E search request body"""
     converted_filters = _convert_filters(db, search_body.keyword_filters)
     if converted_filters:
-        search_body.filters = KeywordFilters.model_validate(converted_filters)
+        search_body.filters = DataAccessKeywordFilters.model_validate(converted_filters)
     else:
         search_body.filters = None
     return search_body

--- a/app/core/search.py
+++ b/app/core/search.py
@@ -21,8 +21,6 @@ from app.api.api_v1.schemas.search import (
     SearchResponseDocumentPassage,
     SearchResponseFamily,
     SearchResponseFamilyDocument,
-    SortField,
-    SortOrder,
 )
 from app.core.config import (
     INDEX_ENCODER_CACHE_FOLDER,
@@ -266,26 +264,6 @@ def process_result_into_csv(
 
     csv_result_io.seek(0)
     return csv_result_io.read()
-
-
-# Vespa search processing functions
-def _convert_sort_field(
-    sort_field: Optional[SortField],
-) -> Optional[str]:
-    if sort_field is None:
-        return None
-
-    if sort_field == SortField.DATE:
-        return "date"
-    if sort_field == SortField.TITLE:
-        return "name"
-
-
-def _convert_sort_order(sort_order: SortOrder) -> str:
-    if sort_order == SortOrder.ASCENDING:
-        return "ascending"
-    if sort_order == SortOrder.DESCENDING:
-        return "descending"
 
 
 def _convert_filter_field(filter_field: str) -> Optional[str]:

--- a/makefile-docker.defs
+++ b/makefile-docker.defs
@@ -56,6 +56,9 @@ build_bats:
 build:
 	docker compose build --no-cache backend
 
+build_from_cached:
+	docker compose build backend
+
 # ----------------------------------
 # testing
 # ----------------------------------

--- a/poetry.lock
+++ b/poetry.lock
@@ -619,7 +619,7 @@ files = [
 
 [[package]]
 name = "cpr-data-access"
-version = "0.5.1"
+version = "0.5.6"
 description = ""
 category = "main"
 optional = false
@@ -633,7 +633,7 @@ boto3 = "^1.26.16"
 datasets = "^2.14.0"
 deprecation = "^2.1.0"
 langdetect = "^1.0.9"
-numpy = "1.24.4"
+numpy = ">=1.23.5"
 pandas = "^1.5.3"
 pydantic = "^2.4.0"
 pyvespa = {version = "^0.37.1", optional = true}
@@ -649,8 +649,8 @@ vespa = ["pyvespa (>=0.37.1,<0.38.0)", "pyyaml (>=6.0.1,<7.0.0)", "sentence-tran
 [package.source]
 type = "git"
 url = "https://github.com/climatepolicyradar/data-access.git"
-reference = "v0.5.3"
-resolved_reference = "32beab111d0d2560b933e50d1dd268152f4f9fc6"
+reference = "v0.5.6"
+resolved_reference = "aa80fdea1f6de27968d806f52a541410ebff0e4b"
 
 [[package]]
 name = "cryptography"
@@ -4359,4 +4359,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "62b9b6b26668da137d54b966ea5a7d0560a01da18fdd4a7e0ae0a3c49848b4fa"
+content-hash = "c513420b1fa0eeab3e73ac1bc73a16ad74dadc2b1c82181333288c7afca025de"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ python = "^3.9"
 Authlib = "^0.15.5"
 bcrypt = "^3.2.0"
 boto3 = "^1.26"
-cpr-data-access = {git = "https://github.com/climatepolicyradar/data-access.git", tag="v0.5.3", extras = ["vespa"]}
+cpr-data-access = {git = "https://github.com/climatepolicyradar/data-access.git", tag="v0.5.6", extras = ["vespa"]}
 fastapi = "^0.104.1"
 fastapi-health = "^0.4.0"
 fastapi-pagination = { extras = ["sqlalchemy"], version = "^0.12.19" }

--- a/tests/core/test_search.py
+++ b/tests/core/test_search.py
@@ -5,6 +5,7 @@ from slugify import slugify
 from typing import Sequence
 
 import pytest
+from cpr_data_access.models.search import Filters as DataAccessFilters
 from cpr_data_access.models.search import (
     Document as DataAccessDocument,
     Family as DataAccessFamily,
@@ -12,7 +13,6 @@ from cpr_data_access.models.search import (
     Passage as DataAccessPassage,
     SearchResponse as DataAccessSearchResponse,
     filter_fields,
-    KeywordFilters,
 )
 from sqlalchemy.orm import Session
 
@@ -252,11 +252,12 @@ def test_create_vespa_search_params(
 
     # Test converted data
     if keyword_filters:
-        assert produced_search_parameters.keyword_filters == KeywordFilters(
+        assert produced_search_parameters.filters == DataAccessFilters(
             **_convert_filters(test_db, keyword_filters)
         )
     else:
         assert not produced_search_parameters.keyword_filters
+        assert not produced_search_parameters.filters
 
     assert produced_search_parameters.sort_by == sort_field
     assert produced_search_parameters.sort_order == sort_order

--- a/tests/routes/test_vespasearch.py
+++ b/tests/routes/test_vespasearch.py
@@ -626,22 +626,6 @@ def test_continuation_token__passages(test_vespa, data_db, monkeypatch, data_cli
 
 
 @pytest.mark.search
-@pytest.mark.parametrize(
-    "params",
-    [
-        {"exact_match": False},
-        {},
-    ],
-)
-def test_invalid_requests(params, test_vespa, data_db, monkeypatch, data_client):
-    monkeypatch.setattr(search, "_VESPA_CONNECTION", test_vespa)
-    _populate_db_families(data_db)
-
-    response = data_client.post(SEARCH_ENDPOINT, json=params)
-    assert response.status_code == 422
-
-
-@pytest.mark.search
 def test_case_insensitivity(test_vespa, data_db, monkeypatch, data_client):
     monkeypatch.setattr(search, "_VESPA_CONNECTION", test_vespa)
     _populate_db_families(data_db)


### PR DESCRIPTION
Searches are inefficient because we validate requests with a backend pydantic model, and then load the content into a data access library one. This will have an impact on query time and also has impacted the delivery speed of recent changes. This simplifies the request as much as possible. There is two outstanding pieces of unique backend behaviour, filter processing and the limit/offset pagination. These can be revisited in the future and for now extending the data access library's model still allows us to only use one model rather than two.

This should have no impact on the frontend as I've made sure to support previous naming for requests.

This is entirely dependent on: https://github.com/climatepolicyradar/data-access/pull/157 once it is merged I will come back and update the dependency here so its not pointing at the specific branch

Also! We have the same problem with the response! but separating them felt like the best way of minimising how messy this change needs to be.

## Type of change

Please select the option(s) below that are most relevant:

- [x] Refactor
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [x] The PR represents a single feature (small driveby fixes are also ok)
- [x] The PR includes tests that are sufficient for the level of risk
- [x] The code is sufficiently commented, particularly in hard-to-understand areas
- [x] Any required documentation updates have been made
- [x] Any TODOs added are captured in future tickets
- [x] No FIXMEs remain
