### PR TITLE
bump sdk to include acronym expansion feature (switched off)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -702,13 +702,13 @@ files = [
 
 [[package]]
 name = "cpr-sdk"
-version = "1.12.0"
+version = "1.13.0"
 description = ""
 optional = false
 python-versions = "<4.0,>=3.10"
 files = [
-    {file = "cpr_sdk-1.12.0-py3-none-any.whl", hash = "sha256:b3c47392d3074ff2398bcde5979d13be2f4e41f3aff9f09efd8051d876511b7f"},
-    {file = "cpr_sdk-1.12.0.tar.gz", hash = "sha256:acc81f3d1c1436d547db11685792fd20ed01996d575f8d098a3c6d5d9e12d277"},
+    {file = "cpr_sdk-1.13.0-py3-none-any.whl", hash = "sha256:4eff02c839ffe0b9b95701fa76def13601ed663fabd0ea27be60a0356093ee21"},
+    {file = "cpr_sdk-1.13.0.tar.gz", hash = "sha256:7e339ac449cf8475cedf9d55e4cf5bdf6f8dd1d72801fb94067a8ced9af3fabe"},
 ]
 
 [package.dependencies]
@@ -4320,4 +4320,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c70522e09b10ac5f53b62864603313bff934da7d904d976c0c0b8d6401487605"
+content-hash = "eeea3e108cf7e1202636257dd8bdff50adf0b91b86a0f6add502fabbba0fc1af"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ python = "^3.10"
 Authlib = "^0.15.5"
 bcrypt = "^3.2.0"
 boto3 = "^1.26"
-cpr_sdk = { version = "1.12.0", extras = ["vespa", "datasets"] }
+cpr_sdk = { version = "1.13.0", extras = ["vespa", "datasets"] }
 fastapi = "^0.104.1"
 fastapi-health = "^0.4.0"
 fastapi-pagination = { extras = ["sqlalchemy"], version = "^0.12.19" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "navigator_backend"
-version = "1.20.4"
+version = "1.21.0"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]

--- a/tests/search/vespa/test_vespa_search_pagination.py
+++ b/tests/search/vespa/test_vespa_search_pagination.py
@@ -107,7 +107,7 @@ def test_continuation_token__passages(
 
     # Get second set of families
     params = {
-        "query_string": "the",
+        "query_string": "climate",
         "document_ids": ["CCLW.executive.10246.4861", "CCLW.executive.4934.1571"],
         "limit": 1,
         "page_size": 1,


### PR DESCRIPTION
# Description

See https://github.com/climatepolicyradar/cpr-sdk/pull/171.

Note this doesn't enable acronym expansion, but adds a flag in search parameters that can be used to enable it.

**Overall, it looks like we shouldn't enable acronym expansion – the way Vespa does it seems inefficient, and bumps query time from ~0.6 seconds to over 5 seconds when an expansion is done.**

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [ ] Patch
- [x] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Refactor legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
