### PR TITLE
Force `DocumentParserInput` type to be string

### DIFF
--- a/app/api/api_v1/schemas/document.py
+++ b/app/api/api_v1/schemas/document.py
@@ -129,13 +129,18 @@ class DocumentParserInput(BaseModel):
     family_import_id: str
     family_slug: str
 
-    type: str
+    type: str = ""
     source: str
     category: str
     geography: str
     languages: Sequence[str]
 
     metadata: Json
+
+    @field_validator("type", mode="before")
+    @classmethod
+    def none_to_empty_string(cls, value):
+        return "" if value is None else value
 
     def to_json(self) -> Mapping[str, Any]:
         """Provide a serialisable version of the model"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "navigator_backend"
-version = "1.14.3"
+version = "1.14.4"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]

--- a/tests/core/test_lookups.py
+++ b/tests/core/test_lookups.py
@@ -9,9 +9,13 @@ from app.core.lookups import doc_type_from_family_document_metadata
     (
         ({"role": ["MAIN"], "type": ["Law"]}, "Law"),
         ({"role": ["MAIN"], "type": ["Law", "Executive"]}, "Law"),
+        ({"role": ["MAIN"], "type": ["Law", None]}, "Law"),
         ({"role": ["MAIN"], "type": [None]}, ""),
+        ({"role": ["MAIN"], "type": [None, "Law"]}, ""),
         ({"role": ["MAIN"], "type": []}, ""),
+        ({"role": ["MAIN"], "type": None}, ""),
         ({"role": ["MAIN"]}, ""),
+        ({}, ""),
     ),
 )
 def test_doc_type_from_family_document_metadata(metadata, expected):

--- a/tests/non_search/core/validation/test_util.py
+++ b/tests/non_search/core/validation/test_util.py
@@ -72,6 +72,28 @@ def test__flatten_maybe_tree_is_a_tree(is_a_tree: Sequence, expected: Collection
     assert _flatten_maybe_tree(is_a_tree) == expected
 
 
+def test_document_parser_input_type():
+    """Check type is converted to string when null"""
+    d = DocumentParserInput(
+        publication_ts=datetime.datetime(year=2008, month=12, day=25),
+        name="name",
+        description="description",
+        source_url=None,
+        download_url=None,
+        type=None,  # pyright: ignore[reportArgumentType]
+        source="CCLW",
+        import_id="1234-5678",
+        slug="geo_2008_name_1234_5678",
+        family_import_id="family_1234-5678",
+        family_slug="geo_2008_family_1234_5679",
+        category="category",
+        geography="GEO",
+        languages=[],
+        metadata={},
+    )
+    assert d.type == ""
+
+
 def test_write_documents_to_s3(test_s3_client, mocker):
     """Really simple check that values are passed to the s3 client correctly"""
     d = DocumentParserInput(


### PR DESCRIPTION
Somehow we are still getting None's passed to the pipeline trigger in production. This adds type coercion to the actual model.

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Refactor legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
