### PR TITLE
Don't filter on empty filters

### DIFF
--- a/app/core/search.py
+++ b/app/core/search.py
@@ -286,12 +286,15 @@ def _convert_filters(
     db: Session,
     keyword_filters: Optional[Mapping[BackendFilterValues, Sequence[str]]],
 ) -> Optional[Mapping[str, Sequence[str]]]:
-    if keyword_filters is None:
+    if not keyword_filters:
         return None
     new_keyword_filters = {}
     regions = []
     countries = []
     for field, values in keyword_filters.items():
+        if not values:
+            continue
+
         new_field = _convert_filter_field(field)
         if field == FilterField.REGION:
             for region in values:

--- a/tests/core/test_search.py
+++ b/tests/core/test_search.py
@@ -337,6 +337,12 @@ def test_create_browse_request_params(
     "filters, expected",
     [
         (None, None),
+        ({}, None),
+        ({"regions": {}}, None),
+        (
+            {"regions": {}, "categories": ["Executive"]},
+            {"family_category": ["Executive"]},
+        ),
         ({"regions": ["this-is-not-a-region"]}, None),
         (
             {


### PR DESCRIPTION
Makes the keyword filter parsing treat `{}` the same as `None`. Otherwise we end up filtering out valid results

## Type of change

Please select the option(s) below that are most relevant:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [x] The PR represents a single feature (small driveby fixes are also ok)
- [x] The PR includes tests that are sufficient for the level of risk
- [x] The code is sufficiently commented, particularly in hard-to-understand areas
- [x] Any required documentation updates have been made
- [x] Any TODOs added are captured in future tickets
- [x] No FIXMEs remain
