### PR TITLE
Fix retrieving document type from metadata

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -19,7 +19,7 @@ jobs:
     if: |
       github.event_name == 'pull_request' &&
       (! startsWith(github.ref, 'refs/tags') && ! startsWith(github.ref, 'refs/heads/main'))
-    uses: climatepolicyradar/reusable-workflows/.github/workflows/check-auto-tagging-will-work.yml@v8
+    uses: climatepolicyradar/reusable-workflows/.github/workflows/check-auto-tagging-will-work.yml@v3
 
   code-quality:
     if: |
@@ -33,7 +33,7 @@ jobs:
       checks: write
       # For repo checkout
       contents: read
-    uses: climatepolicyradar/reusable-workflows/.github/workflows/python-precommit-validator.yml@v8
+    uses: climatepolicyradar/reusable-workflows/.github/workflows/python-precommit-validator.yml@v7
 
   non-search-tests:
     if: |
@@ -185,7 +185,7 @@ jobs:
 
   manual-semver:
     if: ${{ ! cancelled() && always() && startsWith(github.ref, 'refs/tags') }}
-    uses: climatepolicyradar/reusable-workflows/.github/workflows/semver.yml@v8
+    uses: climatepolicyradar/reusable-workflows/.github/workflows/semver.yml@v3
     secrets: inherit
     with:
       repo-name: navigator-backend
@@ -196,7 +196,7 @@ jobs:
     needs: build
     permissions:
       contents: write
-    uses: climatepolicyradar/reusable-workflows/.github/workflows/tag.yml@v8
+    uses: climatepolicyradar/reusable-workflows/.github/workflows/tag.yml@v3
     with:
       repo-name: navigator-backend
       semver-tag: main-${GITHUB_SHA::8}
@@ -210,6 +210,6 @@ jobs:
     needs: tag
     permissions:
       contents: write
-    uses: climatepolicyradar/reusable-workflows/.github/workflows/release.yml@v8
+    uses: climatepolicyradar/reusable-workflows/.github/workflows/release.yml@v3
     with:
       new_tag: ${{ needs.tag.outputs.new_tag }}

--- a/app/core/ingestion/pipeline.py
+++ b/app/core/ingestion/pipeline.py
@@ -14,6 +14,7 @@ from db_client.models.organisation import Organisation
 from sqlalchemy.orm import Session
 
 from app.api.api_v1.schemas.document import DocumentParserInput
+from app.core.lookups import doc_type_from_family_document_metadata
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -55,11 +56,7 @@ def generate_pipeline_ingest_input(db: Session) -> Sequence[DocumentParserInput]
                 else None
             ),
             download_url=None,
-            type=(
-                cast(str, family_document.valid_metadata["type"][0])  # type:ignore
-                if "type" in family_document.valid_metadata.keys()
-                else ""
-            ),
+            type=doc_type_from_family_document_metadata(family_document),
             source=cast(str, organisation.name),
             geography=cast(str, geography.value),
             languages=[

--- a/app/core/lookups.py
+++ b/app/core/lookups.py
@@ -119,3 +119,15 @@ def get_family_document_by_import_id_or_slug(
             .one_or_none()
         )
     return family_document
+
+
+def doc_type_from_family_document_metadata(family_document: FamilyDocument) -> str:
+    """Retrieves the document type from FamilyDocument metadata
+
+    If the field is missing, empty or None, returns an empty string
+    Will also return at empty string if the first value of metadata is None
+    """
+    doctype: list = family_document.valid_metadata.get("type")
+    if not doctype or len(doctype) == 0:
+        return ""
+    return cast(str, doctype[0] or "")

--- a/app/db/crud/document.py
+++ b/app/db/crud/document.py
@@ -33,6 +33,7 @@ from app.api.api_v1.schemas.document import (
     FamilyEventsResponse,
     LinkableFamily,
 )
+from app.core.lookups import doc_type_from_family_document_metadata
 from app.core.util import to_cdn_url
 
 _LOGGER = logging.getLogger(__file__)
@@ -108,11 +109,7 @@ def get_family_document_and_context(
         content_type=physical_document.content_type,
         language=(visible_languages[0] if visible_languages else ""),
         languages=visible_languages,
-        document_type=(
-            document.valid_metadata["type"][0]
-            if "type" in document.valid_metadata.keys()
-            else ""
-        ),
+        document_type=doc_type_from_family_document_metadata(document),
         document_role=(
             document.valid_metadata["role"][0]
             if "role" in document.valid_metadata.keys()
@@ -251,11 +248,7 @@ def _get_documents_for_family_import_id(
             content_type=cast(str, d.physical_document.content_type),
             language=(visible_languages[0] if visible_languages else ""),
             languages=visible_languages,
-            document_type=(
-                cast(str, d.valid_metadata["type"][0])  # type:ignore
-                if "type" in d.valid_metadata.keys()
-                else ""
-            ),
+            document_type=doc_type_from_family_document_metadata(d),
             document_role=(
                 cast(str, d.valid_metadata["role"][0])  # type:ignore
                 if "role" in d.valid_metadata.keys()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "navigator_backend"
-version = "1.14.2"
+version = "1.14.3"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]

--- a/tests/core/test_lookups.py
+++ b/tests/core/test_lookups.py
@@ -1,0 +1,27 @@
+import pytest
+from db_client.models.dfce import FamilyDocument
+
+from app.core.lookups import doc_type_from_family_document_metadata
+
+
+@pytest.mark.parametrize(
+    ("metadata", "expected"),
+    (
+        ({"role": ["MAIN"], "type": ["Law"]}, "Law"),
+        ({"role": ["MAIN"], "type": ["Law", "Executive"]}, "Law"),
+        ({"role": ["MAIN"], "type": [None]}, ""),
+        ({"role": ["MAIN"], "type": []}, ""),
+        ({"role": ["MAIN"]}, ""),
+    ),
+)
+def test_doc_type_from_family_document_metadata(metadata, expected):
+    family_document = FamilyDocument(
+        family_import_id="test.1",
+        physical_document_id="test.1",
+        import_id="test.1",
+        variant_name=None,
+        document_status="Published",
+        valid_metadata=metadata,
+    )
+    result = doc_type_from_family_document_metadata(family_document)
+    assert result == expected


### PR DESCRIPTION
# Description

The pipeline trigger was failing due to a validation error on the document type:

```
1 validation error for DocumentParserInput
type
  Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
```

There was an update last week to how we determine the document type. It seems there are situations when this can evaluate to None. Here we extract the logic into its own function so we can apply a fix and test various conditions.

## Note

This approach might also be made more generalisable to extract any metadata field. I've left this for someone else as I'm just trying to fix the pipeline trigger

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Refactor legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
