### PR TITLE
Feature/pla 65 interim solution handle deleted documents in the pipeline

### DIFF
--- a/app/core/ingestion/pipeline.py
+++ b/app/core/ingestion/pipeline.py
@@ -2,6 +2,7 @@ import logging
 from datetime import datetime, timezone
 from typing import Any, Sequence, Tuple, cast
 
+from db_client.models.dfce import DocumentStatus
 from db_client.models.dfce.family import (
     Corpus,
     Family,
@@ -30,6 +31,7 @@ def generate_pipeline_ingest_input(db: Session) -> Sequence[DocumentParserInput]
         .join(FamilyMetadata, Family.import_id == FamilyMetadata.family_import_id)
         .join(Organisation, Organisation.id == Corpus.organisation_id)
         .join(Geography, Geography.id == Family.geography_id)
+        .filter(FamilyDocument.document_status != DocumentStatus.DELETED)
     )
 
     query_result = cast(

--- a/poetry.lock
+++ b/poetry.lock
@@ -4782,4 +4782,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "7f460050e580a1e582cc0c1c2dfeea068f9800dbe6f21384ccc55503a5098e4d"
+content-hash = "687fcc0c485bba28a200203fd9757739059d9f041dbb959e3e421b711e118014"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ urllib3 = "<2"
 apscheduler = "^3.10.4"
 numpy = "1.26.4"
 torch = [
-  { platform = "darwin", url = "https://download.pytorch.org/whl/cpu/torch-2.0.0-cp39-none-macosx_10_9_x86_64.whl", markers = "platform_machine=='amd64'" },
+  { platform = "darwin", url = "https://download.pytorch.org/whl/cpu/torch-2.0.0-cp39-none-macosx_10_9_x86_64.whl", markers = "platform_machine=='x86_64'" },
   { platform = "darwin", url = "https://download.pytorch.org/whl/cpu/torch-2.0.0-cp39-none-macosx_11_0_arm64.whl", markers = "platform_machine=='arm64'" },
   { platform = "linux", version = "2.0.0", source = "pytorch" },
   { platform = "win32", version = "2.0.0", source = "pytorch" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "navigator_backend"
-version = "1.14.9"
+version = "1.14.10"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]

--- a/tests/unit/app/core/test_pipeline.py
+++ b/tests/unit/app/core/test_pipeline.py
@@ -1,14 +1,25 @@
 from sqlalchemy.orm import Session
 
 from app.core.ingestion.pipeline import generate_pipeline_ingest_input
-from tests.non_search.setup_helpers import setup_with_two_docs_one_family
+from tests.non_search.setup_helpers import setup_with_two_docs_one_family, setup_with_two_unpublished_docs
 
 
 def test_generate_pipeline_ingest_input(data_db: Session):
     setup_with_two_docs_one_family(data_db)
 
     documents = generate_pipeline_ingest_input(data_db)
-
     assert len(documents) == 2
     assert documents[0].name == "Fam1"
+    assert documents[0].import_id == "CCLW.executive.2.2"
     assert documents[1].name == "Fam1"
+    assert documents[1].import_id == "CCLW.executive.1.2"
+
+
+def test_generate_pipeline_ingest_input__deleted(data_db: Session):
+    setup_with_two_unpublished_docs(data_db)
+
+    documents = generate_pipeline_ingest_input(data_db)
+    assert len(documents) == 1
+    assert documents[0].name == "Fam1"
+    assert documents[0].import_id == "CCLW.executive.1.2"
+

--- a/tests/unit/app/core/test_pipeline.py
+++ b/tests/unit/app/core/test_pipeline.py
@@ -1,7 +1,10 @@
 from sqlalchemy.orm import Session
 
 from app.core.ingestion.pipeline import generate_pipeline_ingest_input
-from tests.non_search.setup_helpers import setup_with_two_docs_one_family, setup_with_two_unpublished_docs
+from tests.non_search.setup_helpers import (
+    setup_with_two_docs_one_family,
+    setup_with_two_unpublished_docs,
+)
 
 
 def test_generate_pipeline_ingest_input(data_db: Session):
@@ -22,4 +25,3 @@ def test_generate_pipeline_ingest_input__deleted(data_db: Session):
     assert len(documents) == 1
     assert documents[0].name == "Fam1"
     assert documents[0].import_id == "CCLW.executive.1.2"
-


### PR DESCRIPTION
# Description

Prevents deleted documents from being passed to the pipeline by the trigger. These have been causing validation issues leading to false flags.

Should not be deployed before this pipeline update that will prevent this change from breaking the pipeline: https://github.com/climatepolicyradar/navigator-data-pipeline/pull/230

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Refactor legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [x] The PR represents a single feature (small driveby fixes are also ok)
- [x] The PR includes tests that are sufficient for the level of risk
- [x] The code is sufficiently commented, particularly in hard-to-understand areas
- [x] Any required documentation updates have been made
- [x] Any TODOs added are captured in future tickets
- [x] No FIXMEs remain
