### PR TITLE
Config endpoint returns only orgs that correspond to allowed corpora

### DIFF
--- a/app/api/api_v1/routers/lookups/config.py
+++ b/app/api/api_v1/routers/lookups/config.py
@@ -1,12 +1,20 @@
-from fastapi import Depends, Request
+from typing import Annotated
+
+from fastapi import Depends, Header, Request
 
 from app.api.api_v1.routers.lookups.router import lookups_router
 from app.clients.db.session import get_db
 from app.models.metadata import ApplicationConfig
 from app.repository.lookups import get_config
+from app.service.custom_app import AppTokenFactory
 
 
 @lookups_router.get("/config", response_model=ApplicationConfig)
-def lookup_config(request: Request, db=Depends(get_db)):
+def lookup_config(
+    request: Request, app_token: Annotated[str, Header()], db=Depends(get_db)
+):
     """Get the config for the metadata."""
-    return get_config(db)
+    token = AppTokenFactory()
+    token.decode_and_validate(db, request, app_token)
+
+    return get_config(db, token.allowed_corpora_ids)

--- a/app/repository/lookups.py
+++ b/app/repository/lookups.py
@@ -8,20 +8,20 @@ from sqlalchemy.exc import MultipleResultsFound
 from sqlalchemy.orm import Session
 
 from app.models.metadata import ApplicationConfig
-from app.repository.organisation import get_all_organisations, get_organisation_config
+from app.repository.organisation import get_organisation_config, get_organisations
 from app.service.pipeline import IMPORT_ID_MATCHER
 from app.service.util import tree_table_to_json
 
 _LOGGER = logging.getLogger(__name__)
 
 
-def get_config(db: Session) -> ApplicationConfig:
+def get_config(db: Session, allowed_corpora: list[str]) -> ApplicationConfig:
     # First get the CCLW stats
     return ApplicationConfig(
         geographies=tree_table_to_json(table=Geography, db=db),
         organisations={
             cast(str, org.name): get_organisation_config(db, org)
-            for org in get_all_organisations(db)
+            for org in get_organisations(db, allowed_corpora)
         },
         languages={lang.language_code: lang.name for lang in db.query(Language).all()},
         document_variants=[

--- a/app/repository/organisation.py
+++ b/app/repository/organisation.py
@@ -88,9 +88,9 @@ def get_organisation_config(db: Session, org: Organisation) -> OrganisationConfi
 
 
 def get_organisations(db: Session, allowed_corpora: list[str]) -> list[Organisation]:
-    return (
-        db.query(Organisation)
-        .join(Corpus, Corpus.organisation_id == Organisation.id)
-        .filter(Corpus.import_id.in_(allowed_corpora))
-        .all()
+    query = db.query(Organisation).join(
+        Corpus, Corpus.organisation_id == Organisation.id
     )
+    if allowed_corpora != []:
+        query = query.filter(Corpus.import_id.in_(allowed_corpora))
+    return query.all()

--- a/app/repository/organisation.py
+++ b/app/repository/organisation.py
@@ -87,5 +87,10 @@ def get_organisation_config(db: Session, org: Organisation) -> OrganisationConfi
     )
 
 
-def get_all_organisations(db: Session) -> list[Organisation]:
-    return db.query(Organisation).all()
+def get_organisations(db: Session, allowed_corpora: list[str]) -> list[Organisation]:
+    return (
+        db.query(Organisation)
+        .join(Corpus, Corpus.organisation_id == Organisation.id)
+        .filter(Corpus.import_id.in_(allowed_corpora))
+        .all()
+    )

--- a/app/service/custom_app.py
+++ b/app/service/custom_app.py
@@ -260,4 +260,5 @@ class AppTokenFactory:
 
         # First corpora validation is app token against DB. At least one of the app token
         # corpora IDs must be present in the DB to continue the search request.
+        any_exist = False if not self.allowed_corpora_ids else True
         self.validate(db, any_exist)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "navigator_backend"
-version = "1.19.16"
+version = "1.19.17"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "navigator_backend"
-version = "1.19.17"
+version = "1.19.18"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -165,7 +165,7 @@ def app_token_factory(monkeypatch):
     def mock_return(_, __, ___):
         return True
 
-    def _app_token(allowed_corpora_ids: list[str]):
+    def _app_token(allowed_corpora_ids):
         subject = "CCLW"
         audience = "localhost"
         input_str = f"{allowed_corpora_ids};{subject};{audience}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -152,6 +152,32 @@ def alternative_token(monkeypatch):
 
 
 @pytest.fixture
+def app_token_factory(monkeypatch):
+    """Generate a valid config token using TOKEN_SECRET_KEY and given corpora ids.
+
+    Need to generate the config token using the token secret key from
+    your local env file. For tests in CI, this will be the secret key in
+    the .env.example file, but for local development this secret key
+    might be different (e.g., the one for staging). This fixture works
+    around this.
+    """
+
+    def mock_return(_, __, ___):
+        return True
+
+    def _app_token(allowed_corpora_ids):
+        subject = "CCLW"
+        audience = "localhost"
+        input_str = f"{allowed_corpora_ids};{subject};{audience}"
+
+        af = AppTokenFactory()
+        monkeypatch.setattr(custom_app.AppTokenFactory, "validate", mock_return)
+        return af.create_configuration_token(input_str)
+
+    return _app_token
+
+
+@pytest.fixture
 def create_test_db():
     """Create a test database and use it for the whole test session."""
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -165,7 +165,7 @@ def app_token_factory(monkeypatch):
     def mock_return(_, __, ___):
         return True
 
-    def _app_token(allowed_corpora_ids):
+    def _app_token(allowed_corpora_ids: list[str]):
         subject = "CCLW"
         audience = "localhost"
         input_str = f"{allowed_corpora_ids};{subject};{audience}"

--- a/tests/non_search/routers/lookups/test_config.py
+++ b/tests/non_search/routers/lookups/test_config.py
@@ -306,7 +306,6 @@ def test_config_endpoint_returns_stats_for_all_orgs_if_no_allowed_corpora_in_app
     app_token = jwt.encode(
         to_encode, os.environ["TOKEN_SECRET_KEY"], algorithm=security.ALGORITHM
     )
-    # app_token = app_token_factory(",")
     url_under_test = "/api/v1/config"
 
     cclw_corpus = (

--- a/tests/non_search/routers/lookups/test_config.py
+++ b/tests/non_search/routers/lookups/test_config.py
@@ -210,8 +210,8 @@ def test_config_endpoint_cclw_stats(data_client, data_db, valid_token):
 @pytest.mark.parametrize(
     "allowed_corpora_ids, expected_organisation, other_organisation",
     [
-        ("UNFCCC.corpus.i00000001.n0000", "UNFCCC", "CCLW"),
-        ("CCLW.corpus.i00000001.n0000", "CCLW", "UNFCCC"),
+        (["UNFCCC.corpus.i00000001.n0000"], "UNFCCC", "CCLW"),
+        (["CCLW.corpus.i00000001.n0000"], "CCLW", "UNFCCC"),
     ],
 )
 def test_config_endpoint_returns_stats_for_allowed_corpora_only(

--- a/tests/non_search/routers/lookups/test_config.py
+++ b/tests/non_search/routers/lookups/test_config.py
@@ -210,8 +210,8 @@ def test_config_endpoint_cclw_stats(data_client, data_db, valid_token):
 @pytest.mark.parametrize(
     "allowed_corpora_ids, expected_organisation, other_organisation",
     [
-        (["UNFCCC.corpus.i00000001.n0000"], "UNFCCC", "CCLW"),
-        (["CCLW.corpus.i00000001.n0000"], "CCLW", "UNFCCC"),
+        ("UNFCCC.corpus.i00000001.n0000", "UNFCCC", "CCLW"),
+        ("CCLW.corpus.i00000001.n0000", "CCLW", "UNFCCC"),
     ],
 )
 def test_config_endpoint_returns_stats_for_allowed_corpora_only(

--- a/tests/unit/app/core/test_organisation.py
+++ b/tests/unit/app/core/test_organisation.py
@@ -3,7 +3,7 @@ from typing import cast
 import pytest
 from sqlalchemy.orm import Session
 
-from app.repository.organisation import get_all_organisations, get_corpora_for_org
+from app.repository.organisation import get_corpora_for_org, get_organisations
 from tests.non_search.setup_helpers import setup_new_corpus, setup_with_docs
 
 CCLW_EXPECTED_NUM_CORPORA = 1
@@ -34,7 +34,7 @@ EXPECTED_NUM_ORGS = 2
 
 
 def test_expected_organisations_present(data_db: Session):
-    orgs = get_all_organisations(data_db)
+    orgs = get_organisations(data_db)
     assert len(orgs) == EXPECTED_NUM_ORGS
 
     org_names = set([cast(str, org.name) for org in orgs])

--- a/tests/unit/app/core/test_organisation.py
+++ b/tests/unit/app/core/test_organisation.py
@@ -34,7 +34,9 @@ EXPECTED_NUM_ORGS = 2
 
 
 def test_expected_organisations_present(data_db: Session):
-    orgs = get_organisations(data_db)
+    orgs = get_organisations(
+        data_db, ["UNFCCC.corpus.i00000001.n0000,CCLW.corpus.i00000001.n0000"]
+    )
     assert len(orgs) == EXPECTED_NUM_ORGS
 
     org_names = set([cast(str, org.name) for org in orgs])

--- a/tests/unit/app/core/test_organisation.py
+++ b/tests/unit/app/core/test_organisation.py
@@ -35,7 +35,7 @@ EXPECTED_NUM_ORGS = 2
 
 def test_expected_organisations_present(data_db: Session):
     orgs = get_organisations(
-        data_db, ["UNFCCC.corpus.i00000001.n0000,CCLW.corpus.i00000001.n0000"]
+        data_db, ["UNFCCC.corpus.i00000001.n0000", "CCLW.corpus.i00000001.n0000"]
     )
     assert len(orgs) == EXPECTED_NUM_ORGS
 


### PR DESCRIPTION
# Description
- require an app_token header for the /config endpoint
- validate and decode the app_token in the /config endpoint
- only return stats for organisations linked to allowed corpora from the app_token

Please include:

- a summary of the changes
- links to any related issue/ticket
- any additional relevant motivation and context
- details of any dependency updates that are required for this change

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Refactor legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
