### PR TITLE
:robot: bug fix in local vespa schema (summary features)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "navigator_backend"
-version = "1.19.18"
+version = "1.19.19"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "navigator_backend"
-version = "1.19.19"
+version = "1.19.20"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]

--- a/tests/search/vespa/fixtures/vespa_test_schema/schemas/document_passage.sd
+++ b/tests/search/vespa/fixtures/vespa_test_schema/schemas/document_passage.sd
@@ -177,7 +177,7 @@ schema document_passage {
         first-phase {
             expression: text_score()
         }
-        match-features: text_score() fieldMatch(text_block)
+        summary-features: text_score() fieldMatch(text_block)
     }
     
     rank-profile exact_not_stemmed inherits default {
@@ -187,7 +187,7 @@ schema document_passage {
         first-phase {
             expression: text_score()
         }
-        match-features: text_score() fieldMatch(text_block)
+        summary-features: text_score() fieldMatch(text_block)
     }
 
     rank-profile hybrid_no_closeness inherits default {
@@ -197,7 +197,7 @@ schema document_passage {
         first-phase {
             expression: text_score()
         }
-        match-features: text_score() bm25(text_block)
+        summary-features: text_score() bm25(text_block)
     }
 
     rank-profile hybrid inherits default {
@@ -210,7 +210,7 @@ schema document_passage {
         first-phase {
             expression: text_score()
         }
-        match-features: text_score() bm25(text_block) closeness(text_embedding)
+        summary-features: text_score() bm25(text_block) closeness(text_embedding)
     }
     
     rank-profile hybrid_custom_weight inherits default {
@@ -224,6 +224,6 @@ schema document_passage {
         first-phase {
             expression: text_score()
         }
-        match-features: text_score() bm25(text_block) closeness(text_embedding)
+        summary-features: text_score() bm25(text_block) closeness(text_embedding)
     }
 }

--- a/tests/search/vespa/fixtures/vespa_test_schema/schemas/family_document.sd
+++ b/tests/search/vespa/fixtures/vespa_test_schema/schemas/family_document.sd
@@ -178,7 +178,7 @@ schema family_document {
         first-phase {
             expression: name_score() + description_score()
         }
-        match-features: name_score() description_score()
+        summary-features: name_score() description_score()
     }
     
     rank-profile exact_not_stemmed inherits default {
@@ -191,7 +191,7 @@ schema family_document {
         first-phase {
             expression: name_score() + description_score()
         }
-        match-features: name_score() description_score()
+        summary-features: name_score() description_score()
     }
 
     rank-profile hybrid_no_closeness inherits default {
@@ -204,7 +204,7 @@ schema family_document {
         first-phase {
             expression: name_score() + description_score()
         }
-        match-features: name_score() description_score()
+        summary-features: name_score() description_score()
     }
 
     rank-profile hybrid inherits default {
@@ -220,7 +220,7 @@ schema family_document {
         first-phase {
             expression: name_score() + description_score()
         }
-        match-features: name_score() description_score()
+        summary-features: name_score() description_score()
     }
     
     rank-profile hybrid_no_description_embedding inherits default {
@@ -236,7 +236,7 @@ schema family_document {
         first-phase {
             expression: name_score() + description_score()
         }
-        match-features: name_score() description_score()
+        summary-features: name_score() description_score()
     }
 
     rank-profile hybrid_custom_weight inherits default {
@@ -253,7 +253,7 @@ schema family_document {
         first-phase {
             expression: name_score() + description_score()
         }
-        match-features: name_score() description_score()
+        summary-features: name_score() description_score()
     }
 
 


### PR DESCRIPTION
# Description

Update to Vespa schema to fix showing rank features. **This is already deployed on prod Vespa – this just updates the schema of the local test instance**

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Refactor legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
