### PR TITLE
fix: Migrate missed Python version

### DIFF
--- a/makefile-local.defs
+++ b/makefile-local.defs
@@ -20,14 +20,14 @@ dev_install: install_trunk check_dev_environment
 	# Install pip
 	pip install --upgrade pip
 	# Install poetry
-	pip install "poetry==1.7.1"
+	pip install "poetry==1.8.1"
 
 	make poetry_environment
 	make configure_pyright
 
 create_venv:
 	- pyenv deactivate
-	pyenv virtualenv 3.9 backend
+	pyenv virtualenv 3.10 backend
 	pyenv activate backend
 
 install_trunk:


### PR DESCRIPTION
# Description

This was missed in #324.


## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [x] Skip auto-tagging
- [ ] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Refactor legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [x] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [x] The PR represents a single feature (small driveby fixes are also ok)
- [x] The PR includes tests that are sufficient for the level of risk
- [x] The code is sufficiently commented, particularly in hard-to-understand areas
- [x] Any required documentation updates have been made
- [x] Any TODOs added are captured in future tickets
- [x] No FIXMEs remain