### PR TITLE
Feature/pdct 1244 remove references to familydocumenttype

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -173,29 +173,15 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v1.6.1
 
       - name: Publish initial image based on branch to ECR
+        id: retag_and_push_to_ecr
+        uses: climatepolicyradar/retag-and-push-to-ecr@v1
         env:
           DOCKER_REGISTRY: ${{ secrets.DOCKER_REGISTRY }}
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-        shell: bash
-        run: |
-          if [[ "${GITHUB_REF}" == "refs/heads"* ]]; then
-            branch="${GITHUB_REF/refs\/heads\//}"
-            if [[ "${branch}" = "main" ]]; then
-              docker_tag=latest
-              docker tag navigator-backend "$ECR_REGISTRY/navigator-backend:${docker_tag}"
-              docker push "$ECR_REGISTRY/navigator-backend:${docker_tag}"
-            fi
-          elif [[ "${GITHUB_REF}" != "refs/tags"* ]]; then
-            echo "Assuming '${GITHUB_HEAD_REF}' is a branch"
-            if [[ -n "${GITHUB_HEAD_REF}" ]]; then
-                branch="$(echo ${GITHUB_HEAD_REF}| tr -c '[0-9,A-Z,a-z]' '-')"
-                timestamp=$(date --utc -Iseconds | cut -c1-19 | tr -c '[0-9]T\n' '-')
-                short_sha=${GITHUB_SHA:0:8}
-                docker_tag="${branch}-${timestamp}-${short_sha}"
-                docker tag navigator-backend "$ECR_REGISTRY/navigator-backend:${docker_tag}"
-                docker push "$ECR_REGISTRY/navigator-backend:${docker_tag}"
-            fi
-          fi
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        with:
+          repo-name: navigator-backend
+          semver-tag: latest
 
   manual-semver:
     if: ${{ ! cancelled() && always() && startsWith(github.ref, 'refs/tags') }}

--- a/app/api/api_v1/schemas/metadata.py
+++ b/app/api/api_v1/schemas/metadata.py
@@ -31,5 +31,4 @@ class ApplicationConfig(BaseModel):
     geographies: Sequence[dict]
     organisations: Mapping[str, OrganisationConfig]
     languages: Mapping[str, str]
-    document_types: Sequence[str]
     document_variants: Sequence[str]

--- a/app/core/download.py
+++ b/app/core/download.py
@@ -142,7 +142,9 @@ def create_query(ingest_cycle_start: str) -> str:
         '"Document Role", '
         'd.variant_name as "Document Variant", '
         'p.source_url as "Document Content URL", '
-        'd.document_type as "Document Type", '
+        "INITCAP(d.valid_metadata::json#>>'{"
+        "type,0}') as "
+        '"Document Type", '
         "CASE "
         "WHEN f.family_category = 'UNFCCC' THEN 'UNFCCC' "
         "ELSE INITCAP(f.family_category::TEXT) "

--- a/app/core/ingestion/pipeline.py
+++ b/app/core/ingestion/pipeline.py
@@ -55,7 +55,7 @@ def generate_pipeline_ingest_input(db: Session) -> Sequence[DocumentParserInput]
                 else None
             ),
             download_url=None,
-            type=cast(str, family_document.document_type or ""),
+            type=cast(str, family_document.valid_metadata["type"][0]),
             source=cast(str, organisation.name),
             geography=cast(str, geography.value),
             languages=[

--- a/app/core/ingestion/pipeline.py
+++ b/app/core/ingestion/pipeline.py
@@ -55,7 +55,11 @@ def generate_pipeline_ingest_input(db: Session) -> Sequence[DocumentParserInput]
                 else None
             ),
             download_url=None,
-            type=cast(str, family_document.valid_metadata["type"][0]),  # type:ignore
+            type=(
+                cast(str, family_document.valid_metadata["type"][0])  # type:ignore
+                if "type" in family_document.valid_metadata.keys()
+                else ""
+            ),
             source=cast(str, organisation.name),
             geography=cast(str, geography.value),
             languages=[

--- a/app/core/ingestion/pipeline.py
+++ b/app/core/ingestion/pipeline.py
@@ -55,7 +55,7 @@ def generate_pipeline_ingest_input(db: Session) -> Sequence[DocumentParserInput]
                 else None
             ),
             download_url=None,
-            type=cast(str, family_document.valid_metadata["type"][0]),
+            type=cast(str, family_document.valid_metadata["type"][0]),  # type:ignore
             source=cast(str, organisation.name),
             geography=cast(str, geography.value),
             languages=[

--- a/app/core/lookups.py
+++ b/app/core/lookups.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Optional, Sequence, cast
 
-from db_client.models.dfce import FamilyDocumentType, Geography, Variant
+from db_client.models.dfce import Geography, Variant
 from db_client.models.dfce.family import FamilyDocument, Slug
 from db_client.models.document.physical_document import Language
 from sqlalchemy.exc import MultipleResultsFound
@@ -24,12 +24,6 @@ def get_config(db: Session) -> ApplicationConfig:
             for org in get_all_organisations(db)
         },
         languages={lang.language_code: lang.name for lang in db.query(Language).all()},
-        document_types=[
-            doc_type.name
-            for doc_type in db.query(FamilyDocumentType)
-            .order_by(FamilyDocumentType.name)
-            .all()
-        ],
         document_variants=[
             variant.variant_name
             for variant in db.query(Variant).order_by(Variant.variant_name).all()

--- a/app/core/search.py
+++ b/app/core/search.py
@@ -449,7 +449,9 @@ def _process_vespa_search_response_families(
                     response_document = SearchResponseFamilyDocument(
                         document_title=str(db_family_document.physical_document.title),
                         document_slug=hit.document_slug,
-                        document_type=str(db_family_document.document_type),
+                        document_type=cast(
+                            str, db_family_document.valid_metadata["type"][0]
+                        ),
                         document_source_url=hit.document_source_url,
                         document_url=to_cdn_url(hit.document_cdn_object),
                         document_content_type=hit.document_content_type,

--- a/app/core/search.py
+++ b/app/core/search.py
@@ -219,7 +219,9 @@ def process_result_into_csv(
                     "Document Title": document_title,
                     "Document URL": f"{url_base}/{document.slugs[-1].name}",
                     "Document Content URL": document_content,
-                    "Document Type": cast(str, document.valid_metadata["type"][0]),
+                    "Document Type": cast(
+                        str, document.valid_metadata["type"][0]  # type:ignore
+                    ),
                     "Document Content Matches Search Phrase": document_match,
                     "Geography": family.family_geography,
                     "Category": family.family_category,
@@ -450,7 +452,8 @@ def _process_vespa_search_response_families(
                         document_title=str(db_family_document.physical_document.title),
                         document_slug=hit.document_slug,
                         document_type=cast(
-                            str, db_family_document.valid_metadata["type"][0]
+                            str,
+                            db_family_document.valid_metadata["type"][0],  # type:ignore
                         ),
                         document_source_url=hit.document_source_url,
                         document_url=to_cdn_url(hit.document_cdn_object),

--- a/app/core/search.py
+++ b/app/core/search.py
@@ -219,7 +219,7 @@ def process_result_into_csv(
                     "Document Title": document_title,
                     "Document URL": f"{url_base}/{document.slugs[-1].name}",
                     "Document Content URL": document_content,
-                    "Document Type": document.document_type,
+                    "Document Type": cast(str, document.valid_metadata["type"][0]),
                     "Document Content Matches Search Phrase": document_match,
                     "Geography": family.family_geography,
                     "Category": family.family_category,

--- a/app/core/search.py
+++ b/app/core/search.py
@@ -219,8 +219,12 @@ def process_result_into_csv(
                     "Document Title": document_title,
                     "Document URL": f"{url_base}/{document.slugs[-1].name}",
                     "Document Content URL": document_content,
-                    "Document Type": cast(
-                        str, document.valid_metadata["type"][0]  # type:ignore
+                    "Document Type": (
+                        cast(
+                            str, document.valid_metadata["type"][0]  # type:ignore
+                        )
+                        if "type" in document.valid_metadata.keys()
+                        else ""
                     ),
                     "Document Content Matches Search Phrase": document_match,
                     "Geography": family.family_geography,
@@ -451,9 +455,10 @@ def _process_vespa_search_response_families(
                     response_document = SearchResponseFamilyDocument(
                         document_title=str(db_family_document.physical_document.title),
                         document_slug=hit.document_slug,
-                        document_type=cast(
-                            str,
-                            db_family_document.valid_metadata["type"][0],  # type:ignore
+                        document_type=(
+                            db_family_document.valid_metadata["type"][0]  # type:ignore
+                            if "type" in db_family_document.valid_metadata.keys()
+                            else ""
                         ),
                         document_source_url=hit.document_source_url,
                         document_url=to_cdn_url(hit.document_cdn_object),

--- a/app/db/crud/document.py
+++ b/app/db/crud/document.py
@@ -243,7 +243,7 @@ def _get_documents_for_family_import_id(
             content_type=cast(str, d.physical_document.content_type),
             language=(visible_languages[0] if visible_languages else ""),
             languages=visible_languages,
-            document_type=cast(str, d.valid_metadata["type"][0]),
+            document_type=cast(str, d.valid_metadata["type"][0]),  # type:ignore
             document_role=cast(str, d.valid_metadata["role"][0]),  # type:ignore
         )
 

--- a/app/db/crud/document.py
+++ b/app/db/crud/document.py
@@ -80,11 +80,6 @@ def get_family_document_and_context(
 
     family, document, physical_document, geography, family_corpus = db_objects
 
-    if set(document.valid_metadata.keys()) ^ set(["role", "type"]) != set():
-        raise AttributeError(
-            "Additional document metadata keys present compared to what is expected"
-        )
-
     if (
         family.family_status != FamilyStatus.PUBLISHED
         or document.document_status != DocumentStatus.PUBLISHED
@@ -113,8 +108,16 @@ def get_family_document_and_context(
         content_type=physical_document.content_type,
         language=(visible_languages[0] if visible_languages else ""),
         languages=visible_languages,
-        document_type=document.valid_metadata["type"][0],
-        document_role=document.valid_metadata["role"][0],
+        document_type=(
+            document.valid_metadata["type"][0]
+            if "type" in document.valid_metadata.keys()
+            else ""
+        ),
+        document_role=(
+            document.valid_metadata["role"][0]
+            if "role" in document.valid_metadata.keys()
+            else ""
+        ),
     )
 
     return FamilyDocumentWithContextResponse(family=family_context, document=response)
@@ -248,8 +251,16 @@ def _get_documents_for_family_import_id(
             content_type=cast(str, d.physical_document.content_type),
             language=(visible_languages[0] if visible_languages else ""),
             languages=visible_languages,
-            document_type=cast(str, d.valid_metadata["type"][0]),  # type:ignore
-            document_role=cast(str, d.valid_metadata["role"][0]),  # type:ignore
+            document_type=(
+                cast(str, d.valid_metadata["type"][0])  # type:ignore
+                if "type" in d.valid_metadata.keys()
+                else ""
+            ),
+            document_role=(
+                cast(str, d.valid_metadata["role"][0])  # type:ignore
+                if "role" in d.valid_metadata.keys()
+                else ""
+            ),
         )
 
     return [make_response(d) for d in db_documents]

--- a/app/db/crud/document.py
+++ b/app/db/crud/document.py
@@ -80,6 +80,11 @@ def get_family_document_and_context(
 
     family, document, physical_document, geography, family_corpus = db_objects
 
+    if set(document.valid_metadata.keys()) ^ set(["role", "type"]) != set():
+        raise AttributeError(
+            "Additional document metadata keys present compared to what is expected"
+        )
+
     if (
         family.family_status != FamilyStatus.PUBLISHED
         or document.document_status != DocumentStatus.PUBLISHED

--- a/app/db/crud/document.py
+++ b/app/db/crud/document.py
@@ -108,7 +108,7 @@ def get_family_document_and_context(
         content_type=physical_document.content_type,
         language=(visible_languages[0] if visible_languages else ""),
         languages=visible_languages,
-        document_type=document.document_type,
+        document_type=document.valid_metadata["type"][0],
         document_role=document.valid_metadata["role"][0],
     )
 
@@ -243,7 +243,7 @@ def _get_documents_for_family_import_id(
             content_type=cast(str, d.physical_document.content_type),
             language=(visible_languages[0] if visible_languages else ""),
             languages=visible_languages,
-            document_type=cast(str, d.document_type),
+            document_type=cast(str, d.valid_metadata["type"][0]),
             document_role=cast(str, d.valid_metadata["role"][0]),  # type:ignore
         )
 

--- a/app/main.py
+++ b/app/main.py
@@ -56,7 +56,7 @@ DEFAULT_LOGGING = {
         "level": LOG_LEVEL,
     },
 }
-logger = logging.getLogger(__name__)
+_LOGGER = logging.getLogger(__name__)
 logging.config.dictConfig(DEFAULT_LOGGING)
 
 _docs_description = """
@@ -77,10 +77,10 @@ _openapi_url = "/api" if ENABLE_API_DOCS else None
 @asynccontextmanager
 async def lifespan(app_: FastAPI):
     """Run startup and shutdown events."""
-    logger.info("Starting up...")
+    _LOGGER.info("Starting up...")
     run_migrations(engine)
     yield
-    logger.info("Shutting down...")
+    _LOGGER.info("Shutting down...")
 
 
 app = FastAPI(

--- a/poetry.lock
+++ b/poetry.lock
@@ -789,7 +789,7 @@ vision = ["Pillow (>=9.4.0)"]
 
 [[package]]
 name = "db-client"
-version = "3.8.6"
+version = "3.8.9"
 description = "All things to do with the datamodel and its storage. Including alembic migrations and datamodel code."
 optional = false
 python-versions = "^3.9"
@@ -809,8 +809,8 @@ SQLAlchemy-Utils = "^0.38.2"
 [package.source]
 type = "git"
 url = "https://github.com/climatepolicyradar/navigator-db-client.git"
-reference = "v3.8.6"
-resolved_reference = "1ea889f05a4b5a4c88232ed07285a17275413fd9"
+reference = "v3.8.9"
+resolved_reference = "a6985c6d42be5fd5549deb693b60fd7b2694b97a"
 
 [[package]]
 name = "deprecation"
@@ -2914,7 +2914,6 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -4693,4 +4692,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "0ff95fa249175d57959f03d792c98ee50ee48d48df05504921b2c07639167b90"
+content-hash = "c064dd7101cc15234e8771337907ab64d20acbcf09805ffcf343ae8269640934"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "navigator_backend"
-version = "1.14.0"
+version = "1.14.1"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ starlette = "^0.27.0"
 tenacity = "^8.0.1"
 uvicorn = { extras = ["standard"], version = "^0.20.0" }
 botocore = "^1.34.19"
-db-client = { git = "https://github.com/climatepolicyradar/navigator-db-client.git", tag = "v3.8.6" }
+db-client = { git = "https://github.com/climatepolicyradar/navigator-db-client.git", tag = "v3.8.9" }
 urllib3 = "<2"
 apscheduler = "^3.10.4"
 numpy = "1.26.4"

--- a/tests/non_search/app/geographies/setup_world_map_helpers.py
+++ b/tests/non_search/app/geographies/setup_world_map_helpers.py
@@ -25,10 +25,7 @@ def _add_published_fams_and_docs(db: Session):
         "import_id": "CCLW.executive.3.3",
         "language_variant": None,
         "status": "PUBLISHED",
-        "metadata": {
-            "role": ["MAIN"],
-        },
-        "type": "Order",
+        "metadata": {"role": ["MAIN"], "type": ["Order"]},
         "languages": [],
         "events": [
             {
@@ -122,10 +119,7 @@ def setup_mixed_doc_statuses_world_map(db: Session):
         "import_id": "CCLW.executive.0.0",
         "language_variant": None,
         "status": "CREATED",
-        "metadata": {
-            "role": ["MAIN"],
-        },
-        "type": "Order",
+        "metadata": {"role": ["MAIN"], "type": ["Order"]},
         "languages": [],
         "events": [
             {
@@ -146,10 +140,7 @@ def setup_mixed_doc_statuses_world_map(db: Session):
         "import_id": "CCLW.executive.4.4",
         "language_variant": None,
         "status": "DELETED",
-        "metadata": {
-            "role": ["MAIN"],
-        },
-        "type": "Order",
+        "metadata": {"role": ["MAIN"], "type": ["Order"]},
         "languages": [],
         "events": [
             {
@@ -170,10 +161,7 @@ def setup_mixed_doc_statuses_world_map(db: Session):
         "import_id": "CCLW.executive.5.5",
         "language_variant": None,
         "status": "CREATED",
-        "metadata": {
-            "role": ["MAIN"],
-        },
-        "type": "Order",
+        "metadata": {"role": ["MAIN"], "type": ["Order"]},
         "languages": [],
         "events": [
             {
@@ -194,10 +182,7 @@ def setup_mixed_doc_statuses_world_map(db: Session):
         "import_id": "CCLW.executive.6.6",
         "language_variant": None,
         "status": "PUBLISHED",
-        "metadata": {
-            "role": ["MAIN"],
-        },
-        "type": "Order",
+        "metadata": {"role": ["MAIN"], "type": ["Order"]},
         "languages": [],
         "events": [
             {
@@ -218,10 +203,7 @@ def setup_mixed_doc_statuses_world_map(db: Session):
         "import_id": "CCLW.executive.7.7",
         "language_variant": None,
         "status": "PUBLISHED",
-        "metadata": {
-            "role": ["MAIN"],
-        },
-        "type": "Order",
+        "metadata": {"role": ["MAIN"], "type": ["Order"]},
         "languages": [],
         "events": [
             {

--- a/tests/non_search/app/lookups/test_config.py
+++ b/tests/non_search/app/lookups/test_config.py
@@ -79,7 +79,6 @@ def test_config_endpoint_content(data_client, data_db):
             "organisations",
             "document_variants",
             "languages",
-            "document_types",
         }
         == set()
     )
@@ -92,10 +91,6 @@ def test_config_endpoint_content(data_client, data_db):
 
     assert "fra" in response_json["languages"]
     assert all(len(key) == 3 for key in response_json["languages"])
-
-    assert "document_types" in response_json
-    assert len(response_json["document_types"]) == 76
-    assert "Adaptation Communication" in response_json["document_types"]
 
     assert "document_variants" in response_json
     assert len(response_json["document_variants"]) == 2
@@ -135,8 +130,17 @@ def test_config_endpoint_content(data_client, data_db):
     assert set(cclw_corpora[0]["taxonomy"]) ^ EXPECTED_CCLW_TAXONOMY == set()
 
     # Check document roles.
+    assert "role" in cclw_corpora[0]["taxonomy"]["_document"].keys()
     assert len(cclw_corpora[0]["taxonomy"]["_document"]["role"]["allowed_values"]) == 10
     assert "MAIN" in cclw_corpora[0]["taxonomy"]["_document"]["role"]["allowed_values"]
+
+    # Check document roles.
+    assert "type" in cclw_corpora[0]["taxonomy"]["_document"].keys()
+    assert len(cclw_corpora[0]["taxonomy"]["_document"]["type"]["allowed_values"]) == 76
+    assert (
+        "Adaptation Communication"
+        in cclw_corpora[0]["taxonomy"]["_document"]["type"]["allowed_values"]
+    )
 
 
 def test_config_endpoint_cclw_stats(data_client, data_db):

--- a/tests/non_search/conftest.py
+++ b/tests/non_search/conftest.py
@@ -1,9 +1,5 @@
 import pytest
-from db_client.models.dfce import (  # noqa F401
-    FamilyDocument,
-    FamilyDocumentType,
-    Geography,
-)
+from db_client.models.dfce import Geography
 from db_client.models.organisation import Organisation
 
 template_doc = {
@@ -30,11 +26,9 @@ def summary_geography_family_data(test_db):
             display_value="A place in the sea", slug="a-place-in-the-sea", value="YYY"
         ),
     ]
-    doc_types = [FamilyDocumentType(name="doctype", description="for testing")]
     organisations = [Organisation(name="test org")]
 
     test_db.add_all(geos)
-    test_db.add_all(doc_types)
     test_db.add_all(organisations)
     test_db.flush()
 
@@ -59,7 +53,6 @@ def summary_geography_family_data(test_db):
         "docs": documents,
         "families": documents,
         "geos": geos,
-        "doc_types": doc_types,
         "organisations": organisations,
         "events": events,
     }

--- a/tests/non_search/dfce_helpers.py
+++ b/tests/non_search/dfce_helpers.py
@@ -118,7 +118,6 @@ def add_document(db: Session, family_import_id, d):
             import_id=d["import_id"],
             variant_name=d["language_variant"],
             document_status=d["status"],
-            document_type=d["type"],
             valid_metadata=d["metadata"],
         )
     )

--- a/tests/non_search/setup_helpers.py
+++ b/tests/non_search/setup_helpers.py
@@ -32,10 +32,7 @@ def get_default_documents():
         "import_id": "CCLW.executive.1.2",
         "language_variant": "Original Language",
         "status": "PUBLISHED",
-        "metadata": {
-            "role": ["MAIN"],
-        },
-        "type": "Plan",
+        "metadata": {"role": ["MAIN"], "type": "Plan"},
         "languages": ["eng"],
         "events": [
             {
@@ -57,10 +54,7 @@ def get_default_documents():
         "import_id": "CCLW.executive.2.2",
         "language_variant": None,
         "status": "PUBLISHED",
-        "metadata": {
-            "role": ["MAIN"],
-        },
-        "type": "Order",
+        "metadata": {"role": ["MAIN"], "type": "Order"},
         "languages": [],
         "events": [
             {

--- a/tests/non_search/setup_helpers.py
+++ b/tests/non_search/setup_helpers.py
@@ -54,7 +54,7 @@ def get_default_documents():
         "import_id": "CCLW.executive.2.2",
         "language_variant": None,
         "status": "PUBLISHED",
-        "metadata": {"role": ["MAIN"], "type": "Order"},
+        "metadata": {"role": ["MAIN"], "type": ["Order"]},
         "languages": [],
         "events": [
             {

--- a/tests/search/setup_search_tests.py
+++ b/tests/search/setup_search_tests.py
@@ -11,7 +11,6 @@ from db_client.models.dfce.family import (
     FamilyCategory,
     FamilyCorpus,
     FamilyDocument,
-    FamilyDocumentType,
     FamilyEvent,
     Geography,
     Slug,
@@ -212,12 +211,6 @@ def _create_document(
     db.merge(variant)
     db.commit()
 
-    doc_type = FamilyDocumentType(
-        name=family["fields"]["family_category"], description=""
-    )
-    db.merge(doc_type)
-    db.commit()
-
     family_import_id = family["fields"]["family_import_id"]
     doc_import_id = family["fields"]["document_import_id"]
 
@@ -227,8 +220,10 @@ def _create_document(
         import_id=doc_import_id,
         variant_name=variant.variant_name,
         document_status=DocumentStatus.PUBLISHED,
-        document_type=doc_type.name,
-        valid_metadata={"role": ["MAIN"]},
+        valid_metadata={
+            "role": ["MAIN"],
+            "type": [family["fields"]["family_category"]],
+        },
     )
 
     family_document_slug = Slug(

--- a/tests/search/test_search.py
+++ b/tests/search/test_search.py
@@ -682,8 +682,7 @@ def populate_data_db(db: Session, fam_specs: Sequence[FamSpec]) -> None:
                 import_id=f"{fam_spec.family_import_id}.{i}",
                 variant_name=None,
                 document_status=DocumentStatus.PUBLISHED,
-                document_type=None,
-                valid_metadata={"role": ["MAIN"]},
+                valid_metadata={"role": ["MAIN"], "type": ["Law"]},
             )
             db.add(family_document)
 

--- a/tests/unit/app/schemas/test_schemas.py
+++ b/tests/unit/app/schemas/test_schemas.py
@@ -77,7 +77,7 @@ def test_climate_laws_source_url_filtered_from_document(source_domain_path, sche
         content_type=None,
         language="",
         languages=[],
-        document_type=None,
+        document_type="Law",
         document_role="MAIN",
     )
     assert document_response.source_url is None
@@ -101,7 +101,7 @@ def test_non_climate_laws_source_url_left_in_document(source_domain_path, scheme
         content_type=None,
         language="",
         languages=[],
-        document_type=None,
+        document_type="Law",
         document_role="MAIN",
     )
     assert document_response.source_url == given_url


### PR DESCRIPTION
# Description

- Bump db client to 3.8.9
- Remove all references to FamilyDocumentType and family_document_type
- Remove all references to document_type column on FamilyDocument

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Refactor legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
