### PR TITLE
Add additional validation of corpora IDs & use host for audience

### DIFF
--- a/app/api/api_v1/routers/search.py
+++ b/app/api/api_v1/routers/search.py
@@ -113,6 +113,7 @@ def search_documents(
             }
         ),
     ],
+    host: Annotated[str, Header()],
     app_token: Annotated[str, Header()],
     db=Depends(get_db),
 ) -> SearchResponse:
@@ -137,7 +138,7 @@ def search_documents(
     results from the search database. See the request schema for more details.
     """
     try:
-        allowed_corpora_ids = decode_config_token(app_token, PUBLIC_APP_URL)
+        allowed_corpora_ids = decode_config_token(app_token, host)
     except PyJWTError as e:
         _LOGGER.error(e)
         raise HTTPException(

--- a/app/api/api_v1/schemas/custom_app.py
+++ b/app/api/api_v1/schemas/custom_app.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from pydantic import BaseModel, HttpUrl
+from pydantic import BaseModel
 
 
 class CustomAppConfigDTO(BaseModel):
@@ -8,7 +8,7 @@ class CustomAppConfigDTO(BaseModel):
 
     allowed_corpora_ids: list[str]
     subject: str
-    audience: HttpUrl
+    audience: str
     issuer: str
     expiry: datetime
     issued_at: int

--- a/app/core/custom_app.py
+++ b/app/core/custom_app.py
@@ -1,11 +1,10 @@
 import logging
 import os
 from datetime import datetime
-from typing import Optional, cast
+from typing import Optional
 
 import jwt
 from dateutil.relativedelta import relativedelta
-from pydantic import HttpUrl
 
 from app.api.api_v1.schemas.custom_app import CustomAppConfigDTO
 from app.core import security
@@ -69,7 +68,7 @@ def create_configuration_token(input: str, years: Optional[int] = None) -> str:
         allowed_corpora_ids=_parse_and_sort_corpora_ids(corpora_ids),
         subject=subject,
         issuer=ISSUER,
-        audience=cast(HttpUrl, add_trailing_slash_to_url(audience)),
+        audience=audience,
         expiry=expire,
         issued_at=int(
             datetime.timestamp(issued_at.replace(microsecond=0))
@@ -111,21 +110,8 @@ def decode_config_token(token: str, audience: Optional[str]) -> list[str]:
         TOKEN_SECRET_KEY,
         algorithms=[security.ALGORITHM],
         issuer=ISSUER,
-        audience=(
-            add_trailing_slash_to_url(audience) if audience is not None else None
-        ),
+        audience=audience,
     )
     corpora_ids: list = decoded_token.get("allowed_corpora_ids")
 
     return corpora_ids
-
-
-def add_trailing_slash_to_url(app_url: str) -> str:
-    """Add trailing slash to end of a URL string.
-
-    :param str app_url : A URL in string format.
-    :return str: The URL with a trailing '/' added if it wasn't present.
-    """
-    if not app_url.endswith("/"):
-        app_url += "/"
-    return app_url

--- a/docs/custom_apps.md
+++ b/docs/custom_apps.md
@@ -15,8 +15,8 @@ where:
   custom app
 - `THEME` is the name of the theme or organisation - it must not contain any
   special characters or spaces
-- `APP_DOMAIN` is the domain name of the custom app (NOTE: this is specific to
-  the AWS environment)
+- `AUDIENCE` is the host name of the custom app, without HTTP scheme. This must
+  not end with a trailing slash OR start with a trailing slash.
 
 ## Example usage
 
@@ -29,8 +29,8 @@ want to generate the token for.
 export TOKEN_SECRET_KEY=secret_key
 export CORPORA_IDS=CCLW.corpus.i00000001.n0000,UNFCCC.corpus.i00000001.n0000
 export THEME=CPR
-export APP_DOMAIN=https://app.climatepolicyradar.org/
-python -c "from app.core import config; from app.core.custom_app import create_configuration_token; print(create_configuration_token('$CORPORA_IDS;$THEME;$APP_DOMAIN'))"
+export AUDIENCE=app.dev.climatepolicyradar.org
+python -c "from app.core import config; from app.core.custom_app import create_configuration_token; print(create_configuration_token('$CORPORA_IDS;$THEME;$AUDIENCE'))"
 ```
 
 ### Decoding

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "navigator_backend"
-version = "1.16.3"
+version = "1.16.4"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -115,7 +115,24 @@ def valid_token():
     """
     corpora_ids = "CCLW.corpus.i00000001.n0000,UNFCCC.corpus.i00000001.n0000"
     subject = "CCLW"
-    audience = "http://localhost:3000"
+    audience = "localhost:8888"
+    input_str = f"{corpora_ids};{subject};{audience}"
+    return create_configuration_token(input_str)
+
+
+@pytest.fixture
+def unfccc_token():
+    """Generate valid config token using TOKEN_SECRET_KEY.
+
+    Need to generate the config token using the token secret key from
+    your local env file. For tests in CI, this will be the secret key in
+    the .env.example file, but for local development this secret key
+    might be different (e.g., the one for staging). This fixture works
+    around this.
+    """
+    corpora_ids = "CCLW.corpus.i00000001.n0000,UNFCCC.corpus.i00000001.n0000"
+    subject = "CCLW"
+    audience = "localhost:8888"
     input_str = f"{corpora_ids};{subject};{audience}"
     return create_configuration_token(input_str)
 

--- a/tests/search/vespa/setup_search_tests.py
+++ b/tests/search/vespa/setup_search_tests.py
@@ -29,6 +29,7 @@ from fastapi import status
 from sqlalchemy.orm import Session
 
 SEARCH_ENDPOINT = "/api/v1/searches"
+TEST_HOST = "localhost:8888"
 
 
 def _make_search_request(
@@ -37,7 +38,11 @@ def _make_search_request(
     params: Mapping[str, Any],
     expected_status_code: int = status.HTTP_200_OK,
 ):
-    response = client.post(SEARCH_ENDPOINT, json=params, headers={"app-token": token})
+    response = client.post(
+        SEARCH_ENDPOINT,
+        json=params,
+        headers={"app-token": token, "host": TEST_HOST},
+    )
     assert response.status_code == expected_status_code, response.text
     return response.json()
 
@@ -160,7 +165,7 @@ def _create_family_event(db: Session, family: VespaFixture):
 
 
 def _generate_synthetic_metadata(
-    taxonomy: Mapping[str, dict]
+    taxonomy: Mapping[str, dict],
 ) -> Mapping[str, Sequence[str]]:
     meta_value = {}
     for k in taxonomy:

--- a/tests/search/vespa/test_search_raises_on_token_errors.py
+++ b/tests/search/vespa/test_search_raises_on_token_errors.py
@@ -24,7 +24,7 @@ def test_search_with_invalid_corpus_id_in_token(
     _populate_db_families(data_db)
 
     with patch(
-        "app.api.api_v1.routers.search.validate_corpora_ids", return_value=False
+        "app.api.api_v1.routers.search.verify_any_corpora_ids_in_db", return_value=False
     ):
         response = _make_search_request(
             data_client,
@@ -33,7 +33,7 @@ def test_search_with_invalid_corpus_id_in_token(
             expected_status_code=status.HTTP_400_BAD_REQUEST,
         )
 
-        assert response["detail"] == "Error validating corpora IDs."
+        assert response["detail"] == "Error verifying corpora IDs."
 
 
 @pytest.mark.search


### PR DESCRIPTION
# Description

- Add step one of two-stage verification for corpora IDs
- Use host for audience instead of FQDN + scheme
- Basic tests

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Refactor legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
