### PR TITLE
Fix flakey latency test

### DIFF
--- a/tests/search/vespa/test_vespa_search.py
+++ b/tests/search/vespa/test_vespa_search.py
@@ -159,7 +159,7 @@ def test_benchmark_families_search(
     _populate_db_families(data_db)
 
     # This is high as it's meant as a last resort for catching new performance problems
-    REASONABLE_LATENCY_MS = 50
+    REASONABLE_LATENCY_MS = 100
 
     times = []
     for _ in range(1, 10):


### PR DESCRIPTION
This test is intended to catch very broken queries, but it is too sensitive and doesnt account for variance caused by other factors (genreal ambient compute fluctuations, etc).

Raising it will unblock others while hopefully also continuing to catch actual breaking changes to queries

# Description

Please include:

- a summary of the changes
- links to any related issue/ticket
- any additional relevant motivation and context
- details of any dependency updates that are required for this change

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [x] Skip auto-tagging
- [ ] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Refactor legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
