### PR TITLE
Adding a fix for the no certs.

### DIFF
--- a/app/api/api_v1/routers/search.py
+++ b/app/api/api_v1/routers/search.py
@@ -23,6 +23,7 @@ from app.core.aws import S3Document, get_s3_client
 from app.core.config import (
     AWS_REGION,
     CDN_DOMAIN,
+    DEVELOPMENT_MODE,
     DOC_CACHE_BUCKET,
     INGEST_TRIGGER_ROOT,
     PIPELINE_BUCKET,
@@ -44,7 +45,7 @@ _LOGGER = logging.getLogger(__name__)
 
 _VESPA_CONNECTION = VespaSearchAdapter(
     instance_url=VESPA_URL,
-    cert_directory=VESPA_SECRETS_LOCATION,
+    cert_directory=VESPA_SECRETS_LOCATION if not DEVELOPMENT_MODE else None,
     embedder=ENCODER,
 )
 

--- a/app/api/api_v1/routers/search.py
+++ b/app/api/api_v1/routers/search.py
@@ -23,7 +23,6 @@ from app.core.aws import S3Document, get_s3_client
 from app.core.config import (
     AWS_REGION,
     CDN_DOMAIN,
-    DEVELOPMENT_MODE,
     DOC_CACHE_BUCKET,
     INGEST_TRIGGER_ROOT,
     PIPELINE_BUCKET,
@@ -43,9 +42,11 @@ from app.db.session import get_db
 
 _LOGGER = logging.getLogger(__name__)
 
+print(VESPA_SECRETS_LOCATION)
+
 _VESPA_CONNECTION = VespaSearchAdapter(
     instance_url=VESPA_URL,
-    cert_directory=VESPA_SECRETS_LOCATION if not DEVELOPMENT_MODE else None,
+    cert_directory=VESPA_SECRETS_LOCATION,
     embedder=ENCODER,
 )
 

--- a/app/api/api_v1/routers/search.py
+++ b/app/api/api_v1/routers/search.py
@@ -23,6 +23,7 @@ from app.core.aws import S3Document, get_s3_client
 from app.core.config import (
     AWS_REGION,
     CDN_DOMAIN,
+    DEVELOPMENT_MODE,
     DOC_CACHE_BUCKET,
     INGEST_TRIGGER_ROOT,
     PIPELINE_BUCKET,
@@ -42,11 +43,9 @@ from app.db.session import get_db
 
 _LOGGER = logging.getLogger(__name__)
 
-print(VESPA_SECRETS_LOCATION)
-
 _VESPA_CONNECTION = VespaSearchAdapter(
     instance_url=VESPA_URL,
-    cert_directory=VESPA_SECRETS_LOCATION,
+    cert_directory=VESPA_SECRETS_LOCATION if not DEVELOPMENT_MODE else None,
     embedder=ENCODER,
 )
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,5 +1,5 @@
 import os
-from typing import Final, Optional
+from typing import Final
 
 PROJECT_NAME = "navigator"
 
@@ -11,7 +11,7 @@ PUBLIC_APP_URL = os.environ["PUBLIC_APP_URL"].rstrip("/")
 API_V1_STR = "/api/v1"
 
 # Vespa Config
-VESPA_SECRETS_LOCATION: Optional[str] = os.getenv("VESPA_SECRETS_LOCATION", None)
+VESPA_SECRETS_LOCATION: str = os.getenv("VESPA_SECRETS_LOCATION", "/secrets")
 VESPA_URL: str = os.environ["VESPA_URL"]
 
 # Shared search config

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,5 +1,5 @@
 import os
-from typing import Final
+from typing import Final, Optional
 
 PROJECT_NAME = "navigator"
 
@@ -11,7 +11,7 @@ PUBLIC_APP_URL = os.environ["PUBLIC_APP_URL"].rstrip("/")
 API_V1_STR = "/api/v1"
 
 # Vespa Config
-VESPA_SECRETS_LOCATION: str = os.getenv("VESPA_SECRETS_LOCATION", "/secrets")
+VESPA_SECRETS_LOCATION: Optional[str] = os.getenv("VESPA_SECRETS_LOCATION", None)
 VESPA_URL: str = os.environ["VESPA_URL"]
 
 # Shared search config

--- a/app/core/custom_app.py
+++ b/app/core/custom_app.py
@@ -117,7 +117,6 @@ def decode_config_token(token: str, audience: Optional[str]) -> list[str]:
     db = next(get_db())
 
     try:
-        _LOGGER.error(f"Audience {audience}")
         decoded_token = jwt.decode(
             token,
             security.SECRET_KEY,

--- a/app/core/custom_app.py
+++ b/app/core/custom_app.py
@@ -117,6 +117,7 @@ def decode_config_token(token: str, audience: Optional[str]) -> list[str]:
     db = next(get_db())
 
     try:
+        _LOGGER.error(f"Audience {audience}")
         decoded_token = jwt.decode(
             token,
             security.SECRET_KEY,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ python = "^3.10"
 Authlib = "^0.15.5"
 bcrypt = "^3.2.0"
 boto3 = "^1.26"
-cpr_sdk = { version = "1.4.3", extras = ["vespa"] }
+cpr_sdk = { version = "1.4.4", extras = ["vespa"] }
 fastapi = "^0.104.1"
 fastapi-health = "^0.4.0"
 fastapi-pagination = { extras = ["sqlalchemy"], version = "^0.12.19" }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,29 +80,6 @@ def test_s3_client(s3_document_bucket_names, mock_aws_creds):
         yield s3_client
 
 
-# @pytest.fixture(scope="session")
-# def test_vespa():
-#     """Connect to local vespa instance"""
-
-#     def __mocked_init__(
-#         self,
-#         instance_url: str,
-#         cert_directory: Optional[str] = None,
-#         embedder: Optional[Embedder] = None,
-#     ):
-#         self.client = Vespa(url=instance_url, port=8080)
-#         self.embedder = embedder or Embedder()
-
-#     VespaSearchAdapter.__init__ = __mocked_init__
-
-#     yield VespaSearchAdapter(instance_url="http://vespatest")
-
-
-@pytest.fixture()
-def test_vespa():
-    pass
-
-
 def get_test_db_url() -> str:
     return os.environ["DATABASE_URL"] + f"_test_{uuid.uuid4()}"
 

--- a/tests/search/test_vespasearch.py
+++ b/tests/search/test_vespasearch.py
@@ -11,7 +11,10 @@ from sqlalchemy import update
 from sqlalchemy.orm import Session
 
 from app.api.api_v1.routers import search
+from app.core.search import ENCODER
+from cpr_sdk.search_adaptors import VespaSearchAdapter
 from app.core.lookups import get_country_slug_from_country_code
+from app.core.config import VESPA_URL
 from tests.search.setup_search_tests import (
     VESPA_FIXTURE_COUNT,
     _create_document,
@@ -853,7 +856,12 @@ def test_csv_download_search_variable_limit(
     # monkeypatch.setattr(search, "_VESPA_CONNECTION", test_vespa)
     _populate_db_families(data_db)
 
-    query_spy = mocker.spy(search._VESPA_CONNECTION, "search")
+    search_adapter = VespaSearchAdapter(
+        instance_url=VESPA_URL,
+        embedder=ENCODER,
+    )
+
+    query_spy = mocker.spy(search_adapter, "search")
 
     params = {
         "query_string": query,


### PR DESCRIPTION
# Description

This pull request integrates a new sdk version and new method of instantiation of the search adaptor object. This can be utilised across the other failing tests. 

The issue: 
We were using the following code to instantiate the `search._VESPA_CONNECTION` object, we were therefore passing in cert paths that didn't exist that requests then couldn't find. Now we allow no cert paths in the sdk. 

```python
_VESPA_CONNECTION = VespaSearchAdapter(
    instance_url=VESPA_URL,
    cert_directory=VESPA_SECRETS_LOCATION,
    embedder=ENCODER,
)
```


- [ ] TODO: Update the lock file when poetry and pypi decide to behave and identify the update. 

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Refactor legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
