### PR TITLE
Feature/pla 60 reshape db statejson and rerun pipeline on historic

### DIFF
--- a/app/core/ingestion/pipeline.py
+++ b/app/core/ingestion/pipeline.py
@@ -113,7 +113,12 @@ def generate_pipeline_ingest_input(db: Session) -> Sequence[DocumentParserInput]
         ) in query_result
     ]
 
-    # FIXME: Break if row explosion
+    database_doc_count = db.query(PhysicalDocument).count()
+    if len(documents) > database_doc_count:
+        raise ValueError(
+            "Potential Row Explosion. Ingest input is returning more documents than "
+            f"exist in the database {len(documents)}:{database_doc_count}"
+        )
 
     return documents
 

--- a/app/db/crud/geography.py
+++ b/app/db/crud/geography.py
@@ -36,6 +36,8 @@ def get_geo_subquery(
     However, the browse code only uses one of these values, so it should be fine.
 
     Don't forget this is temporary and will be removed once multi-geography support is implemented.
+
+    Also remember to update the pipeline query to pass these in when changing this.
     """
 
     if allowed_geo_slugs is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "navigator_backend"
-version = "1.14.14"
+version = "1.14.15"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]

--- a/tests/non_search/dfce_helpers.py
+++ b/tests/non_search/dfce_helpers.py
@@ -40,6 +40,8 @@ def add_collections(db: Session, collections, org_id=1):
 
 
 def add_families(db: Session, families, org_id=1):
+    # Note: corpus & organisation are set up in migrations
+
     for f in families:
         db.add(
             Family(
@@ -84,7 +86,6 @@ def add_families(db: Session, families, org_id=1):
                     corpus_import_id=f["corpus_import_id"],
                 )
             )
-
     db.commit()
 
 

--- a/tests/unit/app/core/test_pipeline.py
+++ b/tests/unit/app/core/test_pipeline.py
@@ -1,6 +1,9 @@
 from sqlalchemy.orm import Session
 
-from app.core.ingestion.pipeline import generate_pipeline_ingest_input
+from app.core.ingestion.pipeline import (
+    flatten_pipeline_metadata,
+    generate_pipeline_ingest_input,
+)
 from tests.non_search.setup_helpers import (
     setup_with_two_docs_one_family,
     setup_with_two_unpublished_docs,
@@ -10,12 +13,35 @@ from tests.non_search.setup_helpers import (
 def test_generate_pipeline_ingest_input(data_db: Session):
     setup_with_two_docs_one_family(data_db)
 
-    documents = generate_pipeline_ingest_input(data_db)
-    assert len(documents) == 2
-    assert documents[0].name == "Fam1"
-    assert documents[1].name == "Fam1"
-    doc_ids = set([doc.import_id for doc in documents])
+    state_rows = generate_pipeline_ingest_input(data_db)
+    assert len(state_rows) == 2
+
+    # Now test one field from each table we've queried
+    # Check family title
+    assert state_rows[0].name == "Fam1"
+    assert state_rows[1].name == "Fam1"
+
+    # Check family_document import_id
+    doc_ids = set([doc.import_id for doc in state_rows])
     assert doc_ids == {"CCLW.executive.1.2", "CCLW.executive.2.2"}
+
+    # Check family_metadata
+    assert state_rows[0].metadata["family.size"] == "big"
+
+    # Check geography
+    assert state_rows[0].geographies == ["South Asia"]
+
+    # Check organisation
+    assert state_rows[0].source == "CCLW"
+
+    # Check corpus
+    assert state_rows[0].corpus_import_id == "CCLW.corpus.i00000001.n0000"
+
+    # Check physical_document
+    assert state_rows[0].document_title == "Document2"
+
+    # Check collection
+    assert state_rows[0].collection_title == "Collection1"
 
 
 def test_generate_pipeline_ingest_input__deleted(data_db: Session):
@@ -25,3 +51,15 @@ def test_generate_pipeline_ingest_input__deleted(data_db: Session):
     assert len(documents) == 1
     assert documents[0].name == "Fam1"
     assert documents[0].import_id == "CCLW.executive.1.2"
+
+
+def test_flatten_pipeline_metadata():
+    family_metadata = {"a": ["1"], "b": ["2"]}
+    doc_metadata = {"a": ["3"], "b": ["4"]}
+    result = flatten_pipeline_metadata(family_metadata, doc_metadata)
+
+    assert len(result) == 4
+    assert result["family.a"] == ["1"]
+    assert result["family.b"] == ["2"]
+    assert result["document.a"] == ["3"]
+    assert result["document.b"] == ["4"]

--- a/tests/unit/app/core/test_pipeline.py
+++ b/tests/unit/app/core/test_pipeline.py
@@ -15,6 +15,8 @@ def test_generate_pipeline_ingest_input(data_db: Session):
 
     state_rows = generate_pipeline_ingest_input(data_db)
     assert len(state_rows) == 2
+    # Sort to ensure order is consistent across tests
+    sorted(state_rows, key=lambda d: d.import_id)
 
     # Now test one field from each table we've queried
     # Check family title
@@ -22,8 +24,8 @@ def test_generate_pipeline_ingest_input(data_db: Session):
     assert state_rows[1].name == "Fam1"
 
     # Check family_document import_id
-    doc_ids = set([doc.import_id for doc in state_rows])
-    assert doc_ids == {"CCLW.executive.1.2", "CCLW.executive.2.2"}
+    assert state_rows[0].import_id == "CCLW.executive.2.2"
+    assert state_rows[1].import_id == "CCLW.executive.1.2"
 
     # Check family_metadata
     assert state_rows[0].metadata["family.size"] == "big"


### PR DESCRIPTION
# Description

Adds the new fields required for custom apps to the db_state file.

Note that geographies is a special case here because all of our current documents only have a single geography. This will need revisiting when we start getting multiples.

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Refactor legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
