### PR TITLE
Ignore extra fields in csv export

### DIFF
--- a/app/core/search.py
+++ b/app/core/search.py
@@ -255,8 +255,7 @@ def process_result_into_csv(
         itertools.chain(_CSV_SEARCH_RESPONSE_COLUMNS, *metadata_keys.values())
     )
     writer = csv.DictWriter(
-        csv_result_io,
-        fieldnames=csv_fieldnames,
+        csv_result_io, fieldnames=csv_fieldnames, extrasaction="ignore"
     )
     writer.writeheader()
     for row in rows:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "navigator_backend"
-version = "1.13.1"
+version = "1.13.2"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]

--- a/tests/search/test_vespasearch.py
+++ b/tests/search/test_vespasearch.py
@@ -843,6 +843,27 @@ def test_csv_download_search_variable_limit(
 
 
 @pytest.mark.search
+def test_csv_download__ignore_extra_fields(
+    test_vespa, data_db, monkeypatch, data_client, mocker
+):
+    monkeypatch.setattr(search, "_VESPA_CONNECTION", test_vespa)
+    _populate_db_families(data_db)
+
+    params = {
+        "query_string": "winter",
+    }
+
+    # Ensure extra, unspecified fields don't cause an error
+    fields = []
+    with patch("app.core.search._CSV_SEARCH_RESPONSE_COLUMNS", fields):
+        download_response = data_client.post(
+            CSV_DOWNLOAD_ENDPOINT,
+            json=params,
+        )
+    assert download_response.status_code == 200
+
+
+@pytest.mark.search
 def test_all_data_download(data_db, data_client):
     _populate_db_families(data_db)
 


### PR DESCRIPTION
Some rows managed to find extra fields leading to a hard failure. This changes the behaviour in this situation to simply ignore the extra fields.

Also added a test that simulates missing fields by emptying out the list of expected fields so we can confirm it still passes

# Description

Please include:

- a summary of the changes
- links to any related issue/ticket
- any additional relevant motivation and context
- details of any dependency updates that are required for this change

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Refactor legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
