### PR TITLE
Use origin as custom app configuration audience on decode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "navigator_backend"
-version = "1.17.0"
+version = "1.17.1"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -115,7 +115,7 @@ def valid_token():
     """
     corpora_ids = "CCLW.corpus.1.0,CCLW.corpus.2.0"
     subject = "CCLW"
-    audience = "localhost:8888"
+    audience = "localhost"
     input_str = f"{corpora_ids};{subject};{audience}"
     return create_configuration_token(input_str)
 

--- a/tests/search/vespa/setup_search_tests.py
+++ b/tests/search/vespa/setup_search_tests.py
@@ -39,10 +39,16 @@ def _make_search_request(
     expected_status_code: int = status.HTTP_200_OK,
     origin: Optional[str] = TEST_HOST,
 ):
+    headers = (
+        {"app-token": token}
+        if origin is None
+        else {"app-token": token, "origin": origin}
+    )
+
     response = client.post(
         SEARCH_ENDPOINT,
         json=params,
-        headers={"app-token": token, "origin": origin},
+        headers=headers,
     )
     assert response.status_code == expected_status_code, response.text
     return response.json()

--- a/tests/search/vespa/setup_search_tests.py
+++ b/tests/search/vespa/setup_search_tests.py
@@ -29,7 +29,7 @@ from fastapi import status
 from sqlalchemy.orm import Session
 
 SEARCH_ENDPOINT = "/api/v1/searches"
-TEST_HOST = "localhost:8888"
+TEST_HOST = "http://localhost:3000/"
 
 
 def _make_search_request(
@@ -41,7 +41,7 @@ def _make_search_request(
     response = client.post(
         SEARCH_ENDPOINT,
         json=params,
-        headers={"app-token": token, "host": TEST_HOST},
+        headers={"app-token": token, "origin": TEST_HOST},
     )
     assert response.status_code == expected_status_code, response.text
     return response.json()

--- a/tests/search/vespa/setup_search_tests.py
+++ b/tests/search/vespa/setup_search_tests.py
@@ -37,11 +37,12 @@ def _make_search_request(
     token,
     params: Mapping[str, Any],
     expected_status_code: int = status.HTTP_200_OK,
+    origin: Optional[str] = TEST_HOST,
 ):
     response = client.post(
         SEARCH_ENDPOINT,
         json=params,
-        headers={"app-token": token, "origin": TEST_HOST},
+        headers={"app-token": token, "origin": origin},
     )
     assert response.status_code == expected_status_code, response.text
     return response.json()

--- a/tests/search/vespa/test_vespa_corpus_filtering.py
+++ b/tests/search/vespa/test_vespa_corpus_filtering.py
@@ -127,6 +127,33 @@ def test_search_decoding_token_raises_PyJWTError(
 
 
 @pytest.mark.search
+def test_search_decoding_token_with_none_origin_passed_to_audience(
+    data_client,
+    data_db,
+    valid_token,
+    monkeypatch,
+    test_vespa,
+):
+    """
+    GIVEN a request to the search endpoint
+    WHEN the decode_config_token() function is passed a None origin
+    THEN raise a 400 HTTP error
+    """
+    monkeypatch.setattr(search, "_VESPA_CONNECTION", test_vespa)
+    _populate_db_families(data_db)
+
+    response = _make_search_request(
+        data_client,
+        valid_token,
+        params={"query_string": ""},
+        origin=None,
+        expected_status_code=status.HTTP_400_BAD_REQUEST,
+    )
+
+    assert response["detail"] == "Could not decode configuration token"
+
+
+@pytest.mark.search
 def test_search_with_invalid_corpus_id_in_search_request_params(
     data_client, data_db, valid_token, monkeypatch, test_vespa
 ):


### PR DESCRIPTION
# Description

Fix staging - use origin from CORS as custom app configuration token audience value on decode.

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Refactor legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
