### PR TITLE
Make query string required for backend

### DIFF
--- a/app/api/api_v1/schemas/search.py
+++ b/app/api/api_v1/schemas/search.py
@@ -50,6 +50,9 @@ BackendKeywordFilter = Optional[Mapping[BackendFilterValues, Sequence[str]]]
 class SearchRequestBody(DataAccessSearchParameters):
     """The request body expected by the search API endpoint."""
 
+    # Query string should be required in backend (its not in dal)
+    query_string: str
+
     # We need to add `keyword_filters` here because the items recieved from the frontend
     # need processing to be ready for vespa (key name change & geo slugs to geo codes)
     keyword_filters: BackendKeywordFilter = None


### PR DESCRIPTION
# Description

Taking this out led to the default behavior in the data access library.
This in turn led to a server error for the backend, but only under the
very specific circumstance that this parameter was missing and
continuation tokens where being used in the query.

## Type of change

Please select the option(s) below that are most relevant:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [x] The PR represents a single feature (small driveby fixes are also ok)
- [x] The PR includes tests that are sufficient for the level of risk
- [x] The code is sufficiently commented, particularly in hard-to-understand areas
- [x] Any required documentation updates have been made
- [x] Any TODOs added are captured in future tickets
- [x] No FIXMEs remain
