### PR TITLE
Move search download tests into separate files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "navigator_backend"
-version = "1.14.17"
+version = "1.14.18"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]

--- a/tests/search/data_download/test_this_search.py
+++ b/tests/search/data_download/test_this_search.py
@@ -1,0 +1,107 @@
+import csv
+from io import StringIO
+from typing import Mapping
+from unittest.mock import patch
+
+import pytest
+
+from app.api.api_v1.routers import search
+from tests.search.setup_search_tests import _populate_db_families
+
+SEARCH_ENDPOINT = "/api/v1/searches"
+CSV_DOWNLOAD_ENDPOINT = "/api/v1/searches/download-csv"
+
+
+def _make_search_request(client, params: Mapping[str, str]):
+    response = client.post(SEARCH_ENDPOINT, json=params)
+    assert response.status_code == 200, response.text
+    return response.json()
+
+
+@pytest.mark.search
+@pytest.mark.parametrize("exact_match", [True, False])
+@pytest.mark.parametrize("query_string", ["", "local"])
+def test_csv_content(
+    exact_match, query_string, test_vespa, data_db, monkeypatch, data_client
+):
+    """Make sure that downloaded CSV content matches a given search"""
+    monkeypatch.setattr(search, "_VESPA_CONNECTION", test_vespa)
+    _populate_db_families(data_db)
+    params = {
+        "exact_match": exact_match,
+        "query_string": query_string,
+    }
+    body = _make_search_request(data_client, params)
+    families = body["families"]
+    assert len(families) > 0
+
+    csv_response = data_client.post(
+        CSV_DOWNLOAD_ENDPOINT,
+        json={
+            "exact_match": exact_match,
+            "query_string": query_string,
+        },
+    )
+    assert csv_response.status_code == 200
+
+    csv_content = csv.DictReader(StringIO(csv_response.text))
+    for row, family in zip(csv_content, families):
+        assert row["Family Name"] == family["family_name"]
+        assert row["Family Summary"] == family["family_description"]
+        assert row["Family Publication Date"] == family["family_date"]
+        assert row["Category"] == family["family_category"]
+        assert row["Geography"] == family["family_geography"]
+
+        # TODO: Add collections to test db setup to provide document level coverage
+
+
+@pytest.mark.search
+@pytest.mark.parametrize("label, query", [("search", "the"), ("browse", "")])
+@pytest.mark.parametrize("limit", [100, 250, 500])
+def test_csv_download_search_variable_limit(
+    label, query, limit, test_vespa, data_db, monkeypatch, data_client, mocker
+):
+    monkeypatch.setattr(search, "_VESPA_CONNECTION", test_vespa)
+    _populate_db_families(data_db)
+
+    query_spy = mocker.spy(search._VESPA_CONNECTION, "search")
+
+    params = {
+        "query_string": query,
+        "limit": limit,
+        "page_size": 100,
+        "offset": 0,
+    }
+
+    download_response = data_client.post(
+        CSV_DOWNLOAD_ENDPOINT,
+        json=params,
+    )
+    assert download_response.status_code == 200
+
+    actual_params = query_spy.call_args.kwargs["parameters"].model_dump()
+
+    # Check requested params are not changed
+    for key, value in params.items():
+        assert actual_params[key] == value
+
+
+@pytest.mark.search
+def test_csv_download__ignore_extra_fields(
+    test_vespa, data_db, monkeypatch, data_client, mocker
+):
+    monkeypatch.setattr(search, "_VESPA_CONNECTION", test_vespa)
+    _populate_db_families(data_db)
+
+    params = {
+        "query_string": "winter",
+    }
+
+    # Ensure extra, unspecified fields don't cause an error
+    fields = []
+    with patch("app.core.search._CSV_SEARCH_RESPONSE_COLUMNS", fields):
+        download_response = data_client.post(
+            CSV_DOWNLOAD_ENDPOINT,
+            json=params,
+        )
+    assert download_response.status_code == 200

--- a/tests/search/data_download/test_whole_database.py
+++ b/tests/search/data_download/test_whole_database.py
@@ -1,0 +1,27 @@
+from unittest.mock import patch
+
+import pytest
+
+from tests.search.setup_search_tests import _populate_db_families
+
+ALL_DATA_DOWNLOAD_ENDPOINT = "/api/v1/searches/download-all-data"
+
+
+@pytest.mark.search
+def test_all_data_download(data_db, data_client):
+    _populate_db_families(data_db)
+
+    with (
+        patch("app.api.api_v1.routers.search.PIPELINE_BUCKET", "test_pipeline_bucket"),
+        patch("app.api.api_v1.routers.search.DOC_CACHE_BUCKET", "test_cdn_bucket"),
+        patch("app.core.aws.S3Client.is_connected", return_value=True),
+    ):
+        data_client.follow_redirects = False
+        download_response = data_client.get(ALL_DATA_DOWNLOAD_ENDPOINT)
+
+    # Redirects to cdn
+    assert download_response.status_code == 303
+    assert download_response.headers["location"] == (
+        "https://cdn.climatepolicyradar.org/"
+        "navigator/dumps/whole_data_dump-2024-03-22.zip"
+    )

--- a/tests/search/test_vespasearch.py
+++ b/tests/search/test_vespasearch.py
@@ -1,8 +1,5 @@
-import csv
 import time
-from io import StringIO
 from typing import Mapping
-from unittest.mock import patch
 
 import pytest
 from db_client.models.dfce import Geography, Slug
@@ -22,8 +19,6 @@ from tests.search.setup_search_tests import (
 )
 
 SEARCH_ENDPOINT = "/api/v1/searches"
-CSV_DOWNLOAD_ENDPOINT = "/api/v1/searches/download-csv"
-ALL_DATA_DOWNLOAD_ENDPOINT = "/api/v1/searches/download-all-data"
 
 
 def _make_search_request(client, params: Mapping[str, str]):
@@ -264,7 +259,6 @@ def test_specific_doc_returned(test_vespa, monkeypatch, data_client, data_db):
 def test_search_params_backend_limits(
     test_vespa, monkeypatch, data_client, data_db, extra_params, invalid_field
 ):
-
     monkeypatch.setattr(search, "_VESPA_CONNECTION", test_vespa)
     _populate_db_families(data_db)
 
@@ -772,112 +766,3 @@ def test_empty_ids_dont_limit_result(
 
     assert len(got_family_ids) > 1
     assert len(got_document_ids) > 1
-
-
-@pytest.mark.search
-@pytest.mark.parametrize("exact_match", [True, False])
-@pytest.mark.parametrize("query_string", ["", "local"])
-def test_csv_content(
-    exact_match, query_string, test_vespa, data_db, monkeypatch, data_client
-):
-    """Make sure that downloaded CSV content matches a given search"""
-    monkeypatch.setattr(search, "_VESPA_CONNECTION", test_vespa)
-    _populate_db_families(data_db)
-    params = {
-        "exact_match": exact_match,
-        "query_string": query_string,
-    }
-    body = _make_search_request(data_client, params)
-    families = body["families"]
-    assert len(families) > 0
-
-    csv_response = data_client.post(
-        CSV_DOWNLOAD_ENDPOINT,
-        json={
-            "exact_match": exact_match,
-            "query_string": query_string,
-        },
-    )
-    assert csv_response.status_code == 200
-
-    csv_content = csv.DictReader(StringIO(csv_response.text))
-    for row, family in zip(csv_content, families):
-        assert row["Family Name"] == family["family_name"]
-        assert row["Family Summary"] == family["family_description"]
-        assert row["Family Publication Date"] == family["family_date"]
-        assert row["Category"] == family["family_category"]
-        assert row["Geography"] == family["family_geography"]
-
-        # TODO: Add collections to test db setup to provide document level coverage
-
-
-@pytest.mark.search
-@pytest.mark.parametrize("label, query", [("search", "the"), ("browse", "")])
-@pytest.mark.parametrize("limit", [100, 250, 500])
-def test_csv_download_search_variable_limit(
-    label, query, limit, test_vespa, data_db, monkeypatch, data_client, mocker
-):
-    monkeypatch.setattr(search, "_VESPA_CONNECTION", test_vespa)
-    _populate_db_families(data_db)
-
-    query_spy = mocker.spy(search._VESPA_CONNECTION, "search")
-
-    params = {
-        "query_string": query,
-        "limit": limit,
-        "page_size": 100,
-        "offset": 0,
-    }
-
-    download_response = data_client.post(
-        CSV_DOWNLOAD_ENDPOINT,
-        json=params,
-    )
-    assert download_response.status_code == 200
-
-    actual_params = query_spy.call_args.kwargs["parameters"].model_dump()
-
-    # Check requested params are not changed
-    for key, value in params.items():
-        assert actual_params[key] == value
-
-
-@pytest.mark.search
-def test_csv_download__ignore_extra_fields(
-    test_vespa, data_db, monkeypatch, data_client, mocker
-):
-    monkeypatch.setattr(search, "_VESPA_CONNECTION", test_vespa)
-    _populate_db_families(data_db)
-
-    params = {
-        "query_string": "winter",
-    }
-
-    # Ensure extra, unspecified fields don't cause an error
-    fields = []
-    with patch("app.core.search._CSV_SEARCH_RESPONSE_COLUMNS", fields):
-        download_response = data_client.post(
-            CSV_DOWNLOAD_ENDPOINT,
-            json=params,
-        )
-    assert download_response.status_code == 200
-
-
-@pytest.mark.search
-def test_all_data_download(data_db, data_client):
-    _populate_db_families(data_db)
-
-    with (
-        patch("app.api.api_v1.routers.search.PIPELINE_BUCKET", "test_pipeline_bucket"),
-        patch("app.api.api_v1.routers.search.DOC_CACHE_BUCKET", "test_cdn_bucket"),
-        patch("app.core.aws.S3Client.is_connected", return_value=True),
-    ):
-        data_client.follow_redirects = False
-        download_response = data_client.get(ALL_DATA_DOWNLOAD_ENDPOINT)
-
-    # Redirects to cdn
-    assert download_response.status_code == 303
-    assert download_response.headers["location"] == (
-        "https://cdn.climatepolicyradar.org/"
-        "navigator/dumps/whole_data_dump-2024-03-22.zip"
-    )


### PR DESCRIPTION
# Description

When working on PDCT-1274, I found that the search test files are huge and kinda grim to maintain. This PR splits the download search tests into separate files as part one of a refactor to make the search tests more maintainable.

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Refactor legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
