### PR TITLE
fix title and description search

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -702,13 +702,13 @@ files = [
 
 [[package]]
 name = "cpr-sdk"
-version = "1.9.5"
+version = "1.10.2"
 description = ""
 optional = false
 python-versions = "<4.0,>=3.10"
 files = [
-    {file = "cpr_sdk-1.9.5-py3-none-any.whl", hash = "sha256:dd32806499b5bb44c98be1f4135b88406f1a77abcf60c7d4f61ac740de979da3"},
-    {file = "cpr_sdk-1.9.5.tar.gz", hash = "sha256:addc22e557381935ac66c95721312c4a37080fda7419381971cdf6e7cb331fe0"},
+    {file = "cpr_sdk-1.10.2-py3-none-any.whl", hash = "sha256:c368b80e85695ed9ef433288cec0542b1484947c0be11982bb1c5ce5d3258651"},
+    {file = "cpr_sdk-1.10.2.tar.gz", hash = "sha256:3a8d1f589ec1b2fcbd13bc0be544a9434e088e9af2a9a5934b03e3c74ffd4bd3"},
 ]
 
 [package.dependencies]
@@ -724,6 +724,7 @@ poetry = ">=1.8.3,<2.0.0"
 pydantic = ">=2.9.2,<3.0.0"
 pyvespa = {version = ">=0.45.0,<0.46.0", optional = true, markers = "extra == \"vespa\""}
 pyyaml = {version = ">=6.0.2,<7.0.0", optional = true, markers = "extra == \"vespa\""}
+rich = ">=13.8.1,<14.0.0"
 tqdm = ">=4.66.5,<5.0.0"
 
 [package.extras]
@@ -1721,6 +1722,30 @@ lingua = ["lingua"]
 testing = ["pytest"]
 
 [[package]]
+name = "markdown-it-py"
+version = "3.0.0"
+description = "Python port of markdown-it. Markdown parsing, done right!"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb"},
+    {file = "markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1"},
+]
+
+[package.dependencies]
+mdurl = ">=0.1,<1.0"
+
+[package.extras]
+benchmarking = ["psutil", "pytest", "pytest-benchmark"]
+code-style = ["pre-commit (>=3.0,<4.0)"]
+compare = ["commonmark (>=0.9,<1.0)", "markdown (>=3.4,<4.0)", "mistletoe (>=1.0,<2.0)", "mistune (>=2.0,<3.0)", "panflute (>=2.3,<3.0)"]
+linkify = ["linkify-it-py (>=1,<3)"]
+plugins = ["mdit-py-plugins"]
+profiling = ["gprof2dot"]
+rtd = ["jupyter_sphinx", "mdit-py-plugins", "myst-parser", "pyyaml", "sphinx", "sphinx-copybutton", "sphinx-design", "sphinx_book_theme"]
+testing = ["coverage", "pytest", "pytest-cov", "pytest-regressions"]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.2"
 description = "Safely add untrusted strings to HTML/XML markup."
@@ -1788,6 +1813,17 @@ files = [
     {file = "MarkupSafe-3.0.2-cp39-cp39-win32.whl", hash = "sha256:8c4e8c3ce11e1f92f6536ff07154f9d49677ebaaafc32db9db4620bc11ed480f"},
     {file = "MarkupSafe-3.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:6e296a513ca3d94054c2c881cc913116e90fd030ad1c656b3869762b754f5f8a"},
     {file = "markupsafe-3.0.2.tar.gz", hash = "sha256:ee55d3edf80167e48ea11a923c7386f4669df67d7994554387f84e7d8b0a2bf0"},
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+description = "Markdown URL utilities"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
+    {file = "mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"},
 ]
 
 [[package]]
@@ -2759,6 +2795,20 @@ files = [
 typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
 
 [[package]]
+name = "pygments"
+version = "2.18.0"
+description = "Pygments is a syntax highlighting package written in Python."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pygments-2.18.0-py3-none-any.whl", hash = "sha256:b8e6aca0523f3ab76fee51799c488e38782ac06eafcf95e7ba832985c8e7b13a"},
+    {file = "pygments-2.18.0.tar.gz", hash = "sha256:786ff802f32e91311bff3889f6e9a86e81505fe99f2735bb6d60ae0c5004f199"},
+]
+
+[package.extras]
+windows-terminal = ["colorama (>=0.4.6)"]
+
+[[package]]
 name = "pyjwt"
 version = "2.9.0"
 description = "JSON Web Token implementation in Python"
@@ -3229,6 +3279,25 @@ idna = {version = "*", optional = true, markers = "extra == \"idna2008\""}
 
 [package.extras]
 idna2008 = ["idna"]
+
+[[package]]
+name = "rich"
+version = "13.9.4"
+description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
+optional = false
+python-versions = ">=3.8.0"
+files = [
+    {file = "rich-13.9.4-py3-none-any.whl", hash = "sha256:6049d5e6ec054bf2779ab3358186963bac2ea89175919d699e378b99738c2a90"},
+    {file = "rich-13.9.4.tar.gz", hash = "sha256:439594978a49a09530cff7ebc4b5c7103ef57baf48d5ea3184f21d9a2befa098"},
+]
+
+[package.dependencies]
+markdown-it-py = ">=2.2.0"
+pygments = ">=2.13.0,<3.0.0"
+typing-extensions = {version = ">=4.0.0,<5.0", markers = "python_version < \"3.11\""}
+
+[package.extras]
+jupyter = ["ipywidgets (>=7.5.1,<9)"]
 
 [[package]]
 name = "ruff"
@@ -4250,4 +4319,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "d96225e60602c52c47631f4a12f8519bcb5d1e2f5d2b15c2f57760db6b28c33c"
+content-hash = "59023d813695301b9e3bcec5d6fac9ca404a3c9858fc5ab7477210295cbbf1db"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "navigator_backend"
-version = "1.19.18"
+version = "1.19.19"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ python = "^3.10"
 Authlib = "^0.15.5"
 bcrypt = "^3.2.0"
 boto3 = "^1.26"
-cpr_sdk = { version = "1.9.5", extras = ["vespa"] }
+cpr_sdk = { version = "1.10.2", extras = ["vespa"] }
 fastapi = "^0.104.1"
 fastapi-health = "^0.4.0"
 fastapi-pagination = { extras = ["sqlalchemy"], version = "^0.12.19" }

--- a/tests/search/vespa/test_vespa_search_pagination.py
+++ b/tests/search/vespa/test_vespa_search_pagination.py
@@ -32,14 +32,7 @@ def test_simple_pagination_families(
     body_one = _make_search_request(data_client, valid_token, params)
     assert body_one["hits"] == VESPA_FIXTURE_COUNT
     assert len(body_one["families"]) == PAGE_SIZE
-    assert (
-        body_one["families"][0]["family_slug"]
-        == "agriculture-sector-plan-2015-2019_7999"
-    )
-    assert (
-        body_one["families"][1]["family_slug"]
-        == "national-environment-policy-of-guinea_f0df"
-    )
+    query_one_family_slugs = set([f["family_slug"] for f in body_one["families"]])
 
     # Query two
     params = {
@@ -50,14 +43,9 @@ def test_simple_pagination_families(
     body_two = _make_search_request(data_client, valid_token, params)
     assert body_two["hits"] == VESPA_FIXTURE_COUNT
     assert len(body_two["families"]) == PAGE_SIZE
-    assert (
-        body_two["families"][0]["family_slug"]
-        == "national-energy-policy-and-energy-action-plan_9262"
-    )
-    assert (
-        body_two["families"][1]["family_slug"]
-        == "submission-to-the-unfccc-ahead-of-the-first-technical-dialogue_e760"
-    )
+    query_two_family_slugs = set([f["family_slug"] for f in body_two["families"]])
+
+    assert query_one_family_slugs.isdisjoint(query_two_family_slugs)
 
     assert mock_corpora_exist_in_db.assert_called
 


### PR DESCRIPTION
# Description

Updates the SDK to include a fix for bm25 search on family names and descriptions ([see PR](https://github.com/climatepolicyradar/cpr-sdk/pull/160)).

Also fixes a brittle pagination test.

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Refactor legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
