### PR TITLE
fix: use exec to execute python in startup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "navigator_backend"
-version = "1.23.15"
+version = "1.23.16"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]

--- a/startup.sh
+++ b/startup.sh
@@ -20,4 +20,4 @@ else
 fi
 
 echo "Starting backend app"
-python3 app/main.py
+exec python3 app/main.py


### PR DESCRIPTION
# Description
Without exec - Bash is the parent process, which can cause memory corruption and signal-handling issues.

Using exec makes `python` the top-level process.

Somes docs on this
https://stackoverflow.com/questions/32255814/what-purpose-does-using-exec-in-docker-entrypoint-scripts-serve


## Proposed version

- [x] Patch

