### PR TITLE
Add corpus fields to response

### DIFF
--- a/app/api/api_v1/schemas/search.py
+++ b/app/api/api_v1/schemas/search.py
@@ -246,6 +246,16 @@ class SearchResponseFamily(BaseModel):
     The source, currently organisation name. Either “CCLW” or “UNFCCC”
     """
 
+    corpus_import_id: str
+    """
+    The id of the corpus the family belongs to. E.G. 'CCLW.corpus.i00000001.n0000'
+    """
+
+    corpus_type_name: str
+    """
+    The name given to the type of corpus the family belongs to. E.G. 'Laws and Policies'
+    """
+
     family_geography: str
     """
     The geographical location of the family in ISO 3166-1 alpha-3

--- a/app/core/search.py
+++ b/app/core/search.py
@@ -417,6 +417,8 @@ def _process_vespa_search_response_families(
                         else ""
                     ),
                     family_source=hit.family_source,
+                    corpus_import_id=hit.corpus_import_id or "",
+                    corpus_type_name=hit.corpus_type_name or "",
                     family_description_match=False,
                     family_title_match=False,
                     total_passage_hits=vespa_family.total_passage_hits,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "navigator_backend"
-version = "1.16.1"
+version = "1.16.2"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]

--- a/tests/core/test_browse.py
+++ b/tests/core/test_browse.py
@@ -18,3 +18,19 @@ def test_browse_rds_families(data_db):
     )
     result: SearchResponse = browse_rds_families(data_db, args)
     assert result.hits == expected
+
+    family = result.families[0]
+    assert family.family_slug == "FamSlug1"
+    assert family.family_name == "Fam1"
+    assert family.family_description == "Summary1"
+    assert family.family_category == "Executive"
+    assert family.family_date == "2019-12-25T00:00:00+00:00"
+    assert family.family_last_updated_date == "2019-12-25T00:00:00+00:00"
+    assert family.family_source == "CCLW"
+    assert family.corpus_import_id == "CCLW.corpus.i00000001.n0000"
+    assert family.corpus_type_name == "Laws and Policies"
+    assert family.family_geography == "South Asia"
+    assert family.family_geographies == ["South Asia"]
+    assert family.family_metadata == {}
+    assert family.total_passage_hits == 0
+    assert family.family_documents == []

--- a/tests/search/test_search.py
+++ b/tests/search/test_search.py
@@ -584,7 +584,8 @@ class FamSpec:
     family_geo: str
     family_geos: list[str]
     family_metadata: dict[str, list[str]]
-
+    corpus_import_id: str
+    corpus_type_name: str
     description_hit: bool
     family_document_count: int
     document_hit_count: int
@@ -625,6 +626,8 @@ def _generate_search_response_hits(spec: FamSpec) -> Sequence[CprSdkHit]:
                 family_publication_ts=datetime.fromisoformat(spec.family_ts),
                 family_geography=spec.family_geo,
                 family_geographies=spec.family_geos,
+                corpus_import_id=spec.corpus_import_id,
+                corpus_type_name=spec.corpus_type_name,
                 document_cdn_object=(
                     f"{spec.family_import_id}/{slugify(spec.family_name)}"
                     f"_{document_number}"
@@ -657,6 +660,8 @@ def _generate_search_response_hits(spec: FamSpec) -> Sequence[CprSdkHit]:
                 family_publication_ts=datetime.fromisoformat(spec.family_ts),
                 family_geography=spec.family_geo,
                 family_geographies=spec.family_geos,
+                corpus_import_id=spec.corpus_import_id,
+                corpus_type_name=spec.corpus_type_name,
                 document_cdn_object=(
                     f"{spec.family_import_id}/{slugify(spec.family_name)}"
                     f"_{document_number}"
@@ -724,6 +729,8 @@ _FAM_SPEC_0 = FamSpec(
     family_geo="france",
     family_geos=["france"],
     family_metadata={"keyword": ["Spacial Planning"]},
+    corpus_import_id="CCLW.corpus.i00000001.n0000",
+    corpus_type_name="Intl. agreements",
     description_hit=True,
     family_document_count=1,
     document_hit_count=10,
@@ -739,6 +746,8 @@ _FAM_SPEC_1 = FamSpec(
     family_geo="spain",
     family_geos=["spain"],
     family_metadata={"sector": ["Urban", "Transportation"], "keyword": ["Hydrogen"]},
+    corpus_import_id="CCLW.corpus.i00000001.n0000",
+    corpus_type_name="Intl. agreements",
     description_hit=False,
     family_document_count=3,
     document_hit_count=25,
@@ -754,6 +763,8 @@ _FAM_SPEC_2 = FamSpec(
     family_geo="ukraine",
     family_geos=["ukraine"],
     family_metadata={"author_type": ["Non-Party"], "author": ["Anyone"]},
+    corpus_import_id="CCLW.corpus.i00000001.n0000",
+    corpus_type_name="Intl. agreements",
     description_hit=True,
     family_document_count=5,
     document_hit_count=4,
@@ -769,6 +780,8 @@ _FAM_SPEC_3 = FamSpec(
     family_geo="norway",
     family_geos=["norway"],
     family_metadata={"author_type": ["Party"], "author": ["Anyone Else"]},
+    corpus_import_id="CCLW.corpus.i00000001.n0000",
+    corpus_type_name="Intl. agreements",
     description_hit=False,
     family_document_count=2,
     document_hit_count=40,

--- a/tests/search/vespa/setup_search_tests.py
+++ b/tests/search/vespa/setup_search_tests.py
@@ -3,7 +3,7 @@ import random
 from collections import defaultdict
 from datetime import datetime
 from pathlib import Path
-from typing import Iterable, Mapping, Optional, Sequence
+from typing import Any, Iterable, Mapping, Optional, Sequence
 
 from db_client.models.dfce.family import (
     DocumentStatus,
@@ -34,7 +34,7 @@ SEARCH_ENDPOINT = "/api/v1/searches"
 def _make_search_request(
     client,
     token,
-    params: Mapping[str, str],
+    params: Mapping[str, Any],
     expected_status_code: int = status.HTTP_200_OK,
 ):
     response = client.post(SEARCH_ENDPOINT, json=params, headers={"app-token": token})

--- a/tests/search/vespa/test_vespa_search.py
+++ b/tests/search/vespa/test_vespa_search.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 from db_client.models.dfce.family import FamilyDocument
 from fastapi import status
@@ -230,3 +232,44 @@ def test_search_with_deleted_docs(
     all_deleted_count = len(all_deleted_body["families"])
     assert start_family_count > one_deleted_count > all_deleted_count
     assert len(all_deleted_body["families"]) == 0
+
+
+@pytest.mark.search
+@pytest.mark.parametrize(
+    ("corpus_import_id", "corpus_type_name"),
+    [
+        ("CCLW.corpus.1.0", "UNFCCC Submissions"),
+        ("CCLW.corpus.1.0", None),
+        (None, "UNFCCC Submissions"),
+    ],
+)
+def test_corpus_filtering(
+    test_vespa,
+    monkeypatch,
+    data_client,
+    data_db,
+    valid_token,
+    corpus_import_id: str,
+    corpus_type_name: str,
+):
+    monkeypatch.setattr(search, "_VESPA_CONNECTION", test_vespa)
+    _populate_db_families(data_db)
+
+    params: dict[str, Any] = {"query_string": "and"}
+    if corpus_import_id:
+        params["corpus_import_ids"] = [corpus_import_id]
+    if corpus_type_name:
+        params["corpus_type_names"] = [corpus_type_name]
+
+    response = _make_search_request(
+        data_client,
+        token=valid_token,
+        params=params,
+    )
+
+    assert len(response["families"]) > 0
+    for family in response["families"]:
+        if corpus_import_id:
+            assert family["corpus_import_id"] == corpus_import_id
+        if corpus_type_name:
+            assert family["corpus_type_name"] == corpus_type_name

--- a/tests/unit/app/schemas/test_schemas.py
+++ b/tests/unit/app/schemas/test_schemas.py
@@ -134,6 +134,8 @@ def test_search_response() -> None:
                 family_geography="Example Geography",
                 family_geographies=["Example Geography"],
                 family_metadata={"key1": "value1", "key2": "value2"},
+                corpus_import_id="test.corpus.0.1",
+                corpus_type_name="Example Corpus Type",
                 family_title_match=True,
                 family_description_match=False,
                 total_passage_hits=1,


### PR DESCRIPTION
This adds `corpus_import_id` and `corpus_type_name` to the response for search requests.

# Description

Please include:

- a summary of the changes
- links to any related issue/ticket
- any additional relevant motivation and context
- details of any dependency updates that are required for this change

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Refactor legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
