### PR TITLE
Feature/pdct 1243 remove references to familydocumentrole

### DIFF
--- a/app/api/api_v1/schemas/document.py
+++ b/app/api/api_v1/schemas/document.py
@@ -64,7 +64,7 @@ class FamilyDocumentResponse(BaseModel):
     language: str
     languages: Sequence[str]
     document_type: Optional[str] = None
-    document_role: Optional[str] = None
+    document_role: str
 
     @field_validator("source_url")
     @classmethod

--- a/app/api/api_v1/schemas/metadata.py
+++ b/app/api/api_v1/schemas/metadata.py
@@ -31,6 +31,5 @@ class ApplicationConfig(BaseModel):
     geographies: Sequence[dict]
     organisations: Mapping[str, OrganisationConfig]
     languages: Mapping[str, str]
-    document_roles: Sequence[str]
     document_types: Sequence[str]
     document_variants: Sequence[str]

--- a/app/core/download.py
+++ b/app/core/download.py
@@ -137,7 +137,9 @@ def create_query(ingest_cycle_start: str) -> str:
         'f.description as "Family Summary", '
         'n1.collection_titles as "Collection Title(s)", '
         'n1.collection_descriptions as "Collection Description(s)", '
-        'INITCAP(d.document_role::TEXT) as "Document Role", '
+        "INITCAP(d.valid_metadata::json#>>'{"
+        "role,0}') as "
+        '"Document Role", '
         'd.variant_name as "Document Variant", '
         'p.source_url as "Document Content URL", '
         'd.document_type as "Document Type", '
@@ -235,10 +237,10 @@ def create_query(ingest_cycle_start: str) -> str:
         "on ds.family_document_import_id = d.import_id "
         "LEFT JOIN most_recent_family_slugs fs on fs.family_import_id = f.import_id "
         "LEFT JOIN event_dates fp on fp.family_import_id = f.import_id "
-        "WHERE d.last_modified < '{}' "
+        f"WHERE d.last_modified < '{ingest_cycle_start}' "
         "ORDER BY "
         "d.last_modified desc, d.created desc, d.ctid desc, n1.family_import_id"
-    ).format(ingest_cycle_start)
+    )
     return query
 
 

--- a/app/core/lookups.py
+++ b/app/core/lookups.py
@@ -1,12 +1,7 @@
 import logging
 from typing import Optional, Sequence, cast
 
-from db_client.models.dfce import (
-    FamilyDocumentRole,
-    FamilyDocumentType,
-    Geography,
-    Variant,
-)
+from db_client.models.dfce import FamilyDocumentType, Geography, Variant
 from db_client.models.dfce.family import FamilyDocument, Slug
 from db_client.models.document.physical_document import Language
 from sqlalchemy.exc import MultipleResultsFound
@@ -29,12 +24,6 @@ def get_config(db: Session) -> ApplicationConfig:
             for org in get_all_organisations(db)
         },
         languages={lang.language_code: lang.name for lang in db.query(Language).all()},
-        document_roles=[
-            doc_role.name
-            for doc_role in db.query(FamilyDocumentRole)
-            .order_by(FamilyDocumentRole.name)
-            .all()
-        ],
         document_types=[
             doc_type.name
             for doc_type in db.query(FamilyDocumentType)

--- a/app/db/crud/document.py
+++ b/app/db/crud/document.py
@@ -109,7 +109,7 @@ def get_family_document_and_context(
         language=(visible_languages[0] if visible_languages else ""),
         languages=visible_languages,
         document_type=document.document_type,
-        document_role=document.document_role,
+        document_role=document.valid_metadata["role"][0],
     )
 
     return FamilyDocumentWithContextResponse(family=family_context, document=response)
@@ -244,7 +244,7 @@ def _get_documents_for_family_import_id(
             language=(visible_languages[0] if visible_languages else ""),
             languages=visible_languages,
             document_type=cast(str, d.document_type),
-            document_role=cast(str, d.document_role),
+            document_role=cast(str, d.valid_metadata["role"][0]),  # type:ignore
         )
 
     return [make_response(d) for d in db_documents]

--- a/poetry.lock
+++ b/poetry.lock
@@ -789,7 +789,7 @@ vision = ["Pillow (>=9.4.0)"]
 
 [[package]]
 name = "db-client"
-version = "3.8.4"
+version = "3.8.6"
 description = "All things to do with the datamodel and its storage. Including alembic migrations and datamodel code."
 optional = false
 python-versions = "^3.9"
@@ -809,8 +809,8 @@ SQLAlchemy-Utils = "^0.38.2"
 [package.source]
 type = "git"
 url = "https://github.com/climatepolicyradar/navigator-db-client.git"
-reference = "v3.8.4"
-resolved_reference = "bc2c42dc1c924d51d88d972785a1931e28a8940b"
+reference = "v3.8.6"
+resolved_reference = "1ea889f05a4b5a4c88232ed07285a17275413fd9"
 
 [[package]]
 name = "deprecation"
@@ -2914,7 +2914,6 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -4693,4 +4692,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "7f763d4c6fadb5ffadaf816fa060ed168d52d4e87bb27496e4836c9e2d7e7953"
+content-hash = "0ff95fa249175d57959f03d792c98ee50ee48d48df05504921b2c07639167b90"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "navigator_backend"
-version = "1.13.4"
+version = "1.13.5"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ starlette = "^0.27.0"
 tenacity = "^8.0.1"
 uvicorn = { extras = ["standard"], version = "^0.20.0" }
 botocore = "^1.34.19"
-db-client = { git = "https://github.com/climatepolicyradar/navigator-db-client.git", tag = "v3.8.4" }
+db-client = { git = "https://github.com/climatepolicyradar/navigator-db-client.git", tag = "v3.8.6" }
 urllib3 = "<2"
 apscheduler = "^3.10.4"
 numpy = "1.26.4"

--- a/tests/non_search/app/geographies/setup_world_map_helpers.py
+++ b/tests/non_search/app/geographies/setup_world_map_helpers.py
@@ -25,7 +25,9 @@ def _add_published_fams_and_docs(db: Session):
         "import_id": "CCLW.executive.3.3",
         "language_variant": None,
         "status": "PUBLISHED",
-        "role": "MAIN",
+        "metadata": {
+            "role": ["MAIN"],
+        },
         "type": "Order",
         "languages": [],
         "events": [
@@ -120,7 +122,9 @@ def setup_mixed_doc_statuses_world_map(db: Session):
         "import_id": "CCLW.executive.0.0",
         "language_variant": None,
         "status": "CREATED",
-        "role": "MAIN",
+        "metadata": {
+            "role": ["MAIN"],
+        },
         "type": "Order",
         "languages": [],
         "events": [
@@ -142,7 +146,9 @@ def setup_mixed_doc_statuses_world_map(db: Session):
         "import_id": "CCLW.executive.4.4",
         "language_variant": None,
         "status": "DELETED",
-        "role": "MAIN",
+        "metadata": {
+            "role": ["MAIN"],
+        },
         "type": "Order",
         "languages": [],
         "events": [
@@ -164,7 +170,9 @@ def setup_mixed_doc_statuses_world_map(db: Session):
         "import_id": "CCLW.executive.5.5",
         "language_variant": None,
         "status": "CREATED",
-        "role": "MAIN",
+        "metadata": {
+            "role": ["MAIN"],
+        },
         "type": "Order",
         "languages": [],
         "events": [
@@ -186,7 +194,9 @@ def setup_mixed_doc_statuses_world_map(db: Session):
         "import_id": "CCLW.executive.6.6",
         "language_variant": None,
         "status": "PUBLISHED",
-        "role": "MAIN",
+        "metadata": {
+            "role": ["MAIN"],
+        },
         "type": "Order",
         "languages": [],
         "events": [
@@ -208,7 +218,9 @@ def setup_mixed_doc_statuses_world_map(db: Session):
         "import_id": "CCLW.executive.7.7",
         "language_variant": None,
         "status": "PUBLISHED",
-        "role": "MAIN",
+        "metadata": {
+            "role": ["MAIN"],
+        },
         "type": "Order",
         "languages": [],
         "events": [

--- a/tests/non_search/app/lookups/test_config.py
+++ b/tests/non_search/app/lookups/test_config.py
@@ -72,7 +72,17 @@ def test_config_endpoint_content(data_client, data_db):
     response_json = response.json()
 
     assert response.status_code == OK
-    assert len(response_json) == 6
+    assert (
+        set(response_json.keys())
+        ^ {
+            "geographies",
+            "organisations",
+            "document_variants",
+            "languages",
+            "document_types",
+        }
+        == set()
+    )
 
     assert "geographies" in response_json
     assert len(response_json["geographies"]) == 8
@@ -82,10 +92,6 @@ def test_config_endpoint_content(data_client, data_db):
 
     assert "fra" in response_json["languages"]
     assert all(len(key) == 3 for key in response_json["languages"])
-
-    assert "document_roles" in response_json
-    assert len(response_json["document_roles"]) == 10
-    assert "MAIN" in response_json["document_roles"]
 
     assert "document_types" in response_json
     assert len(response_json["document_types"]) == 76
@@ -127,6 +133,10 @@ def test_config_endpoint_content(data_client, data_db):
     assert cclw_corpora[0]["description"] == "CCLW national policies"
     assert cclw_corpora[0]["title"] == "CCLW national policies"
     assert set(cclw_corpora[0]["taxonomy"]) ^ EXPECTED_CCLW_TAXONOMY == set()
+
+    # Check document roles.
+    assert len(cclw_corpora[0]["taxonomy"]["_document"]["role"]["allowed_values"]) == 10
+    assert "MAIN" in cclw_corpora[0]["taxonomy"]["_document"]["role"]["allowed_values"]
 
 
 def test_config_endpoint_cclw_stats(data_client, data_db):

--- a/tests/non_search/app/lookups/test_config.py
+++ b/tests/non_search/app/lookups/test_config.py
@@ -76,16 +76,21 @@ def test_config_endpoint_content(data_client, data_db):
 
     assert "geographies" in response_json
     assert len(response_json["geographies"]) == 8
+
     assert "languages" in response_json
     assert len(response_json["languages"]) == 7893
+
     assert "fra" in response_json["languages"]
     assert all(len(key) == 3 for key in response_json["languages"])
+
     assert "document_roles" in response_json
     assert len(response_json["document_roles"]) == 10
     assert "MAIN" in response_json["document_roles"]
+
     assert "document_types" in response_json
     assert len(response_json["document_types"]) == 76
     assert "Adaptation Communication" in response_json["document_types"]
+
     assert "document_variants" in response_json
     assert len(response_json["document_variants"]) == 2
     assert "Original Language" in response_json["document_variants"]

--- a/tests/non_search/dfce_helpers.py
+++ b/tests/non_search/dfce_helpers.py
@@ -119,7 +119,7 @@ def add_document(db: Session, family_import_id, d):
             variant_name=d["language_variant"],
             document_status=d["status"],
             document_type=d["type"],
-            document_role=d["role"],
+            valid_metadata=d["metadata"],
         )
     )
     db.flush()

--- a/tests/non_search/setup_helpers.py
+++ b/tests/non_search/setup_helpers.py
@@ -32,7 +32,9 @@ def get_default_documents():
         "import_id": "CCLW.executive.1.2",
         "language_variant": "Original Language",
         "status": "PUBLISHED",
-        "role": "MAIN",
+        "metadata": {
+            "role": ["MAIN"],
+        },
         "type": "Plan",
         "languages": ["eng"],
         "events": [
@@ -55,7 +57,9 @@ def get_default_documents():
         "import_id": "CCLW.executive.2.2",
         "language_variant": None,
         "status": "PUBLISHED",
-        "role": "MAIN",
+        "metadata": {
+            "role": ["MAIN"],
+        },
         "type": "Order",
         "languages": [],
         "events": [

--- a/tests/search/setup_search_tests.py
+++ b/tests/search/setup_search_tests.py
@@ -228,6 +228,7 @@ def _create_document(
         variant_name=variant.variant_name,
         document_status=DocumentStatus.PUBLISHED,
         document_type=doc_type.name,
+        valid_metadata={"role": ["MAIN"]},
     )
 
     family_document_slug = Slug(

--- a/tests/search/test_search.py
+++ b/tests/search/test_search.py
@@ -683,7 +683,7 @@ def populate_data_db(db: Session, fam_specs: Sequence[FamSpec]) -> None:
                 variant_name=None,
                 document_status=DocumentStatus.PUBLISHED,
                 document_type=None,
-                document_role=None,
+                valid_metadata={"role": ["MAIN"]},
             )
             db.add(family_document)
 

--- a/tests/unit/app/schemas/test_schemas.py
+++ b/tests/unit/app/schemas/test_schemas.py
@@ -78,7 +78,7 @@ def test_climate_laws_source_url_filtered_from_document(source_domain_path, sche
         language="",
         languages=[],
         document_type=None,
-        document_role=None,
+        document_role="MAIN",
     )
     assert document_response.source_url is None
 
@@ -102,7 +102,7 @@ def test_non_climate_laws_source_url_left_in_document(source_domain_path, scheme
         language="",
         languages=[],
         document_type=None,
-        document_role=None,
+        document_role="MAIN",
     )
     assert document_response.source_url == given_url
 


### PR DESCRIPTION
# Description

- Remove references to FamilyDocumentRole table a document_role column on FamilyDocument table
- Hardcode document metadata for vespa schema tests
- Get document role from FamilyDocument.valid_metadata instead of FamilyDocument.document_role

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Refactor legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
