### PR TITLE
fix: update openssl in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /cpr-backend
 
 # we need libpq-dev gcc as we using the non-binary version of psycopg2
 RUN apt update && \
-    apt install -y postgresql-client curl git libpq-dev gcc \
+    apt install -y postgresql-client curl git libpq-dev gcc openssl \
     && rm -rf /var/lib/apt/lists/*
 
 # Install pip and poetry


### PR DESCRIPTION
# Description
- forces an update of openssl in the dockerfile

There might be a conflict in openssl version in python vs apprunner - this is trying to rule that out as an culprit for the errors we are seeing.


## Proposed version

- [x] Patch