### PR TITLE
Remove verify_aud check when in DEVELOPMENT_MODE

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -20,6 +20,10 @@ INGEST_CYCLE_START = os.getenv("INGEST_CYCLE_START")
 DOC_CACHE_BUCKET = os.getenv("DOCUMENT_CACHE_BUCKET")
 PIPELINE_BUCKET: str = os.getenv("PIPELINE_BUCKET", "not_set")
 INGEST_TRIGGER_ROOT: Final = "input"
-DEVELOPMENT_MODE: bool = os.getenv("DEVELOPMENT_MODE", "False").lower() == "true"
+DEVELOPMENT_MODE = (
+    True
+    if "dev" in PUBLIC_APP_URL
+    else os.getenv("DEVELOPMENT_MODE", "False").lower() == "true"
+)
 AWS_REGION = os.getenv("AWS_REGION", "eu-west-1")
 CDN_DOMAIN = os.getenv("CDN_DOMAIN")

--- a/app/core/custom_app.py
+++ b/app/core/custom_app.py
@@ -8,6 +8,7 @@ from dateutil.relativedelta import relativedelta
 
 from app.api.api_v1.schemas.custom_app import CustomAppConfigDTO
 from app.core import security
+from app.core.config import DEVELOPMENT_MODE
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -111,6 +112,7 @@ def decode_config_token(token: str, audience: Optional[str]) -> list[str]:
         algorithms=[security.ALGORITHM],
         issuer=ISSUER,
         audience=audience,
+        options={"verify_aud": not DEVELOPMENT_MODE},
     )
     corpora_ids: list = decoded_token.get("allowed_corpora_ids")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "navigator_backend"
-version = "1.17.1"
+version = "1.17.2"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -104,7 +104,7 @@ def get_test_db_url() -> str:
 
 
 @pytest.fixture
-def valid_token():
+def valid_token(monkeypatch):
     """Generate valid config token using TOKEN_SECRET_KEY.
 
     Need to generate the config token using the token secret key from
@@ -113,6 +113,7 @@ def valid_token():
     might be different (e.g., the one for staging). This fixture works
     around this.
     """
+    monkeypatch.setattr("app.core.custom_app.DEVELOPMENT_MODE", False)
     corpora_ids = "CCLW.corpus.1.0,CCLW.corpus.2.0"
     subject = "CCLW"
     audience = "localhost"

--- a/tests/unit/app/core/custom_app/test_decode_configuration_token.py
+++ b/tests/unit/app/core/custom_app/test_decode_configuration_token.py
@@ -30,9 +30,10 @@ def test_decoding_expired_token_raise_expired_signature_token_error(expired_toke
         ),
     ],
 )
-def test_decoding_token_with_invalid_aud_raises_expired_signature_token_error(
-    input_str: str, aud: Optional[str], error_msg: str
+def test_decoding_token_with_invalid_aud_raises_invalid_token_error(
+    input_str: str, aud: Optional[str], error_msg: str, monkeypatch
 ):
+    monkeypatch.setattr("app.core.custom_app.DEVELOPMENT_MODE", False)
     token = create_configuration_token(input_str)
     with pytest.raises(jwt.InvalidTokenError) as error:
         decode_config_token(token, aud)

--- a/tests/unit/app/core/custom_app/test_decode_configuration_token.py
+++ b/tests/unit/app/core/custom_app/test_decode_configuration_token.py
@@ -41,7 +41,29 @@ def test_decoding_token_with_invalid_aud_raises_invalid_token_error(
     assert str(error.value) == error_msg
 
 
-def test_decode_configuration_token_success(valid_token):
+@pytest.mark.parametrize(
+    "input_str, aud",
+    [
+        ("mango,apple;subject;https://audience.com", None),
+        ("mango,apple;subject;https://audience.com", "https://audience.org"),
+        ("mango,apple;subject;https://AUDIENCE.OrG", "https://AUDIENCE.Com"),
+    ],
+)
+def test_decoding_token_with_invalid_aud_success_in_dev_mode(
+    input_str: str, aud: Optional[str], monkeypatch
+):
+    monkeypatch.setattr("app.core.custom_app.DEVELOPMENT_MODE", True)
+    token = create_configuration_token(input_str)
+    decoded_corpora_ids = decode_config_token(token, aud)
+    assert len(decoded_corpora_ids) > 0
+
+    expected_num_corpora = 2
+    assert len(decoded_corpora_ids) == expected_num_corpora
+
+
+@pytest.mark.parametrize("development_mode", [True, False])
+def test_decode_configuration_token_success(development_mode, monkeypatch, valid_token):
+    monkeypatch.setattr("app.core.custom_app.DEVELOPMENT_MODE", development_mode)
     decoded_corpora_ids = decode_config_token(valid_token, VALID_AUDIENCE)
     assert len(decoded_corpora_ids) > 0
 


### PR DESCRIPTION
# Description

- If on staging, set DEVELOPMENT_MODE to True
- Otherwise see if DEVELOPMENT_MODE is set, default to False if not
- Add verify_aud to jwt.decode options and set its bool value on the negation of the value of DEVELOPMENT_MODE
- Update tests

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Refactor legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
