### PR TITLE
Improve local test running experience

### DIFF
--- a/makefile-docker.defs
+++ b/makefile-docker.defs
@@ -4,8 +4,9 @@
 # starting, stopping, migrating DB
 # ----------------------------------
 start:
-	# Build and run containers
+	# Build & run containers and setup vespa
 	docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --remove-orphans
+	$(MAKE) vespa_setup
 
 start_backend:
 	# Build and run containers
@@ -92,6 +93,7 @@ vespa_load_data:
 	vespa feed --progress=3 tests/search_fixtures/vespa_document_passage.json
 
 vespa_setup: vespa_confirm_cli_installed vespa_healthy vespa_deploy_schema vespa_load_data
+	# Deploys a vespa application to a local vespa container and loads search_fixtures
 
 .ONESHELL:
 test_search:

--- a/makefile-docker.defs
+++ b/makefile-docker.defs
@@ -104,16 +104,16 @@ test_search:
 		-v "${PWD}/data:/data" \
 		backend pytest \
 		-vvv tests/routes/test_vespasearch.py \
-		-m 'search'
+		-m 'search' ${ARGS}
 
 test_cors:
-	docker compose -f docker-compose.yml -f docker-compose.dev.yml run --rm backend pytest -vvv -m 'cors'
+	docker compose -f docker-compose.yml -f docker-compose.dev.yml run --rm backend pytest -vvv -m 'cors' ${ARGS}
 
 test_unit:
-	docker compose -f docker-compose.yml -f docker-compose.dev.yml run --rm backend pytest -vvv tests/unit
+	docker compose -f docker-compose.yml -f docker-compose.dev.yml run --rm backend pytest -vvv tests/unit ${ARGS}
 
 test:
-	docker compose -f docker-compose.yml -f docker-compose.dev.yml run --rm backend pytest -vvv -m 'not search'
+	docker compose -f docker-compose.yml -f docker-compose.dev.yml run --rm backend pytest -vvv -m 'not search' ${ARGS}
 
 # ----------------------------------
 # tasks


### PR DESCRIPTION
- Adds `vespa_setup` to `make start`
- Add optional arguments for test commands

Makes it possible to run specific tests with the following (rather than changing the file and accidently commiting it all the time):
    
    `make test ARGS='-k test__convert_filters'`
    
Alternatively:
    
    `make test ARGS='tests/core/test_search.py::test__convert_filters[None-None]'`



## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
