### PR TITLE
Bugfix for the db-state dropping rows. 

### DIFF
--- a/app/core/ingestion/pipeline.py
+++ b/app/core/ingestion/pipeline.py
@@ -40,8 +40,8 @@ def generate_pipeline_ingest_input(db: Session) -> Sequence[DocumentParserInput]
         .join(
             PhysicalDocument, PhysicalDocument.id == FamilyDocument.physical_document_id
         )
-        .join(CollectionFamily, CollectionFamily.family_import_id == Family.import_id)
-        .join(Collection, Collection.import_id == CollectionFamily.collection_import_id)
+        .outerjoin(CollectionFamily, CollectionFamily.family_import_id == Family.import_id)
+        .outerjoin(Collection, Collection.import_id == CollectionFamily.collection_import_id)
         .filter(FamilyDocument.document_status != DocumentStatus.DELETED)
         .filter(geo_subquery.c.family_import_id == Family.import_id)  # type: ignore
     )

--- a/app/core/ingestion/pipeline.py
+++ b/app/core/ingestion/pipeline.py
@@ -2,7 +2,7 @@ import logging
 from datetime import datetime, timezone
 from typing import Sequence, Tuple, cast
 
-from db_client.models.dfce import Collection, DocumentStatus
+from db_client.models.dfce import DocumentStatus
 from db_client.models.dfce.family import (
     Corpus,
     Family,
@@ -30,7 +30,7 @@ def generate_pipeline_ingest_input(db: Session) -> Sequence[DocumentParserInput]
 
     query = (
         db.query(
-            Family, FamilyDocument, FamilyMetadata, geo_subquery.c.value, Organisation, Corpus, PhysicalDocument, Collection  # type: ignore
+            Family, FamilyDocument, FamilyMetadata, geo_subquery.c.value, Organisation, Corpus, PhysicalDocument  # type: ignore
         )
         .join(Family, Family.import_id == FamilyDocument.family_import_id)
         .join(FamilyCorpus, FamilyCorpus.family_import_id == Family.import_id)
@@ -54,7 +54,6 @@ def generate_pipeline_ingest_input(db: Session) -> Sequence[DocumentParserInput]
                 Organisation,
                 Corpus,
                 PhysicalDocument,
-                Collection,
             ]
         ],
         query.all(),
@@ -84,12 +83,8 @@ def generate_pipeline_ingest_input(db: Session) -> Sequence[DocumentParserInput]
             geographies=[cast(str, geography)],
             corpus_import_id=cast(str, corpus.import_id),
             corpus_type_name=cast(str, corpus.corpus_type_name),
-            collection_title=(
-                cast(str, collection.title) if collection is not None else None
-            ),
-            collection_summary=(
-                cast(str, collection.description) if collection is not None else None
-            ),
+            collection_title=None,
+            collection_summary=None,
             languages=[
                 cast(str, lang.name)
                 for lang in (
@@ -111,7 +106,6 @@ def generate_pipeline_ingest_input(db: Session) -> Sequence[DocumentParserInput]
             organisation,
             corpus,
             physical_document,
-            collection,
         ) in query_result
     ]
 

--- a/app/core/ingestion/pipeline.py
+++ b/app/core/ingestion/pipeline.py
@@ -87,13 +87,9 @@ def generate_pipeline_ingest_input(db: Session) -> Sequence[DocumentParserInput]
             type=doc_type_from_family_document_metadata(family_document),
             source=cast(str, organisation.name),
             geography=cast(str, geography),
-            geographies=([cast(str, geography)] if geography is not None else []),
-            corpus_import_id=(
-                cast(str, corpus.import_id) if corpus is not None else None
-            ),
-            corpus_type_name=(
-                cast(str, corpus.corpus_type_name) if corpus is not None else None
-            ),
+            geographies=[cast(str, geography)],
+            corpus_import_id=cast(str, corpus.import_id),
+            corpus_type_name=cast(str, corpus.corpus_type_name),
             collection_title=(
                 cast(str, collection.title) if collection is not None else None
             ),

--- a/app/core/ingestion/pipeline.py
+++ b/app/core/ingestion/pipeline.py
@@ -40,8 +40,12 @@ def generate_pipeline_ingest_input(db: Session) -> Sequence[DocumentParserInput]
         .join(
             PhysicalDocument, PhysicalDocument.id == FamilyDocument.physical_document_id
         )
-        .outerjoin(CollectionFamily, CollectionFamily.family_import_id == Family.import_id)
-        .outerjoin(Collection, Collection.import_id == CollectionFamily.collection_import_id)
+        .outerjoin(
+            CollectionFamily, CollectionFamily.family_import_id == Family.import_id
+        )
+        .outerjoin(
+            Collection, Collection.import_id == CollectionFamily.collection_import_id
+        )
         .filter(FamilyDocument.document_status != DocumentStatus.DELETED)
         .filter(geo_subquery.c.family_import_id == Family.import_id)  # type: ignore
     )
@@ -83,11 +87,19 @@ def generate_pipeline_ingest_input(db: Session) -> Sequence[DocumentParserInput]
             type=doc_type_from_family_document_metadata(family_document),
             source=cast(str, organisation.name),
             geography=cast(str, geography),
-            geographies=[cast(str, geography)],
-            corpus_import_id=cast(str, corpus.import_id),
-            corpus_type_name=cast(str, corpus.corpus_type_name),
-            collection_title=cast(str, collection.title),
-            collection_summary=cast(str, collection.description),
+            geographies=([cast(str, geography)] if geography is not None else []),
+            corpus_import_id=(
+                cast(str, corpus.import_id) if corpus is not None else None
+            ),
+            corpus_type_name=(
+                cast(str, corpus.corpus_type_name) if corpus is not None else None
+            ),
+            collection_title=(
+                cast(str, collection.title) if collection is not None else None
+            ),
+            collection_summary=(
+                cast(str, collection.description) if collection is not None else None
+            ),
             languages=[
                 cast(str, lang.name)
                 for lang in (

--- a/app/core/ingestion/pipeline.py
+++ b/app/core/ingestion/pipeline.py
@@ -2,7 +2,7 @@ import logging
 from datetime import datetime, timezone
 from typing import Sequence, Tuple, cast
 
-from db_client.models.dfce import Collection, CollectionFamily, DocumentStatus
+from db_client.models.dfce import Collection, DocumentStatus
 from db_client.models.dfce.family import (
     Corpus,
     Family,

--- a/app/core/ingestion/pipeline.py
+++ b/app/core/ingestion/pipeline.py
@@ -40,12 +40,6 @@ def generate_pipeline_ingest_input(db: Session) -> Sequence[DocumentParserInput]
         .join(
             PhysicalDocument, PhysicalDocument.id == FamilyDocument.physical_document_id
         )
-        .outerjoin(
-            CollectionFamily, CollectionFamily.family_import_id == Family.import_id
-        )
-        .outerjoin(
-            Collection, Collection.import_id == CollectionFamily.collection_import_id
-        )
         .filter(FamilyDocument.document_status != DocumentStatus.DELETED)
         .filter(geo_subquery.c.family_import_id == Family.import_id)  # type: ignore
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "navigator_backend"
-version = "1.14.15"
+version = "1.14.16"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "navigator_backend"
-version = "1.14.16"
+version = "1.14.15"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]

--- a/tests/unit/app/core/test_pipeline.py
+++ b/tests/unit/app/core/test_pipeline.py
@@ -6,12 +6,13 @@ from app.core.ingestion.pipeline import (
 )
 from tests.non_search.setup_helpers import (
     setup_docs_with_two_orgs,
+    setup_with_two_docs_one_family,
     setup_with_two_unpublished_docs,
 )
 
 
 def test_generate_pipeline_ingest_input(data_db: Session):
-    setup_docs_with_two_orgs(data_db)
+    setup_with_two_docs_one_family(data_db)
 
     state_rows = generate_pipeline_ingest_input(data_db)
     assert len(state_rows) == 2
@@ -44,6 +45,13 @@ def test_generate_pipeline_ingest_input(data_db: Session):
 
     # Check collection
     assert state_rows[0].collection_title == "Collection1"
+
+
+def test_generate_pipeline_ingest_input_no_collection_family_link(data_db: Session):
+    setup_docs_with_two_orgs(data_db)
+
+    state_rows = generate_pipeline_ingest_input(data_db)
+    assert len(state_rows) == 2
 
 
 def test_generate_pipeline_ingest_input__deleted(data_db: Session):

--- a/tests/unit/app/core/test_pipeline.py
+++ b/tests/unit/app/core/test_pipeline.py
@@ -5,13 +5,13 @@ from app.core.ingestion.pipeline import (
     generate_pipeline_ingest_input,
 )
 from tests.non_search.setup_helpers import (
-    setup_with_two_docs_one_family,
+    setup_docs_with_two_orgs,
     setup_with_two_unpublished_docs,
 )
 
 
 def test_generate_pipeline_ingest_input(data_db: Session):
-    setup_with_two_docs_one_family(data_db)
+    setup_docs_with_two_orgs(data_db)
 
     state_rows = generate_pipeline_ingest_input(data_db)
     assert len(state_rows) == 2

--- a/tests/unit/app/core/test_pipeline.py
+++ b/tests/unit/app/core/test_pipeline.py
@@ -43,9 +43,6 @@ def test_generate_pipeline_ingest_input(data_db: Session):
     # Check physical_document
     assert state_rows[0].document_title == "Document2"
 
-    # Check collection
-    assert state_rows[0].collection_title == "Collection1"
-
 
 def test_generate_pipeline_ingest_input_no_collection_family_link(data_db: Session):
     setup_docs_with_two_orgs(data_db)


### PR DESCRIPTION
# Description

Using TDD to fix the db state dropping rows. 


Looking at the test documents that were passing and now the test docs that are failing the difference is the `link_collection_family`: 

Working!
```python
def setup_with_two_docs(db: Session):
    """Creates 2 DFCEs"""

    # Collection
    collection1, collection2 = get_default_collections()
    add_collections(db, collections=[collection1])

    # Family + Document + events
    document1, document2 = get_default_documents()
    family1, family2 = get_default_families()
    family1["documents"] = [document1]
    family2["documents"] = [document2]
    add_families(db, families=[family1, family2])

    # Collection - Family
    link_collection_family(
        db,
        [
            (collection1["import_id"], family1["import_id"]),
            (collection1["import_id"], family2["import_id"]),
        ],
    )
```

Failing! 
```python
def setup_docs_with_two_orgs(db: Session):
    document1, document2 = get_default_documents()
    document2["import_id"] = "UNFCCC.non-party.2.2"
    family1, family2 = get_default_families()
    family1["documents"] = [document1]
    family2["documents"] = [document2]
    # Family + Document + events
    add_families(db, families=[family1], org_id=1)
    add_families(db, families=[family2], org_id=2)
## Proposed version
```

So my assumption is that some families are missing an entry in the `CollectionFamily` table and thus dropped by this line in the query. 
`.join(CollectionFamily, CollectionFamily.family_import_id == Family.import_id)`

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [x] Skip auto-tagging
- [ ] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Refactor legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
