### PR TITLE
Feature/pdct 1553 Make one_or_none a first in document CRUD

### DIFF
--- a/app/db/crud/document.py
+++ b/app/db/crud/document.py
@@ -155,7 +155,7 @@ def get_family_and_documents(db: Session, import_id: str) -> FamilyAndDocumentsR
         .join(Organisation, Corpus.organisation_id == Organisation.id)
         .filter(Family.import_id == import_id)
         .filter(geo_subquery.c.family_import_id == Family.import_id)  # type: ignore
-    ).first()
+    ).first()  # TODO Fix as part of PDCT-1440
 
     if not db_objects:
         _LOGGER.warning("No family found for import_id", extra={"slug": import_id})

--- a/app/db/crud/document.py
+++ b/app/db/crud/document.py
@@ -155,7 +155,7 @@ def get_family_and_documents(db: Session, import_id: str) -> FamilyAndDocumentsR
         .join(Organisation, Corpus.organisation_id == Organisation.id)
         .filter(Family.import_id == import_id)
         .filter(geo_subquery.c.family_import_id == Family.import_id)  # type: ignore
-    ).one_or_none()
+    ).first()
 
     if not db_objects:
         _LOGGER.warning("No family found for import_id", extra={"slug": import_id})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "navigator_backend"
-version = "1.17.5"
+version = "1.17.6"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]


### PR DESCRIPTION
# Description

Make one_or_none a first to workaround multiple geographies until PDCT-1440 is implemented.

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Refactor legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
