### PR TITLE
Feature/pla 183 run backfill to add more date information from family to s3

### DIFF
--- a/app/core/ingestion/pipeline.py
+++ b/app/core/ingestion/pipeline.py
@@ -96,6 +96,8 @@ def generate_pipeline_ingest_input(db: Session) -> Sequence[DocumentParserInput]
             metadata=flatten_pipeline_metadata(
                 cast(MetadataType, family_metadata.value),
                 cast(MetadataType, family_document.valid_metadata),
+                family.last_updated_date,
+                family.published_date,
             ),
         )
         for (
@@ -128,7 +130,10 @@ def generate_pipeline_ingest_input(db: Session) -> Sequence[DocumentParserInput]
 
 
 def flatten_pipeline_metadata(
-    family_metadata: MetadataType, document_metadata: MetadataType
+    family_metadata: MetadataType,
+    document_metadata: MetadataType,
+    last_updated: datetime,
+    published_date: datetime,
 ) -> MetadataType:
     """Combines metadata objects ready for the pipeline"""
 
@@ -139,5 +144,8 @@ def flatten_pipeline_metadata(
 
     for k, v in document_metadata.items():
         metadata[f"document.{k}"] = v
+
+    metadata["family.last_updated_date"] = last_updated
+    metadata["family.published_date"] = published_date
 
     return metadata

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "navigator_backend"
-version = "1.17.1"
+version = "1.17.2"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]

--- a/tests/unit/app/core/test_pipeline.py
+++ b/tests/unit/app/core/test_pipeline.py
@@ -49,13 +49,13 @@ def test_generate_pipeline_ingest_input(data_db: Session):
     assert state_rows[0].document_title == "Document2"
 
     # Check metadata
-    assert state_rows[0].metadata["family.published_data"] == datetime(
+    assert state_rows[0].metadata["family.published_date"] == datetime(
         2019, 12, 25, 0, 0, tzinfo=timezone.utc
     )
     assert state_rows[0].metadata["family.last_updated_date"] == datetime(
         2019, 12, 25, 0, 0, tzinfo=timezone.utc
     )
-    assert state_rows[0].metadata["family.published_data"] == datetime(
+    assert state_rows[0].metadata["family.published_date"] == datetime(
         2019, 12, 25, 0, 0, tzinfo=timezone.utc
     )
     assert state_rows[0].metadata["family.last_updated_date"] == datetime(

--- a/tests/unit/app/core/test_pipeline.py
+++ b/tests/unit/app/core/test_pipeline.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timezone
 from typing import Dict
 
 from sqlalchemy.orm import Session
@@ -18,6 +19,7 @@ def test_generate_pipeline_ingest_input(data_db: Session):
     setup_with_two_docs_one_family(data_db)
 
     state_rows = generate_pipeline_ingest_input(data_db)
+
     assert len(state_rows) == 2
     # Sort to ensure order is consistent across tests
     state_rows = sorted(state_rows, key=lambda d: d.import_id, reverse=True)
@@ -45,6 +47,20 @@ def test_generate_pipeline_ingest_input(data_db: Session):
 
     # Check physical_document
     assert state_rows[0].document_title == "Document2"
+
+    # Check metadata
+    assert state_rows[0].metadata["family.published_data"] == datetime(
+        2019, 12, 25, 0, 0, tzinfo=timezone.utc
+    )
+    assert state_rows[0].metadata["family.last_updated_date"] == datetime(
+        2019, 12, 25, 0, 0, tzinfo=timezone.utc
+    )
+    assert state_rows[0].metadata["family.published_data"] == datetime(
+        2019, 12, 25, 0, 0, tzinfo=timezone.utc
+    )
+    assert state_rows[0].metadata["family.last_updated_date"] == datetime(
+        2019, 12, 25, 0, 0, tzinfo=timezone.utc
+    )
 
 
 def test_generate_pipeline_ingest_input_with_fixture(

--- a/tests/unit/app/core/test_pipeline.py
+++ b/tests/unit/app/core/test_pipeline.py
@@ -93,10 +93,17 @@ def test_generate_pipeline_ingest_input__deleted(data_db: Session):
 def test_flatten_pipeline_metadata():
     family_metadata = {"a": ["1"], "b": ["2"]}
     doc_metadata = {"a": ["3"], "b": ["4"]}
-    result = flatten_pipeline_metadata(family_metadata, doc_metadata)
+    last_updated_date = datetime(2021, 1, 1, tzinfo=timezone.utc)
+    published_date = datetime(2021, 1, 1, tzinfo=timezone.utc)
 
-    assert len(result) == 4
+    result = flatten_pipeline_metadata(
+        family_metadata, doc_metadata, last_updated_date, published_date
+    )
+
+    assert len(result) == 6
     assert result["family.a"] == ["1"]
     assert result["family.b"] == ["2"]
     assert result["document.a"] == ["3"]
     assert result["document.b"] == ["4"]
+    assert result["family.last_updated_date"] == last_updated_date
+    assert result["family.published_date"] == published_date


### PR DESCRIPTION
# **DO NOT MERGE YET** 

----

# Description

This update adds more fields from the `Family` object to the metadata field on the `DocumentParserInput` object. This is as data science require some more fields to be accessible from the objects in s3. 

It is deemed a more complete solution to run a backfill rather than call the api for the data in the long term. 

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Refactor legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
