### PR TITLE
Feature/pdct 1299 encode a configuration token for custom apps

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -82,7 +82,6 @@ actions:
   disabled:
     - trunk-check-pre-push
   enabled:
-    - git-lfs
     - configure-pyright-with-pyenv
     - trunk-check-pre-commit
     - trunk-announce

--- a/app/core/custom_app.py
+++ b/app/core/custom_app.py
@@ -59,7 +59,5 @@ def create_configuration_token(
         "allowed_corpora_ids": corpora_ids,
         "exp": expire,
         "iat": datetime.timestamp(issued_at.replace(microsecond=0)),  # No microseconds
-        # "aud": theme,
-        # "sub": theme,
     }
     return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)

--- a/app/core/custom_app.py
+++ b/app/core/custom_app.py
@@ -44,7 +44,8 @@ def create_configuration_token(
     :return str: A JWT token containing the encoded allowed corpora.
     """
     expiry_weeks = weeks or CUSTOM_APP_TOKEN_EXPIRE_WEEKS
-    expire = datetime.utcnow() + timedelta(weeks=expiry_weeks)
+    issued_at = datetime.utcnow()
+    expire = issued_at + timedelta(weeks=expiry_weeks)
 
     corpora_ids = allowed_corpora.split(",")
     corpora_ids.sort()
@@ -54,5 +55,5 @@ def create_configuration_token(
     msg += f"for the following corpora: {corpora_ids}"
     print(msg)
 
-    to_encode = {"allowed_corpora_ids": corpora_ids, "exp": expire}
+    to_encode = {"allowed_corpora_ids": corpora_ids, "exp": expire, "iat": issued_at}
     return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)

--- a/app/core/theming.py
+++ b/app/core/theming.py
@@ -1,0 +1,26 @@
+import os
+
+from db_client.models.dfce.family import Corpus
+from sqlalchemy.orm import Session
+
+from app.db.session import get_db
+
+SECRET_KEY = os.environ["SECRET_KEY"]
+ALGORITHM = "HS256"
+
+
+def validate(db: Session, allowed_corpora_ids: list[str]) -> bool:
+    """Validate whether a corpus with the given ID exists in the DB.
+
+    :param Session db: The DB session to connect to.
+    :param str corpus_id: The corpus import ID we want to validate.
+    :return bool: Return whether or not the corpus exists in the DB.
+    """
+    existing_corpora_in_db = db.query(Corpus.import_id).distinct().all()
+    return all(corpus in existing_corpora_in_db for corpus in allowed_corpora_ids)
+
+
+def create_configuration_token(allowed_corpora: str):
+    db = next(get_db())
+    corpora_ids = allowed_corpora.split(",")
+    print(validate(db, corpora_ids))

--- a/app/core/theming.py
+++ b/app/core/theming.py
@@ -1,26 +1,38 @@
+import logging
 import os
 
+import jwt
 from db_client.models.dfce.family import Corpus
 from sqlalchemy.orm import Session
 
-from app.db.session import get_db
+_LOGGER = logging.getLogger(__name__)
 
 SECRET_KEY = os.environ["SECRET_KEY"]
 ALGORITHM = "HS256"
 
 
 def validate(db: Session, allowed_corpora_ids: list[str]) -> bool:
-    """Validate whether a corpus with the given ID exists in the DB.
+    """Validate whether all given corpus IDs exist in the DB.
 
     :param Session db: The DB session to connect to.
-    :param str corpus_id: The corpus import ID we want to validate.
-    :return bool: Return whether or not the corpus exists in the DB.
+    :param list[str] allowed_corpora_ids: The corpus import IDs we want
+        to validate.
+    :return bool: Return whether or not all the corpora exist in the DB.
     """
     existing_corpora_in_db = db.query(Corpus.import_id).distinct().all()
     return all(corpus in existing_corpora_in_db for corpus in allowed_corpora_ids)
 
 
-def create_configuration_token(allowed_corpora: str):
-    db = next(get_db())
+def create_configuration_token(allowed_corpora: str) -> str:
+    """Create a custom app configuration token.
+
+    :param str allowed_corpora: A comma separated string containing the
+        corpus import IDs that the custom app should show.
+    :return str: A JWT token containing the encoded allowed corpora.
+    """
     corpora_ids = allowed_corpora.split(",")
-    print(validate(db, corpora_ids))
+    msg = "Creating custom app configuration token for the following corpora:"
+    msg += f" {corpora_ids}"
+    _LOGGER.info(msg)
+    to_encode = {"allowed_corpora_ids": corpora_ids}
+    return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)

--- a/poetry.lock
+++ b/poetry.lock
@@ -2914,7 +2914,6 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -3932,6 +3931,14 @@ name = "torch"
 version = "2.0.0+cpu"
 description = "Tensors and Dynamic neural networks in Python with strong GPU acceleration"
 optional = false
+python-versions = "*"
+files = []
+
+[[package]]
+name = "torch"
+version = "2.0.0+cpu"
+description = "Tensors and Dynamic neural networks in Python with strong GPU acceleration"
+optional = false
 python-versions = ">=3.8.0"
 files = [
     {file = "torch-2.0.0+cpu-cp310-cp310-linux_x86_64.whl", hash = "sha256:7c9e668462cd0813fc4baaeaa137efce2516e73cf381120846edf45d4ec21174"},
@@ -4717,4 +4724,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "9a3d4adb5ed4c1c28524ed9737c4f98a0e7d0659e6c7afda73b472a3093bdbe7"
+content-hash = "f22b376c7e477d876daceb8bc6debfaccdeabd59e283bd61bf6be6f551622495"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2914,6 +2914,7 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -3904,6 +3905,30 @@ url = "https://download.pytorch.org/whl/cpu/torch-2.0.0-cp39-none-macosx_10_9_x8
 
 [[package]]
 name = "torch"
+version = "2.0.0"
+description = "Tensors and Dynamic neural networks in Python with strong GPU acceleration"
+optional = false
+python-versions = ">=3.8.0"
+files = [
+    {file = "torch-2.0.0-cp39-none-macosx_11_0_arm64.whl", hash = "sha256:297a4919aff1c0f98a58ebe969200f71350a1d4d4f986dbfd60c02ffce780e99"},
+]
+
+[package.dependencies]
+filelock = "*"
+jinja2 = "*"
+networkx = "*"
+sympy = "*"
+typing-extensions = "*"
+
+[package.extras]
+opt-einsum = ["opt-einsum (>=3.3)"]
+
+[package.source]
+type = "url"
+url = "https://download.pytorch.org/whl/cpu/torch-2.0.0-cp39-none-macosx_11_0_arm64.whl"
+
+[[package]]
+name = "torch"
 version = "2.0.0+cpu"
 description = "Tensors and Dynamic neural networks in Python with strong GPU acceleration"
 optional = false
@@ -4692,4 +4717,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "c064dd7101cc15234e8771337907ab64d20acbcf09805ffcf343ae8269640934"
+content-hash = "9a3d4adb5ed4c1c28524ed9737c4f98a0e7d0659e6c7afda73b472a3093bdbe7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "navigator_backend"
-version = "1.14.4"
+version = "1.14.5"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ torch = [
   { platform = "linux", version = "2.0.0", source = "pytorch" },
   { platform = "win32", version = "2.0.0", source = "pytorch" },
 ]
+python-dateutil = "^2.9.0.post0"
 
 [[tool.poetry.source]]
 name = "pytorch"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "navigator_backend"
-version = "1.14.5"
+version = "1.14.6"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,8 @@ urllib3 = "<2"
 apscheduler = "^3.10.4"
 numpy = "1.26.4"
 torch = [
-  { platform = "darwin", url = "https://download.pytorch.org/whl/cpu/torch-2.0.0-cp39-none-macosx_10_9_x86_64.whl" },
+  { platform = "darwin", url = "https://download.pytorch.org/whl/cpu/torch-2.0.0-cp39-none-macosx_10_9_x86_64.whl", markers = "platform_machine=='amd64'" },
+  { platform = "darwin", url = "https://download.pytorch.org/whl/cpu/torch-2.0.0-cp39-none-macosx_11_0_arm64.whl", markers = "platform_machine=='arm64'" },
   { platform = "linux", version = "2.0.0", source = "pytorch" },
   { platform = "win32", version = "2.0.0", source = "pytorch" },
 ]

--- a/tests/unit/app/core/test_custom_app_token.py
+++ b/tests/unit/app/core/test_custom_app_token.py
@@ -1,0 +1,69 @@
+import os
+from datetime import datetime
+
+import jwt
+import pytest
+from dateutil.relativedelta import relativedelta
+
+from app.core.custom_app import create_configuration_token
+
+SECRET_KEY = os.environ["SECRET_KEY"]
+ALGORITHM = "HS256"
+
+EXPIRE_AFTER_DEFAULT_YEARS = 10
+
+
+def timedelta_years(years, from_date=None):
+    if from_date is None:
+        from_date = datetime.now()
+    return from_date - relativedelta(years=years)
+
+
+@pytest.mark.parametrize(
+    "input_str,expected_allowed_corpora",
+    [
+        ("apple,banana,carrot", ["apple", "banana", "carrot"]),
+        ("cucumber", ["cucumber"]),
+    ],
+)
+def test_create_configuration_token_default_expiry(
+    input_str: str, expected_allowed_corpora: list[str]
+):
+    datetime.utcnow()
+    token = create_configuration_token(input_str)
+    assert token is not None
+    assert isinstance(token, str)
+
+    data = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+
+    assert data["allowed_corpora_ids"] == expected_allowed_corpora
+    assert timedelta_years(
+        EXPIRE_AFTER_DEFAULT_YEARS, datetime.fromtimestamp(data["exp"])
+    ) == datetime.fromtimestamp(data["iat"])
+
+
+@pytest.mark.parametrize(
+    "input_str,expected_allowed_corpora,expiry_years",
+    [
+        (
+            "raspberry,strawberry,orange",
+            ["orange", "raspberry", "strawberry"],
+            1,
+        ),
+        ("grapefruit", ["grapefruit"], 5),
+    ],
+)
+def test_create_configuration_token_specific_expiry(
+    input_str: str, expected_allowed_corpora: list[str], expiry_years: int
+):
+    datetime.utcnow()
+    token = create_configuration_token(input_str, expiry_years)
+    assert token is not None
+    assert isinstance(token, str)
+
+    data = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+
+    assert data["allowed_corpora_ids"] == expected_allowed_corpora
+    assert timedelta_years(
+        expiry_years, datetime.fromtimestamp(data["exp"])
+    ) == datetime.fromtimestamp(data["iat"])

--- a/tests/unit/app/core/test_custom_app_token.py
+++ b/tests/unit/app/core/test_custom_app_token.py
@@ -19,6 +19,18 @@ def timedelta_years(years, from_date=None):
     return from_date - relativedelta(years=years)
 
 
+def has_expected_keys(keys: list[str]) -> bool:
+    return bool(
+        set(keys)
+        ^ {
+            "allowed_corpora_ids",
+            "exp",
+            "iat",
+        }
+        == set()
+    )
+
+
 @pytest.mark.parametrize(
     "input_str,expected_allowed_corpora",
     [
@@ -35,6 +47,8 @@ def test_create_configuration_token_default_expiry(
     assert isinstance(token, str)
 
     data = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+
+    assert has_expected_keys(data)
 
     assert data["allowed_corpora_ids"] == expected_allowed_corpora
     assert timedelta_years(
@@ -56,12 +70,12 @@ def test_create_configuration_token_default_expiry(
 def test_create_configuration_token_specific_expiry(
     input_str: str, expected_allowed_corpora: list[str], expiry_years: int
 ):
-    datetime.utcnow()
     token = create_configuration_token(input_str, expiry_years)
     assert token is not None
     assert isinstance(token, str)
 
     data = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+    assert has_expected_keys(data)
 
     assert data["allowed_corpora_ids"] == expected_allowed_corpora
     assert timedelta_years(


### PR DESCRIPTION
# Description

Create function to configure and encode a list of corpora ids into a jwt token. As part of our work creating custom apps we want to ensure that the appropriate data flows through to the correct corpus, this is one of the first steps in setting up that process.

Please include:

- a summary of the changes
- links to any related issue/ticket
- any additional relevant motivation and context
- details of any dependency updates that are required for this change

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Refactor legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
