### PR TITLE
ci: Reduce reviewers scope

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,8 +8,19 @@
 
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence, members
-# of @climatepolicyradar/tech-devs will be requested for
+# of @climatepolicyradar/software will be requested for
 # review when someone opens a pull request. Teams should
 # be identified in the format @org/team-name. Teams must have
 # explicit write access to the repository.
-* @climatepolicyradar/tech-devs
+
+*                                                @climatepolicyradar/software
+app/api/api_v1/routers/pipeline_trigger.py       @climatepolicyradar/deng
+tests/unit/app/core/test_pipeline.py             @climatepolicyradar/deng
+tests/non_search/app/test_pipeline_trigger.py    @climatepolicyradar/deng
+app/core/ingestion/                              @climatepolicyradar/deng
+tests/search/search_fixtures/vespa_test_schema/  @climatepolicyradar/deng
+app/api/api_v1/routers/search.py                 @climatepolicyradar/tech-devs
+tests/search/                                    @climatepolicyradar/tech-devs
+app/api/api_v1/schemas/                          @climatepolicyradar/tech-devs
+tests/unit/app/schemas/                          @climatepolicyradar/tech-devs
+app/api/api_v1/schemas/search.py                 @climatepolicyradar/deng


### PR DESCRIPTION
# Description

Same as https://github.com/climatepolicyradar/navigator-frontend/pull/200.

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [x] Skip auto-tagging
- [ ] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] GitHub workflow update
- [ ] Documentation update
- [ ] Refactor legacy code
- [ ] Dependency update

## How Has This Been Tested?

N/A

## Reviewer Checklist

- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
