### PR TITLE
Move vespa ids search tests into a separate file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "navigator_backend"
-version = "1.14.18"
+version = "1.14.19"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]

--- a/tests/search/test_vespa_ids_search.py
+++ b/tests/search/test_vespa_ids_search.py
@@ -11,8 +11,8 @@ from tests.search.setup_search_tests import _populate_db_families
 SEARCH_ENDPOINT = "/api/v1/searches"
 
 
-def _make_search_request(client, token, params: Mapping[str, str]):
-    response = client.post(SEARCH_ENDPOINT, json=params, headers={"app-token": token})
+def _make_search_request(client, params: Mapping[str, str]):
+    response = client.post(SEARCH_ENDPOINT, json=params)
     assert response.status_code == 200, response.text
     return response.json()
 
@@ -56,9 +56,7 @@ def _fam_ids_from_response(test_db, response) -> list[str]:
     ],
 )
 @pytest.mark.search
-def test_family_ids_search(
-    test_vespa, data_db, monkeypatch, data_client, family_ids, valid_token
-):
+def test_family_ids_search(test_vespa, data_db, monkeypatch, data_client, family_ids):
     monkeypatch.setattr(search, "_VESPA_CONNECTION", test_vespa)
     _populate_db_families(data_db)
 
@@ -67,7 +65,7 @@ def test_family_ids_search(
         "family_ids": family_ids,
     }
 
-    response = _make_search_request(data_client, valid_token, params)
+    response = _make_search_request(data_client, params)
 
     got_family_ids = _fam_ids_from_response(data_db, response)
     assert sorted(got_family_ids) == sorted(family_ids)
@@ -87,7 +85,7 @@ def test_family_ids_search(
 )
 @pytest.mark.search
 def test_document_ids_search(
-    test_vespa, data_db, monkeypatch, data_client, document_ids, valid_token
+    test_vespa, data_db, monkeypatch, data_client, document_ids
 ):
     monkeypatch.setattr(search, "_VESPA_CONNECTION", test_vespa)
     _populate_db_families(data_db)
@@ -96,7 +94,7 @@ def test_document_ids_search(
         "query_string": "the",
         "document_ids": document_ids,
     }
-    response = _make_search_request(data_client, valid_token, params)
+    response = _make_search_request(data_client, params)
 
     got_document_ids = _doc_ids_from_response(data_db, response)
     assert sorted(got_document_ids) == sorted(document_ids)
@@ -104,7 +102,7 @@ def test_document_ids_search(
 
 @pytest.mark.search
 def test_document_ids_and_family_ids_search(
-    test_vespa, data_db, monkeypatch, data_client, valid_token
+    test_vespa, data_db, monkeypatch, data_client
 ):
     monkeypatch.setattr(search, "_VESPA_CONNECTION", test_vespa)
     _populate_db_families(data_db)
@@ -118,14 +116,12 @@ def test_document_ids_and_family_ids_search(
         "document_ids": document_ids,
     }
 
-    response = _make_search_request(data_client, valid_token, params)
+    response = _make_search_request(data_client, params)
     assert len(response["families"]) == 0
 
 
 @pytest.mark.search
-def test_empty_ids_dont_limit_result(
-    test_vespa, data_db, monkeypatch, data_client, valid_token
-):
+def test_empty_ids_dont_limit_result(test_vespa, data_db, monkeypatch, data_client):
     monkeypatch.setattr(search, "_VESPA_CONNECTION", test_vespa)
     _populate_db_families(data_db)
 
@@ -136,7 +132,7 @@ def test_empty_ids_dont_limit_result(
         "document_ids": [],
     }
 
-    response = _make_search_request(data_client, valid_token, params)
+    response = _make_search_request(data_client, params)
 
     got_document_ids = _doc_ids_from_response(data_db, response)
     got_family_ids = _fam_ids_from_response(data_db, response)

--- a/tests/search/test_vespa_ids_search.py
+++ b/tests/search/test_vespa_ids_search.py
@@ -1,0 +1,145 @@
+from typing import Mapping
+
+import pytest
+from db_client.models.dfce import Slug
+from db_client.models.dfce.family import FamilyDocument
+from sqlalchemy.orm import Session
+
+from app.api.api_v1.routers import search
+from tests.search.setup_search_tests import _populate_db_families
+
+SEARCH_ENDPOINT = "/api/v1/searches"
+
+
+def _make_search_request(client, token, params: Mapping[str, str]):
+    response = client.post(SEARCH_ENDPOINT, json=params, headers={"app-token": token})
+    assert response.status_code == 200, response.text
+    return response.json()
+
+
+def _doc_ids_from_response(test_db: Session, response: dict) -> list[str]:
+    """The response doesnt know about ids, so we look them up using the slug"""
+    document_ids = []
+    for fam in response["families"]:
+        for doc in fam["family_documents"]:
+            family_document = (
+                test_db.query(FamilyDocument)
+                .join(Slug, Slug.family_document_import_id == FamilyDocument.import_id)
+                .filter(Slug.name == doc["document_slug"])
+                .one()
+            )
+            document_ids.append(family_document.import_id)
+
+    return document_ids
+
+
+def _fam_ids_from_response(test_db, response) -> list[str]:
+    """The response doesnt know about ids, so we look them up using the slug"""
+    family_ids = []
+    for fam in response["families"]:
+        family_document = (
+            test_db.query(FamilyDocument)
+            .join(Slug, Slug.family_import_id == FamilyDocument.family_import_id)
+            .filter(Slug.name == fam["family_slug"])
+            .one()
+        )
+        family_ids.append(family_document.family_import_id)
+    return family_ids
+
+
+@pytest.mark.parametrize(
+    "family_ids",
+    [
+        ["CCLW.family.1385.0"],
+        ["CCLW.family.10246.0", "CCLW.family.8633.0"],
+        ["CCLW.family.10246.0", "CCLW.family.8633.0", "UNFCCC.family.1267.0"],
+    ],
+)
+@pytest.mark.search
+def test_family_ids_search(
+    test_vespa, data_db, monkeypatch, data_client, family_ids, valid_token
+):
+    monkeypatch.setattr(search, "_VESPA_CONNECTION", test_vespa)
+    _populate_db_families(data_db)
+
+    params = {
+        "query_string": "the",
+        "family_ids": family_ids,
+    }
+
+    response = _make_search_request(data_client, valid_token, params)
+
+    got_family_ids = _fam_ids_from_response(data_db, response)
+    assert sorted(got_family_ids) == sorted(family_ids)
+
+
+@pytest.mark.parametrize(
+    "document_ids",
+    [
+        ["CCLW.executive.1385.5336"],
+        ["CCLW.executive.10246.4861", "UNFCCC.non-party.1267.0"],
+        [
+            "CCLW.executive.8633.3052",
+            "UNFCCC.non-party.1267.0",
+            "CCLW.executive.10246.4861",
+        ],
+    ],
+)
+@pytest.mark.search
+def test_document_ids_search(
+    test_vespa, data_db, monkeypatch, data_client, document_ids, valid_token
+):
+    monkeypatch.setattr(search, "_VESPA_CONNECTION", test_vespa)
+    _populate_db_families(data_db)
+
+    params = {
+        "query_string": "the",
+        "document_ids": document_ids,
+    }
+    response = _make_search_request(data_client, valid_token, params)
+
+    got_document_ids = _doc_ids_from_response(data_db, response)
+    assert sorted(got_document_ids) == sorted(document_ids)
+
+
+@pytest.mark.search
+def test_document_ids_and_family_ids_search(
+    test_vespa, data_db, monkeypatch, data_client, valid_token
+):
+    monkeypatch.setattr(search, "_VESPA_CONNECTION", test_vespa)
+    _populate_db_families(data_db)
+
+    # The doc doesnt belong to the family, so we should get no results
+    family_ids = ["UNFCCC.family.1267.0"]
+    document_ids = ["CCLW.executive.10246.4861"]
+    params = {
+        "query_string": "the",
+        "family_ids": family_ids,
+        "document_ids": document_ids,
+    }
+
+    response = _make_search_request(data_client, valid_token, params)
+    assert len(response["families"]) == 0
+
+
+@pytest.mark.search
+def test_empty_ids_dont_limit_result(
+    test_vespa, data_db, monkeypatch, data_client, valid_token
+):
+    monkeypatch.setattr(search, "_VESPA_CONNECTION", test_vespa)
+    _populate_db_families(data_db)
+
+    # We'd expect this to be interpreted as 'unlimited'
+    params = {
+        "query_string": "the",
+        "family_ids": [],
+        "document_ids": [],
+    }
+
+    response = _make_search_request(data_client, valid_token, params)
+
+    got_document_ids = _doc_ids_from_response(data_db, response)
+    got_family_ids = _fam_ids_from_response(data_db, response)
+
+    assert len(got_family_ids) > 1
+    assert len(got_document_ids) > 1

--- a/tests/search/test_vespasearch.py
+++ b/tests/search/test_vespasearch.py
@@ -2,10 +2,9 @@ import time
 from typing import Mapping
 
 import pytest
-from db_client.models.dfce import Geography, Slug
+from db_client.models.dfce import Geography
 from db_client.models.dfce.family import FamilyDocument
 from sqlalchemy import update
-from sqlalchemy.orm import Session
 
 from app.api.api_v1.routers import search
 from app.core.lookups import get_country_slug_from_country_code
@@ -25,36 +24,6 @@ def _make_search_request(client, params: Mapping[str, str]):
     response = client.post(SEARCH_ENDPOINT, json=params)
     assert response.status_code == 200, response.text
     return response.json()
-
-
-def _doc_ids_from_response(test_db: Session, response: dict) -> list[str]:
-    """The response doesnt know about ids, so we look them up using the slug"""
-    document_ids = []
-    for fam in response["families"]:
-        for doc in fam["family_documents"]:
-            family_document = (
-                test_db.query(FamilyDocument)
-                .join(Slug, Slug.family_document_import_id == FamilyDocument.import_id)
-                .filter(Slug.name == doc["document_slug"])
-                .one()
-            )
-            document_ids.append(family_document.import_id)
-
-    return document_ids
-
-
-def _fam_ids_from_response(test_db, response) -> list[str]:
-    """The response doesnt know about ids, so we look them up using the slug"""
-    family_ids = []
-    for fam in response["families"]:
-        family_document = (
-            test_db.query(FamilyDocument)
-            .join(Slug, Slug.family_import_id == FamilyDocument.family_import_id)
-            .filter(Slug.name == fam["family_slug"])
-            .one()
-        )
-        family_ids.append(family_document.family_import_id)
-    return family_ids
 
 
 @pytest.mark.search
@@ -654,115 +623,3 @@ def test_accents_ignored(
 
     request_time_ms = 1000 * (end - start)
     assert 0 < body["query_time_ms"] < body["total_time_ms"] < request_time_ms
-
-
-@pytest.mark.parametrize(
-    "family_ids",
-    [
-        ["CCLW.family.1385.0"],
-        ["CCLW.family.10246.0", "CCLW.family.8633.0"],
-        ["CCLW.family.10246.0", "CCLW.family.8633.0", "UNFCCC.family.1267.0"],
-    ],
-)
-@pytest.mark.search
-def test_family_ids_search(
-    test_vespa,
-    data_db,
-    monkeypatch,
-    data_client,
-    family_ids,
-):
-    monkeypatch.setattr(search, "_VESPA_CONNECTION", test_vespa)
-    _populate_db_families(data_db)
-
-    params = {
-        "query_string": "the",
-        "family_ids": family_ids,
-    }
-
-    response = _make_search_request(data_client, params)
-
-    got_family_ids = _fam_ids_from_response(data_db, response)
-    assert sorted(got_family_ids) == sorted(family_ids)
-
-
-@pytest.mark.parametrize(
-    "document_ids",
-    [
-        ["CCLW.executive.1385.5336"],
-        ["CCLW.executive.10246.4861", "UNFCCC.non-party.1267.0"],
-        [
-            "CCLW.executive.8633.3052",
-            "UNFCCC.non-party.1267.0",
-            "CCLW.executive.10246.4861",
-        ],
-    ],
-)
-@pytest.mark.search
-def test_document_ids_search(
-    test_vespa,
-    data_db,
-    monkeypatch,
-    data_client,
-    document_ids,
-):
-    monkeypatch.setattr(search, "_VESPA_CONNECTION", test_vespa)
-    _populate_db_families(data_db)
-
-    params = {
-        "query_string": "the",
-        "document_ids": document_ids,
-    }
-    response = _make_search_request(data_client, params)
-
-    got_document_ids = _doc_ids_from_response(data_db, response)
-    assert sorted(got_document_ids) == sorted(document_ids)
-
-
-@pytest.mark.search
-def test_document_ids_and_family_ids_search(
-    test_vespa,
-    data_db,
-    monkeypatch,
-    data_client,
-):
-    monkeypatch.setattr(search, "_VESPA_CONNECTION", test_vespa)
-    _populate_db_families(data_db)
-
-    # The doc doesnt belong to the family, so we should get no results
-    family_ids = ["UNFCCC.family.1267.0"]
-    document_ids = ["CCLW.executive.10246.4861"]
-    params = {
-        "query_string": "the",
-        "family_ids": family_ids,
-        "document_ids": document_ids,
-    }
-
-    response = _make_search_request(data_client, params)
-    assert len(response["families"]) == 0
-
-
-@pytest.mark.search
-def test_empty_ids_dont_limit_result(
-    test_vespa,
-    data_db,
-    monkeypatch,
-    data_client,
-):
-    monkeypatch.setattr(search, "_VESPA_CONNECTION", test_vespa)
-    _populate_db_families(data_db)
-
-    # We'd expect this to be interpreted as 'unlimited'
-    params = {
-        "query_string": "the",
-        "family_ids": [],
-        "document_ids": [],
-    }
-
-    response = _make_search_request(data_client, params)
-
-    got_document_ids = _doc_ids_from_response(data_db, response)
-    got_family_ids = _fam_ids_from_response(data_db, response)
-
-    assert len(got_family_ids) > 1
-    assert len(got_document_ids) > 1


### PR DESCRIPTION
# Description

When working on PDCT-1274, I found that the search test files are huge and kinda grim to maintain. This PR splits the vespa IDs search tests into a separate file as part two of a refactor to make the search tests more maintainable.

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Refactor legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
