### PR TITLE
Move session to function scope

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ from fastapi.testclient import TestClient
 from freezegun import freeze_time
 from moto import mock_s3
 from sqlalchemy import create_engine, event
-from sqlalchemy.engine import Connection
+from sqlalchemy.engine import Engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy_utils import create_database, database_exists, drop_database
 from surrogate import surrogate
@@ -175,7 +175,7 @@ def test_db(scope="function"):
 
 
 @pytest.fixture(scope="session")
-def data_db_connection() -> t.Generator[Connection, None, None]:
+def data_db_engine() -> t.Generator[Engine, None, None]:
     test_db_url = get_test_db_url()
 
     if database_exists(test_db_url):
@@ -188,28 +188,26 @@ def data_db_connection() -> t.Generator[Connection, None, None]:
     test_engine = create_engine(test_db_url)
 
     run_migrations(test_engine)
-    connection = test_engine.connect()
 
-    yield connection
-    connection.close()
+    yield test_engine
 
     os.environ["DATABASE_URL"] = saved_db_url
     drop_database(test_db_url)
 
 
 @pytest.fixture(scope="function")
-def data_db(data_db_connection):
-    transaction = data_db_connection.begin()
+def data_db(data_db_engine):
+    connection = data_db_engine.connect()
+    transaction = connection.begin()
 
-    SessionLocal = sessionmaker(
-        autocommit=False, autoflush=False, bind=data_db_connection
-    )
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=connection)
     session = SessionLocal()
 
     yield session
 
     session.close()
     transaction.rollback()
+    connection.close()
 
 
 @pytest.fixture


### PR DESCRIPTION
Longer running test runs where routinely seeing the error:
```
sqlalchemy.exc.ResourceClosedError: This Connection is closed
```

We previously had the connection shared across the whole test run, which is faster than starting a new connection each time, unfortunatly it seems to be leading to an issue with the session closing prematurely. To fix the issue, this moves the connection to be created on a per test function basis.

The tradeoff is this slows a full test run with `make test` down slightly (10-20s), but this seems better than them not working.

# Description

Please include:

- a summary of the changes
- links to any related issue/ticket
- any additional relevant motivation and context
- details of any dependency updates that are required for this change

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [x] Skip auto-tagging
- [ ] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Refactor legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
