### PR TITLE
Feature/add a test for metadata

### DIFF
--- a/app/api/api_v1/routers/search.py
+++ b/app/api/api_v1/routers/search.py
@@ -56,9 +56,9 @@ def _search_request(db: Session, search_body: SearchRequestBody) -> SearchRespon
         search_body.documents_only = True
         search_body.exact_match = False
     try:
-        data_access_search_params = create_vespa_search_params(db, search_body)
-        data_access_search_response = _VESPA_CONNECTION.search(
-            parameters=data_access_search_params
+        cpr_sdk_search_params = create_vespa_search_params(db, search_body)
+        cpr_sdk_search_response = _VESPA_CONNECTION.search(
+            parameters=cpr_sdk_search_params
         )
     except QueryError as e:
         raise HTTPException(
@@ -67,7 +67,7 @@ def _search_request(db: Session, search_body: SearchRequestBody) -> SearchRespon
         )
     return process_vespa_search_response(
         db,
-        data_access_search_response,
+        cpr_sdk_search_response,
         limit=search_body.page_size,
         offset=search_body.offset,
     ).increment_pages()

--- a/app/core/search.py
+++ b/app/core/search.py
@@ -326,7 +326,6 @@ def _convert_filters(
         return None
 
 
-# TODO: I think something in here is converting the metadata incorrectly
 # TODO: Add a test for this function
 def _process_vespa_search_response_families(
     db: Session,
@@ -344,7 +343,6 @@ def _process_vespa_search_response_families(
     all_response_family_ids = [vf.id for vf in vespa_families_to_process]
 
     # TODO: Disparity between what's in postgres and vespa
-    breakpoint()
     family_and_family_metadata: Sequence[tuple[Family, FamilyMetadata]] = (
         db.query(Family, FamilyMetadata)
         .filter(Family.import_id.in_(all_response_family_ids))

--- a/app/core/search.py
+++ b/app/core/search.py
@@ -326,6 +326,8 @@ def _convert_filters(
         return None
 
 
+# TODO: I think something in here is converting the metadata incorrectly
+# TODO: Add a test for this function
 def _process_vespa_search_response_families(
     db: Session,
     vespa_families: Sequence[CprSdkResponseFamily],
@@ -341,6 +343,8 @@ def _process_vespa_search_response_families(
     vespa_families_to_process = vespa_families[offset : limit + offset]
     all_response_family_ids = [vf.id for vf in vespa_families_to_process]
 
+    # TODO: Disparity between what's in postgres and vespa
+    breakpoint()
     family_and_family_metadata: Sequence[tuple[Family, FamilyMetadata]] = (
         db.query(Family, FamilyMetadata)
         .filter(Family.import_id.in_(all_response_family_ids))

--- a/app/core/search.py
+++ b/app/core/search.py
@@ -342,7 +342,7 @@ def _process_vespa_search_response_families(
     vespa_families_to_process = vespa_families[offset : limit + offset]
     all_response_family_ids = [vf.id for vf in vespa_families_to_process]
 
-    # TODO: Disparity between what's in postgres and vespa
+    # TODO: Potential disparity between what's in postgres and vespa
     family_and_family_metadata: Sequence[tuple[Family, FamilyMetadata]] = (
         db.query(Family, FamilyMetadata)
         .filter(Family.import_id.in_(all_response_family_ids))

--- a/tests/search/setup_search_tests.py
+++ b/tests/search/setup_search_tests.py
@@ -1,5 +1,6 @@
 import json
 import random
+from collections import defaultdict
 from datetime import datetime
 from pathlib import Path
 from typing import Iterable, Mapping, Optional, Sequence
@@ -165,18 +166,16 @@ def _get_taxonomy(db: Session, org_name: str):
 
 
 def _create_family_metadata(db: Session, family: VespaFixture):
-    if family["fields"]["family_source"] in ["UNFCCC", "CCLW"]:
-        taxonomy = _get_taxonomy(db, family["fields"]["family_source"])
-    else:
-        raise ValueError(
-            f"Could not get taxonomy for: {family['fields']['family_source']}"
-        )
-    metadata_value = _generate_synthetic_metadata(taxonomy)
+    metadata_values = defaultdict(list)
+    family_metadata = family["fields"]["metadata"]
+    if not family_metadata:
+        return
+    for metadata in family_metadata:
+        metadata_values[metadata["name"]].append(metadata["value"])
 
-    family_import_id = family["fields"]["family_import_id"]
     family_metadata = FamilyMetadata(
-        family_import_id=family_import_id,
-        value=metadata_value,
+        family_import_id=family["fields"]["family_import_id"],
+        value=metadata_values,
     )
     db.add(family_metadata)
     db.commit()

--- a/tests/search/setup_search_tests.py
+++ b/tests/search/setup_search_tests.py
@@ -64,7 +64,9 @@ def _fixture_docs() -> Iterable[tuple[VespaFixture, VespaFixture]]:
         yield doc, family
 
 
-def _populate_db_families(db: Session, max_docs: int = VESPA_FIXTURE_COUNT) -> None:
+def _populate_db_families(
+    db: Session, max_docs: int = VESPA_FIXTURE_COUNT, deterministic_metadata=False
+) -> None:
     """
     Sets up the database using fixtures
 
@@ -76,7 +78,10 @@ def _populate_db_families(db: Session, max_docs: int = VESPA_FIXTURE_COUNT) -> N
         if doc["fields"]["family_document_ref"] not in seen_family_ids:
             _create_family(db, family)
             _create_family_event(db, family)
-            _create_family_metadata(db, family)
+            if not deterministic_metadata:
+                _create_family_metadata(db, family)
+            else:
+                _create_family_metadata_deterministic(db, family)
             seen_family_ids.append(doc["fields"]["family_document_ref"])
         _create_document(db, doc, family)
         if count == max_docs:
@@ -166,6 +171,24 @@ def _get_taxonomy(db: Session, org_name: str):
 
 
 def _create_family_metadata(db: Session, family: VespaFixture):
+    if family["fields"]["family_source"] in ["UNFCCC", "CCLW"]:
+        taxonomy = _get_taxonomy(db, family["fields"]["family_source"])
+    else:
+        raise ValueError(
+            f"Could not get taxonomy for: {family['fields']['family_source']}"
+        )
+    metadata_value = _generate_synthetic_metadata(taxonomy)
+
+    family_import_id = family["fields"]["family_import_id"]
+    family_metadata = FamilyMetadata(
+        family_import_id=family_import_id,
+        value=metadata_value,
+    )
+    db.add(family_metadata)
+    db.commit()
+
+
+def _create_family_metadata_deterministic(db: Session, family: VespaFixture):
     metadata_values = defaultdict(list)
     family_metadata = family["fields"]["metadata"]
     if not family_metadata:

--- a/tests/search/test_vespasearch.py
+++ b/tests/search/test_vespasearch.py
@@ -468,7 +468,7 @@ def test_metadata_filter(
 ):
     monkeypatch.setattr(search, "_VESPA_CONNECTION", test_vespa)
 
-    _populate_db_families(data_db)
+    _populate_db_families(data_db, deterministic_metadata=True)
 
     response = data_client.post(
         SEARCH_ENDPOINT,

--- a/tests/search/test_vespasearch.py
+++ b/tests/search/test_vespasearch.py
@@ -473,13 +473,11 @@ def test_metadata_filter(label, query, test_vespa, data_db, monkeypatch, data_cl
         {"name": metadata[0], "value": metadata_value} for metadata_value in metadata[1]
     ]
 
-    breakpoint()
-
     response = data_client.post(
         SEARCH_ENDPOINT,
         json={
             "query_string": query,
-            "metadata": [{"name": "sector", "value": "Price"}],
+            "metadata": metadata_filters,
         },
     )
     assert response.status_code == 200


### PR DESCRIPTION
# Description

Adding a test for metadata filtering. 

----

WIP failing test:

So we have metadata from vespa but then we're also querying the db for metadata. In these tests we are getting a disparity between the metadata in vespa and that in the db. Thus, the search results when using a metadata filter aren't correct. I.e. filtering for `sector: Price` returns results without that metadata being present.

`_populate_db_families` is non-deterministic as well. 

`vespa_families[0].hits[0].metadata -> [{'name': 'sector', 'value': 'Price'}...`

`>> family_and_family_metadata[0][1].value['sector']
['Agriculture', 'Urban', 'LULUCF', 'Cross Cutting Area', 'Finance', 'Social development'...]`

`>>> db_family_tuple[1].value['sector']
['Transport', 'Economy-wide', 'Disaster Risk Management (Drm)'.... Not sector: ['Price']`

In theory this shouldn't happen in practice due to the db_state being from the db but is there a possibility we update metadata and before vespa is updated start getting some odd search results? 

Validating this theory that there's a disparity.
Ran the following yql and proved that the vespa search results are correct against the db. 
`vespa query 'select * from family_document where family_import_id contains "CCLW.family.8633.0"`
Validated postgres by adding a breakpoint and adding running the sql alchemy query. 

---

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [ ] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Refactor legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
