### PR TITLE
Feature/pdct 1001 use family_status instead of doc_status in world map geo endpoint

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -25,6 +25,7 @@ runtimes:
 # (https://docs.trunk.io/check/configuration)
 lint:
   disabled:
+    - hadolint
     - oxipng
   definitions:
     - name: bandit
@@ -50,7 +51,6 @@ lint:
     - black@24.3.0
     - checkov@3.2.55
     - git-diff-check
-    - hadolint@2.12.0
     - isort@5.13.2
     - markdownlint@0.39.0
     - osv-scanner@1.7.0

--- a/app/api/api_v1/routers/geographies.py
+++ b/app/api/api_v1/routers/geographies.py
@@ -3,7 +3,7 @@ import logging
 from fastapi import APIRouter, Depends, HTTPException, status
 
 from app.api.api_v1.schemas.geography import GeographyStatsDTO
-from app.db.crud.geography import get_geography_stats
+from app.db.crud.geography import get_world_map_stats
 from app.db.session import get_db
 from app.errors import RepositoryError
 
@@ -18,15 +18,16 @@ async def geographies(db=Depends(get_db)):
     _LOGGER.info("Getting detailed information on all geographies")
 
     try:
-        geo_stats = get_geography_stats(db)
+        world_map_stats = get_world_map_stats(db)
 
-        if geo_stats == []:
-            _LOGGER.error("No geography stats found")
+        if world_map_stats == []:
+            _LOGGER.error("No stats for world map found")
             raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND, detail="No geography stats found"
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="No stats for world map found",
             )
 
-        return geo_stats
+        return world_map_stats
     except RepositoryError as e:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=e.message

--- a/app/api/api_v1/routers/geographies.py
+++ b/app/api/api_v1/routers/geographies.py
@@ -14,7 +14,7 @@ geographies_router = APIRouter()
 
 @geographies_router.get("/geographies", response_model=list[GeographyStatsDTO])
 async def geographies(db=Depends(get_db)):
-    """Get a summary of doc stats for all geographies for world map."""
+    """Get a summary of fam stats for all geographies for world map."""
     _LOGGER.info("Getting detailed information on all geographies")
 
     try:

--- a/app/db/crud/geography.py
+++ b/app/db/crud/geography.py
@@ -14,9 +14,9 @@ from app.errors import RepositoryError
 _LOGGER = logging.getLogger(__file__)
 
 
-def _db_count_docs_in_category_and_geo(db: Session) -> Query:
+def _db_count_fams_in_category_and_geo(db: Session) -> Query:
     """
-    Query the database for the doc count per category per geo.
+    Query the database for the fam count per category per geo.
 
     NOTE: SqlAlchemy will make a complete hash of query generation if
     columns are used in the query() call. Therefore, entire objects are
@@ -102,19 +102,19 @@ def _to_dto(family_doc_geo_stats) -> GeographyStatsDTO:
 
 def get_world_map_stats(db: Session) -> list[GeographyStatsDTO]:
     """
-    Get a count of docs per category per geography for all geographies.
+    Get a count of fam per category per geography for all geographies.
 
     :param db Session: The database session.
     :return list[GeographyStatsDTO]: A list of Geography stats objects
     """
     try:
-        family_doc_geo_stats = _db_count_docs_in_category_and_geo(db).all()
+        family_geo_stats = _db_count_fams_in_category_and_geo(db).all()
     except OperationalError as e:
         _LOGGER.error(e)
         raise RepositoryError("Error querying the database for geography stats")
 
-    if not family_doc_geo_stats:
+    if not family_geo_stats:
         return []
 
-    result = [_to_dto(fdgs) for fdgs in family_doc_geo_stats]
+    result = [_to_dto(fgs) for fgs in family_geo_stats]
     return result

--- a/app/db/crud/geography.py
+++ b/app/db/crud/geography.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from db_client.models.dfce.family import DocumentStatus, Family, FamilyDocument
+from db_client.models.dfce.family import Family, FamilyStatus
 from db_client.models.dfce.geography import Geography
 from sqlalchemy import func
 from sqlalchemy.exc import OperationalError
@@ -44,8 +44,7 @@ def _db_count_docs_in_category_and_geo(db: Session) -> Query:
             Family.geography_id,
             func.count().label("records_count"),
         )
-        .join(FamilyDocument, FamilyDocument.family_import_id == Family.import_id)
-        .filter(FamilyDocument.document_status == DocumentStatus.PUBLISHED)
+        .filter(Family.family_status == FamilyStatus.PUBLISHED)
         .group_by(Family.family_category, Family.geography_id)
         .subquery("counts")
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "navigator_backend"
-version = "1.9.3"
+version = "1.9.4"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]

--- a/tests/non_search/app/geographies/setup_world_map_helpers.py
+++ b/tests/non_search/app/geographies/setup_world_map_helpers.py
@@ -1,0 +1,230 @@
+from sqlalchemy.orm import Session
+
+from tests.non_search.dfce_helpers import add_document
+from tests.non_search.setup_helpers import (
+    add_collections,
+    add_families,
+    get_default_collections,
+    get_default_documents,
+)
+
+
+def _add_published_fams_and_docs(db: Session):
+    # Collection
+    collection1, _ = get_default_collections()
+    add_collections(db, collections=[collection1])
+
+    # Family + Document + events
+    document1, document2 = get_default_documents()
+    document3 = {
+        "title": "Document3",
+        "slug": "DocSlug3",
+        "md5_sum": None,
+        "url": "http://another_somewhere",
+        "content_type": None,
+        "import_id": "CCLW.executive.3.3",
+        "language_variant": None,
+        "status": "PUBLISHED",
+        "role": "MAIN",
+        "type": "Order",
+        "languages": [],
+        "events": [
+            {
+                "import_id": "CPR.Event.3.0",
+                "title": "Published",
+                "date": "2019-12-25",
+                "type": "Passed/Approved",
+                "status": "OK",
+            }
+        ],
+    }
+
+    family0 = {
+        "import_id": "CCLW.family.0000.0",
+        "corpus_import_id": "CCLW.corpus.i00000001.n0000",
+        "title": "Fam0",
+        "slug": "FamSlug0",
+        "description": "Summary0",
+        "geography_id": 5,
+        "category": "UNFCCC",
+        "documents": [],
+        "metadata": {
+            "size": "small",
+            "color": "blue",
+        },
+    }
+    family1 = {
+        "import_id": "CCLW.family.1001.0",
+        "corpus_import_id": "CCLW.corpus.i00000001.n0000",
+        "title": "Fam1",
+        "slug": "FamSlug1",
+        "description": "Summary1",
+        "geography_id": 5,
+        "category": "Executive",
+        "documents": [],
+        "metadata": {
+            "size": "small",
+            "color": "blue",
+        },
+    }
+    family2 = {
+        "import_id": "CCLW.family.2002.0",
+        "corpus_import_id": "CCLW.corpus.i00000001.n0000",
+        "title": "Fam2",
+        "slug": "FamSlug2",
+        "description": "Summary2",
+        "geography_id": 5,
+        "category": "Legislative",
+        "documents": [],
+        "metadata": {
+            "size": "small",
+            "color": "blue",
+        },
+    }
+    family3 = {
+        "import_id": "CCLW.family.3003.0",
+        "corpus_import_id": "CCLW.corpus.i00000001.n0000",
+        "title": "Fam3",
+        "slug": "FamSlug3",
+        "description": "Summary3",
+        "geography_id": 5,
+        "category": "UNFCCC",
+        "documents": [],
+        "metadata": {
+            "size": "small",
+            "color": "blue",
+        },
+    }
+
+    family0["documents"] = []
+    family1["documents"] = [document1]
+    family2["documents"] = [document2]
+    family3["documents"] = [document3]
+    add_families(db, families=[family0, family1, family2, family3])
+
+
+def setup_all_docs_published_world_map(db: Session):
+    _add_published_fams_and_docs(db)
+
+
+def setup_mixed_doc_statuses_world_map(db: Session):
+    _add_published_fams_and_docs(db)
+
+    # Family + Document + events
+    document0 = {
+        "title": "Document0",
+        "slug": "DocSlug0",
+        "md5_sum": None,
+        "url": "http://another_somewhere",
+        "content_type": None,
+        "import_id": "CCLW.executive.0.0",
+        "language_variant": None,
+        "status": "CREATED",
+        "role": "MAIN",
+        "type": "Order",
+        "languages": [],
+        "events": [
+            {
+                "import_id": "CPR.Event.0.0",
+                "title": "Published",
+                "date": "2019-12-25",
+                "type": "Passed/Approved",
+                "status": "OK",
+            }
+        ],
+    }
+    document4 = {
+        "title": "Document4",
+        "slug": "DocSlug4",
+        "md5_sum": None,
+        "url": "http://another_somewhere",
+        "content_type": None,
+        "import_id": "CCLW.executive.4.4",
+        "language_variant": None,
+        "status": "DELETED",
+        "role": "MAIN",
+        "type": "Order",
+        "languages": [],
+        "events": [
+            {
+                "import_id": "CPR.Event.4.0",
+                "title": "Published",
+                "date": "2019-12-25",
+                "type": "Passed/Approved",
+                "status": "OK",
+            }
+        ],
+    }
+    document5 = {
+        "title": "Document5",
+        "slug": "DocSlug5",
+        "md5_sum": None,
+        "url": "http://another_somewhere",
+        "content_type": None,
+        "import_id": "CCLW.executive.5.5",
+        "language_variant": None,
+        "status": "CREATED",
+        "role": "MAIN",
+        "type": "Order",
+        "languages": [],
+        "events": [
+            {
+                "import_id": "CPR.Event.5.0",
+                "title": "Published",
+                "date": "2019-12-25",
+                "type": "Passed/Approved",
+                "status": "OK",
+            }
+        ],
+    }
+    document6 = {
+        "title": "Document6",
+        "slug": "DocSlug6",
+        "md5_sum": None,
+        "url": "http://another_somewhere",
+        "content_type": None,
+        "import_id": "CCLW.executive.6.6",
+        "language_variant": None,
+        "status": "PUBLISHED",
+        "role": "MAIN",
+        "type": "Order",
+        "languages": [],
+        "events": [
+            {
+                "import_id": "CPR.Event.6.0",
+                "title": "Published",
+                "date": "2019-12-25",
+                "type": "Passed/Approved",
+                "status": "OK",
+            }
+        ],
+    }
+    document7 = {
+        "title": "Document7",
+        "slug": "DocSlug7",
+        "md5_sum": None,
+        "url": "http://another_somewhere",
+        "content_type": None,
+        "import_id": "CCLW.executive.7.7",
+        "language_variant": None,
+        "status": "PUBLISHED",
+        "role": "MAIN",
+        "type": "Order",
+        "languages": [],
+        "events": [
+            {
+                "import_id": "CPR.Event.7.0",
+                "title": "Published",
+                "date": "2019-12-25",
+                "type": "Passed/Approved",
+                "status": "OK",
+            }
+        ],
+    }
+
+    for import_id, docs in [
+        ("CCLW.family.3003.0", [document4, document5, document6]),
+        ("CCLW.family.0000.0", [document0, document7]),
+    ]:
+        for doc in docs:
+            add_document(db, import_id, doc)

--- a/tests/non_search/app/geographies/test_world_map_summary.py
+++ b/tests/non_search/app/geographies/test_world_map_summary.py
@@ -1,0 +1,89 @@
+import pytest
+from db_client.models.dfce.geography import Geography
+from fastapi import status
+
+from tests.non_search.app.geographies.setup_world_map_helpers import (
+    setup_all_docs_published_world_map,
+    setup_mixed_doc_statuses_world_map,
+)
+
+
+def _get_expected_keys():
+    return ["display_name", "iso_code", "slug", "family_counts"]
+
+
+def _url_under_test() -> str:
+    return "/api/v1/geographies"
+
+
+def _find_geography_index(lst, key, value):
+    for i, dic in enumerate(lst):
+        if dic[key] == value:
+            return i
+    return -1
+
+
+def test_geo_table_populated(data_db):
+    lst = data_db.query(Geography).all()
+    assert len(lst) > 0
+
+
+def test_endpoint_returns_ok_all_docs_per_family_published(data_db, data_client):
+    """Check endpoint returns 200 on success"""
+    setup_all_docs_published_world_map(data_db)
+    response = data_client.get(_url_under_test())
+    assert response.status_code == status.HTTP_200_OK
+    resp_json = response.json()
+    assert len(resp_json) > 1
+
+    idx = _find_geography_index(resp_json, "display_name", "Afghanistan")
+    resp = resp_json[idx]
+
+    assert set(["display_name", "iso_code", "slug", "family_counts"]) == set(
+        resp.keys()
+    )
+
+    assert resp["family_counts"]["EXECUTIVE"] == 1
+    assert resp["family_counts"]["LEGISLATIVE"] == 1
+    assert resp["family_counts"]["UNFCCC"] == 1
+
+    assert len(resp["family_counts"]) == 3
+
+
+def test_endpoint_returns_ok_some_docs_per_family_unpublished(data_db, data_client):
+    """Check endpoint returns 200 & discounts CREATED & DELETED docs"""
+    setup_mixed_doc_statuses_world_map(data_db)
+    response = data_client.get(_url_under_test())
+    assert response.status_code == status.HTTP_200_OK
+    resp_json = response.json()
+    assert len(resp_json) > 1
+
+    idx = _find_geography_index(resp_json, "display_name", "Afghanistan")
+    resp = resp_json[idx]
+
+    assert set(["display_name", "iso_code", "slug", "family_counts"]) == set(
+        resp.keys()
+    )
+
+    assert resp["family_counts"]["EXECUTIVE"] == 1
+    assert resp["family_counts"]["LEGISLATIVE"] == 1
+    assert resp["family_counts"]["UNFCCC"] == 3
+
+    assert len(resp["family_counts"]) == 3
+
+
+def test_endpoint_returns_404_when_not_found(data_client):
+    """Test the endpoint returns a 404 when no world map stats found"""
+    response = data_client.get(_url_under_test())
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    data = response.json()
+    assert data["detail"] == "No stats for world map found"
+
+
+@pytest.mark.skip(reason="Bad repo and rollback mocks need rewriting")
+def test_endpoint_returns_503_when_error(data_client):
+    """Test the endpoint returns a 503 on db error"""
+    response = data_client.get(_url_under_test())
+    assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+    data = response.json()
+    assert data["detail"] == "Database error"

--- a/tests/non_search/app/geographies/test_world_map_summary.py
+++ b/tests/non_search/app/geographies/test_world_map_summary.py
@@ -67,7 +67,7 @@ def test_endpoint_returns_ok_some_docs_per_family_unpublished(data_db, data_clie
 
     assert resp["family_counts"]["EXECUTIVE"] == 1
     assert resp["family_counts"]["LEGISLATIVE"] == 1
-    assert resp["family_counts"]["UNFCCC"] == 3
+    assert resp["family_counts"]["UNFCCC"] == 2
 
     assert len(resp["family_counts"]) == 3
 


### PR DESCRIPTION
# Description

Use family_status instead of doc_status in world map geo endpoint

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Refactor legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
