### PR TITLE
fix: remove migrations from running on startup

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -5,7 +5,6 @@ from contextlib import asynccontextmanager
 
 import json_logging
 import uvicorn
-from db_client import run_migrations
 from fastapi import APIRouter, Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi_health import health
@@ -21,7 +20,7 @@ from app.api.api_v1.routers.pipeline_trigger import pipeline_trigger_router
 from app.api.api_v1.routers.search import search_router
 from app.api.api_v1.routers.summaries import summary_router
 from app.api.api_v1.routers.world_map import world_map_router
-from app.clients.db.session import SessionLocal, engine
+from app.clients.db.session import SessionLocal
 from app.service.auth import get_superuser_details
 from app.service.health import is_database_online
 
@@ -76,9 +75,7 @@ _openapi_url = "/api" if ENABLE_API_DOCS else None
 
 @asynccontextmanager
 async def lifespan(app_: FastAPI):
-    """Run startup and shutdown events."""
     _LOGGER.info("Starting up...")
-    run_migrations(engine)
     yield
     _LOGGER.info("Shutting down...")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "navigator_backend"
-version = "1.23.13"
+version = "1.23.14"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,6 @@ from typing import Optional
 
 import pytest
 from cpr_sdk.search_adaptors import Vespa, VespaSearchAdapter
-from db_client import run_migrations
 from db_client.models import Base
 from db_client.models.organisation import AppUser
 from fastapi.testclient import TestClient
@@ -255,7 +254,7 @@ def data_db_engine() -> t.Generator[Engine, None, None]:
 
     test_engine = create_engine(test_db_url)
 
-    run_migrations(test_engine)
+    Base.metadata.create_all(test_engine)
 
     yield test_engine
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ from typing import Optional
 
 import pytest
 from cpr_sdk.search_adaptors import Vespa, VespaSearchAdapter
+from db_client import run_migrations
 from db_client.models import Base
 from db_client.models.organisation import AppUser
 from fastapi.testclient import TestClient
@@ -254,7 +255,7 @@ def data_db_engine() -> t.Generator[Engine, None, None]:
 
     test_engine = create_engine(test_db_url)
 
-    Base.metadata.create_all(test_engine)
+    run_migrations(test_engine)
 
     yield test_engine
 


### PR DESCRIPTION
# Description
- removes the responsibility of the migrations to be exclusively run in `navigator-admin-backend`

Running migrations (write ops) in two places is a risky design.
It also means that backend needs write access which we are trying to avoid. 

## Desired outcome
![Screenshot 2025-03-21 at 10 46 43](https://github.com/user-attachments/assets/77037c37-1be1-43bc-ba43-6cd7222b7056)

## Proposed version

- [x] Patch

Fixes [APP-411: Remove db migrations from navigator-backend](https://linear.app/climate-policy-radar/issue/APP-411/remove-db-migrations-from-navigator-backend)