### PR TITLE
Bump db client to 3.8.22

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -834,7 +834,7 @@ vision = ["Pillow (>=9.4.0)"]
 
 [[package]]
 name = "db-client"
-version = "3.8.21"
+version = "3.8.22"
 description = "All things to do with the datamodel and its storage. Including alembic migrations and datamodel code."
 optional = false
 python-versions = "^3.9"
@@ -854,8 +854,8 @@ SQLAlchemy-Utils = "^0.38.2"
 [package.source]
 type = "git"
 url = "https://github.com/climatepolicyradar/navigator-db-client.git"
-reference = "v3.8.21"
-resolved_reference = "f3d47fd379dbac51ef0d6db5b1654429b386d583"
+reference = "v3.8.22"
+resolved_reference = "92b71b8f39eb578287a03cd657853244c0bc0e1b"
 
 [[package]]
 name = "deprecation"
@@ -4250,4 +4250,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "42635456c923243b7f3717cc0406e4d1418954ac34824565749f6dfd237a569f"
+content-hash = "0d986525b8dd7a5cee02896eaaa6f248f3167e05eec0ef1e695bf282d8b8c904"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "navigator_backend"
-version = "1.19.5"
+version = "1.19.6"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]
@@ -31,7 +31,7 @@ starlette = "^0.27.0"
 tenacity = "^8.0.1"
 uvicorn = { extras = ["standard"], version = "^0.20.0" }
 botocore = "^1.34.19"
-db-client = { git = "https://github.com/climatepolicyradar/navigator-db-client.git", tag = "v3.8.21" }
+db-client = { git = "https://github.com/climatepolicyradar/navigator-db-client.git", tag = "v3.8.22" }
 urllib3 = "<2"
 apscheduler = "^3.10.4"
 numpy = "1.26.4"

--- a/tests/non_search/routers/lookups/test_config.py
+++ b/tests/non_search/routers/lookups/test_config.py
@@ -23,6 +23,7 @@ EXPECTED_CCLW_TAXONOMY = {
     "framework",
     "hazard",
     "_document",
+    "_event",
     "event_type",
 }
 EXPECTED_CCLW_EVENTS = [
@@ -46,7 +47,13 @@ EXPECTED_CCLW_EVENTS = [
 ]
 
 
-EXPECTED_UNFCCC_TAXONOMY = {"author", "author_type", "event_type", "_document"}
+EXPECTED_UNFCCC_TAXONOMY = {
+    "author",
+    "author_type",
+    "event_type",
+    "_document",
+    "_event",
+}
 
 
 def _add_family(test_db, import_id: str, cat: FamilyCategory, corpus_import_id):
@@ -146,6 +153,15 @@ def test_config_endpoint_content(data_client, data_db):
     assert (
         "Adaptation Communication"
         in cclw_corpora[0]["taxonomy"]["_document"]["type"]["allowed_values"]
+    )
+
+    # Check event types.
+    assert (
+        len(cclw_corpora[0]["taxonomy"]["_event"]["event_type"]["allowed_values"]) == 17
+    )
+    assert (
+        "Passed/Approved"
+        in cclw_corpora[0]["taxonomy"]["_event"]["event_type"]["allowed_values"]
     )
 
 

--- a/tests/unit/app/core/test_organisation.py
+++ b/tests/unit/app/core/test_organisation.py
@@ -16,6 +16,7 @@ CCLW_METADATA_KEYS = set(
         "framework",
         "instrument",
         "_document",
+        "_event",
         "event_type",
     ]
 )
@@ -25,6 +26,7 @@ UNFCCC_METADATA_KEYS = set(
         "author",
         "author_type",
         "_document",
+        "_event",
         "event_type",
     ]
 )


### PR DESCRIPTION
# Description

Bump db client to 3.8.22

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Refactor legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
