### PR TITLE
Deal with some of the many warnings we have when running tests 😬 

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   vespatest:
     image: vespaengine/vespa:8.396.18

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   backend_db:
     image: postgres:14

--- a/tests/search/search_fixtures/vespa_test_schema/schemas/document_passage.sd
+++ b/tests/search/search_fixtures/vespa_test_schema/schemas/document_passage.sd
@@ -64,7 +64,7 @@ schema document_passage {
     import field search_weights_ref.passage_weight as passage_weight {}
 
     fieldset default {
-        fields: text_block, text_embedding
+        fields: text_block
     }
 
     document-summary search_summary {

--- a/tests/search/search_fixtures/vespa_test_schema/schemas/document_passage.sd
+++ b/tests/search/search_fixtures/vespa_test_schema/schemas/document_passage.sd
@@ -68,25 +68,25 @@ schema document_passage {
     }
 
     document-summary search_summary {
-        summary family_name type string {}
-        summary family_description type string {}
-        summary family_import_id type string {}
-        summary family_slug type string {}
-        summary family_category type string {}
-        summary family_publication_ts type string {}
-        summary family_geography type string {}
-        summary family_source type string {}
-        summary document_import_id type string {}
-        summary document_slug type string {}
-        summary document_languages type array<string> {}
-        summary document_content_type type string {}
-        summary document_cdn_object type string {}
-        summary document_source_url type string {}
-        summary text_block type string {}
-        summary text_block_id type string {}
-        summary text_block_type type string {}
-        summary text_block_page type int {}
-        summary text_block_coords type array<array<float>> {}
+        summary family_name {}
+        summary family_description {}
+        summary family_import_id {}
+        summary family_slug {}
+        summary family_category {}
+        summary family_publication_ts {}
+        summary family_geography {}
+        summary family_source {}
+        summary document_import_id {}
+        summary document_slug {}
+        summary document_languages {}
+        summary document_content_type {}
+        summary document_cdn_object {}
+        summary document_source_url {}
+        summary text_block {}
+        summary text_block_id {}
+        summary text_block_type {}
+        summary text_block_page {}
+        summary text_block_coords {}
     }
 
     rank-profile exact inherits default {

--- a/tests/search/search_fixtures/vespa_test_schema/schemas/family_document.sd
+++ b/tests/search/search_fixtures/vespa_test_schema/schemas/family_document.sd
@@ -155,7 +155,7 @@ schema family_document {
     import field search_weights_ref.description_weight as description_weight {}
 
     fieldset default {
-        fields: family_name_index, family_description_index, family_description_embedding
+        fields: family_name_index, family_description_index
     }
 
     rank-profile exact inherits default {


### PR DESCRIPTION
# Description

1. Remove obsolete 'version' from docker compose file
2. Remove embeddings from fieldset
    Deals with the error:
    ```
    WARNING For schema '...', fieldset 'default': Tensor fields ['...']
    cannot be mixed with non-tensor fields ['...'] in the same fieldset.
    See https://docs.vespa.ai/en/reference/schema-reference.html#fieldset
    ```
3. Remove obsolete type assignment for summaries

    Deals with the warning for each field:
    ```
    WARNING For schema '...', summary field '...': Specifying the type is
    deprecated, ignored and will be an error in Vespa 9. Remove the type
    specification to silence this warning.


## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [x] Skip auto-tagging
- [ ] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [x] Refactor legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [x] The PR represents a single feature (small driveby fixes are also ok)
- [x] The PR includes tests that are sufficient for the level of risk
- [x] The code is sufficiently commented, particularly in hard-to-understand areas
- [x] Any required documentation updates have been made
- [x] Any TODOs added are captured in future tickets
- [x] No FIXMEs remain
