### PR TITLE
Feature/pdct 1644 Reinstate MCF data in data download 

### DIFF
--- a/app/service/download.py
+++ b/app/service/download.py
@@ -24,19 +24,7 @@ def create_query(
         should allow the data to be dumped.
     :return str: The SQL query to perform on the database session.
     """
-    # TODO: Hide MCF from data dump until after COP.
-    mcf_corpora_ids = [
-        "MCF.corpus.AF.n0000",
-        "MCF.corpus.CIF.n0000",
-        "MCF.corpus.GCF.n0000",
-        "MCF.corpus.GEF.n0000",
-    ]
-    corpora_ids = [
-        corpus_id
-        for corpus_id in allowed_corpora_ids
-        if corpus_id not in mcf_corpora_ids
-    ]
-    corpora_ids = "'" + "','".join(corpora_ids) + "'"
+    corpora_ids = "'" + "','".join(allowed_corpora_ids) + "'"
     return template_query.replace(  # type: ignore
         "{ingest_cycle_start}", ingest_cycle_start
     ).replace(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "navigator_backend"
-version = "1.19.8"
+version = "1.19.9"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]


### PR DESCRIPTION
# Description

Reinstate MCF data in data download.

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Refactor legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
