### PR TITLE
feature/pdct 1553 fix query for muli geography

### DIFF
--- a/app/db/crud/document.py
+++ b/app/db/crud/document.py
@@ -71,7 +71,7 @@ def get_family_document_and_context(
         .filter(FamilyDocument.physical_document_id == PhysicalDocument.id)
         .filter(FamilyCorpus.family_import_id == Family.import_id)
         .filter(geo_subquery.c.family_import_id == Family.import_id)  # type: ignore
-    ).one_or_none()
+    ).first()  # TODO: Fix when handling multiple geographies /PDCT-1510
 
     if not db_objects:
         _LOGGER.warning(

--- a/app/db/crud/document.py
+++ b/app/db/crud/document.py
@@ -61,7 +61,9 @@ def get_slugged_objects(db: Session, slug: str) -> tuple[Optional[str], Optional
 def get_family_document_and_context(
     db: Session, family_document_import_id: str
 ) -> FamilyDocumentWithContextResponse:
-    geo_subquery = get_geo_subquery(db)
+    geo_subquery = get_geo_subquery(
+        db, family_document_import_id=family_document_import_id
+    )
     db_objects = (
         db.query(
             Family, FamilyDocument, PhysicalDocument, geo_subquery.c.value, FamilyCorpus  # type: ignore

--- a/app/db/crud/geography.py
+++ b/app/db/crud/geography.py
@@ -2,7 +2,12 @@
 
 import logging
 
-from db_client.models.dfce.family import Family, FamilyGeography, FamilyStatus
+from db_client.models.dfce.family import (
+    Family,
+    FamilyDocument,
+    FamilyGeography,
+    FamilyStatus,
+)
 from db_client.models.dfce.geography import Geography
 from sqlalchemy import func
 from sqlalchemy.exc import OperationalError
@@ -15,7 +20,10 @@ _LOGGER = logging.getLogger(__file__)
 
 
 def get_geo_subquery(
-    db: Session, allowed_geo_slugs=None, allowed_geo_values=None
+    db: Session,
+    allowed_geo_slugs=None,
+    allowed_geo_values=None,
+    family_document_import_id=None,
 ) -> Query:
 
     geo_subquery = (
@@ -45,6 +53,12 @@ def get_geo_subquery(
 
     if allowed_geo_values is not None:
         geo_subquery = geo_subquery.filter(Geography.value.in_(allowed_geo_values))
+
+    if family_document_import_id is not None:
+        geo_subquery = geo_subquery.join(
+            FamilyDocument,
+            FamilyDocument.family_import_id == FamilyGeography.family_import_id,
+        ).filter(FamilyDocument.import_id == family_document_import_id)
 
     return geo_subquery.subquery("geo_subquery")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "navigator_backend"
-version = "1.17.2"
+version = "1.17.3"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]

--- a/tests/unit/app/db/crud/test_get_family_document_and_context.py
+++ b/tests/unit/app/db/crud/test_get_family_document_and_context.py
@@ -1,0 +1,20 @@
+from typing import Dict
+
+from sqlalchemy.orm import Session
+
+from app.api.api_v1.schemas.document import FamilyDocumentWithContextResponse
+from app.db.crud.document import get_family_document_and_context
+from tests.non_search.setup_helpers import setup_with_documents_large_with_families
+
+
+def test_get_family_document_and_context(
+    documents_large: list[Dict],
+    data_db: Session,
+):
+    setup_with_documents_large_with_families(documents_large, data_db)
+    response: FamilyDocumentWithContextResponse = get_family_document_and_context(
+        data_db, "CCLW.document.i00000192.n0000"
+    )
+
+    assert response.family.import_id == "CCLW.family.1001.0"
+    assert response.document.import_id == "CCLW.document.i00000192.n0000"

--- a/tests/unit/app/db/crud/test_get_family_document_and_context.py
+++ b/tests/unit/app/db/crud/test_get_family_document_and_context.py
@@ -41,7 +41,7 @@ def test_get_family_document_and_context_extra_geog(
     data_db.add(
         FamilyGeography(
             family_import_id=doc.family_import_id,
-            geography_id=2,
+            geography_id=17,
         )
     )
     data_db.commit()

--- a/tests/unit/app/db/crud/test_get_family_document_and_context.py
+++ b/tests/unit/app/db/crud/test_get_family_document_and_context.py
@@ -1,5 +1,6 @@
 from typing import Dict
 
+from db_client.models.dfce import FamilyGeography
 from sqlalchemy.orm import Session
 
 from app.api.api_v1.schemas.document import FamilyDocumentWithContextResponse
@@ -12,6 +13,27 @@ def test_get_family_document_and_context(
     data_db: Session,
 ):
     setup_with_documents_large_with_families(documents_large, data_db)
+    response: FamilyDocumentWithContextResponse = get_family_document_and_context(
+        data_db, "CCLW.document.i00000192.n0000"
+    )
+
+    assert response.family.import_id == "CCLW.family.1001.0"
+    assert response.document.import_id == "CCLW.document.i00000192.n0000"
+
+
+def test_get_family_document_and_context_extra_geog(
+    documents_large: list[Dict],
+    data_db: Session,
+):
+    setup_with_documents_large_with_families(documents_large, data_db)
+    # add an extra geography
+    data_db.add(
+        FamilyGeography(
+            family_import_id="CCLW.family.1001.0",
+            geography_id=2,
+        )
+    )
+    data_db.commit()
     response: FamilyDocumentWithContextResponse = get_family_document_and_context(
         data_db, "CCLW.document.i00000192.n0000"
     )

--- a/tests/unit/fixtures/CCLW.document.i00000192.n0000.json
+++ b/tests/unit/fixtures/CCLW.document.i00000192.n0000.json
@@ -5,6 +5,7 @@
   "url": "https://www.ndrc.gov.cn/xxgk/zcfb/ghxwj/202304/P020230407401908613786.pdf",
   "content_type": "application/pdf",
   "import_id": "CCLW.document.i00000192.n0000",
+  "geography_id": "CHN",
   "language_variant": "Original Language",
   "status": "PUBLISHED",
   "metadata": {


### PR DESCRIPTION
# Description

- Add a test for get_family_document_and_context
- Change query to return first item (from `one_or_none`)

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Refactor legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
