### PR TITLE
Feature/pdct 1405 cleanup after implementing family geographies

### DIFF
--- a/app/api/api_v1/schemas/document.py
+++ b/app/api/api_v1/schemas/document.py
@@ -81,7 +81,6 @@ class FamilyContext(BaseModel):
 
     title: str
     import_id: str
-    geography: str  # Keep this for backward compatibility PDCT-1440
     geographies: list[str]
     category: str
     slug: str
@@ -104,7 +103,6 @@ class FamilyAndDocumentsResponse(BaseModel):
     import_id: str
     title: str
     summary: str
-    geography: str  # Keep this for backward compatibility PDCT-1440
     geographies: list[str]
     category: str
     status: str

--- a/app/repository/document.py
+++ b/app/repository/document.py
@@ -103,9 +103,6 @@ def get_family_document_and_context(
     family_context = FamilyContext(
         title=cast(str, family.title),
         import_id=cast(str, family.import_id),
-        geography=geographies[
-            0
-        ],  # First geography for backward compatibility PDCT-1440
         geographies=geographies,
         slug=family.slugs[0].name,
         category=family.family_category,
@@ -192,9 +189,6 @@ def get_family_and_documents(db: Session, import_id: str) -> FamilyAndDocumentsR
         import_id=import_id,
         title=cast(str, family.title),
         summary=cast(str, family.description),
-        geography=geographies[
-            0
-        ],  # First geography for backward compatibility PDCT-1440
         geographies=geographies,
         category=cast(str, family.family_category),
         status=cast(str, family.family_status),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "navigator_backend"
-version = "1.19.1"
+version = "1.19.2"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]

--- a/tests/non_search/core/validation/test_util.py
+++ b/tests/non_search/core/validation/test_util.py
@@ -88,6 +88,7 @@ def test_document_parser_input_type():
         family_slug="geo_2008_family_1234_5679",
         category="category",
         geography="GEO",
+        geographies=["GEO"],
         languages=[],
         metadata={},
     )
@@ -110,6 +111,7 @@ def test_write_documents_to_s3(test_s3_client, mocker):
         family_slug="geo_2008_family_1234_5679",
         category="category",
         geography="GEO",
+        geographies=["GEO"],
         languages=[],
         metadata={},
     )


### PR DESCRIPTION
# Description

Remove geography in favour of geographies from  FamilyAndDocumentsResponse and FamilyContext.

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Refactor legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
