### PR TITLE
Feature/pdct 1447 backend does not allow none corpus image urls

### DIFF
--- a/app/core/organisation.py
+++ b/app/core/organisation.py
@@ -11,8 +11,11 @@ from app.core import config
 
 def _to_corpus_data(row) -> CorpusData:
     image_url = (
-        f"https://{config.CDN_DOMAIN}/{row.image_url}" if len(row.image_url) > 0 else ""
+        f"https://{config.CDN_DOMAIN}/{row.image_url}"
+        if row.image_url is not None and len(row.image_url) > 0
+        else ""
     )
+    corpus_text = row.text if row.text is not None else ""
     return CorpusData(
         corpus_import_id=row.corpus_import_id,
         title=row.title,
@@ -20,7 +23,7 @@ def _to_corpus_data(row) -> CorpusData:
         corpus_type=row.corpus_type,
         corpus_type_description=row.corpus_type_description,
         image_url=image_url,
-        text=row.text,
+        text=corpus_text,
         taxonomy={**row.taxonomy},
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "navigator_backend"
-version = "1.16.0"
+version = "1.16.1"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]

--- a/tests/non_search/setup_helpers.py
+++ b/tests/non_search/setup_helpers.py
@@ -1,5 +1,6 @@
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
+from db_client.models.organisation.corpus import Corpus, CorpusType
 from sqlalchemy.orm import Session
 
 from tests.non_search.dfce_helpers import (
@@ -295,3 +296,26 @@ def setup_docs_with_two_orgs_no_langs(db: Session):
     family2["documents"] = [document2]
     add_families(db, families=[family1], org_id=1)
     add_families(db, families=[family2], org_id=2)
+
+
+def setup_new_corpus(
+    db: Session,
+    title: str,
+    description: str,
+    corpus_text: Optional[str],
+    corpus_image_url: Optional[str],
+    organisation_id: int = 1,
+    corpus_type_name: str = "Intl. agreements",
+) -> CorpusType:
+    c = Corpus(
+        import_id="name",
+        title=title,
+        description=description,
+        corpus_text=corpus_text,
+        corpus_image_url=corpus_image_url,
+        organisation_id=organisation_id,
+        corpus_type_name=corpus_type_name,
+    )
+    db.add(c)
+    db.commit()
+    return c

--- a/tests/unit/app/core/test_organisation.py
+++ b/tests/unit/app/core/test_organisation.py
@@ -4,7 +4,7 @@ import pytest
 from sqlalchemy.orm import Session
 
 from app.core.organisation import get_all_organisations, get_corpora_for_org
-from tests.non_search.setup_helpers import setup_with_docs
+from tests.non_search.setup_helpers import setup_new_corpus, setup_with_docs
 
 CCLW_EXPECTED_NUM_CORPORA = 1
 CCLW_METADATA_KEYS = set(
@@ -70,3 +70,11 @@ def test_get_corpora_for_org__empty_when_missing(data_db: Session):
 
     corpora = get_corpora_for_org(data_db, "MISSING_ORG_NAME")
     assert len(corpora) == 0
+
+
+def test_get_corpora_for_org__none_corpus_image_url(data_db: Session):
+    setup_with_docs(data_db)
+    setup_new_corpus(data_db, "title", "description", "corpus_text", None)
+
+    corpora = get_corpora_for_org(data_db, "CCLW")
+    assert len(corpora) == 2

--- a/tests/unit/app/core/test_organisation.py
+++ b/tests/unit/app/core/test_organisation.py
@@ -79,6 +79,12 @@ def test_get_corpora_for_org__none_corpus_image_url(data_db: Session):
     corpora = get_corpora_for_org(data_db, "CCLW")
     assert len(corpora) == 2
 
+    json_corpora = [corpus.model_dump() for corpus in corpora]
+    for corpus in json_corpora:
+        if corpus["title"] == "title":
+            assert corpus["image_url"] == ""
+            pass
+
 
 def test_get_corpora_for_org__none_corpus_text(data_db: Session):
     setup_with_docs(data_db)
@@ -86,3 +92,9 @@ def test_get_corpora_for_org__none_corpus_text(data_db: Session):
 
     corpora = get_corpora_for_org(data_db, "CCLW")
     assert len(corpora) == 2
+
+    json_corpora = [corpus.model_dump() for corpus in corpora]
+    for corpus in json_corpora:
+        if corpus["title"] == "title":
+            assert corpus["text"] == ""
+            pass

--- a/tests/unit/app/core/test_organisation.py
+++ b/tests/unit/app/core/test_organisation.py
@@ -78,3 +78,11 @@ def test_get_corpora_for_org__none_corpus_image_url(data_db: Session):
 
     corpora = get_corpora_for_org(data_db, "CCLW")
     assert len(corpora) == 2
+
+
+def test_get_corpora_for_org__none_corpus_text(data_db: Session):
+    setup_with_docs(data_db)
+    setup_new_corpus(data_db, "title", "description", None, "corpus_image_url")
+
+    corpora = get_corpora_for_org(data_db, "CCLW")
+    assert len(corpora) == 2


### PR DESCRIPTION
# Description

- Convert None corpus image URLs to empty string
- Driveby: Convert None corpus text to empty string
- Tests

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Refactor legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
