### PR TITLE
fix: run uvicorn as the main process

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "navigator_backend"
-version = "1.23.16"
+version = "1.23.17"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]

--- a/startup.sh
+++ b/startup.sh
@@ -20,4 +20,4 @@ else
 fi
 
 echo "Starting backend app"
-exec python3 app/main.py
+exec uvicorn app.main:app --host 0.0.0.0 --port 8000


### PR DESCRIPTION
# Description

- runs `uvicorn` directly as the top-level process

This should allow uvicorn to manage that process and it has better signal handling and a cleaner shutdown.

This is apposed to what we're doing now, which is using python as the top-level process which then runs uvicorn as a sub-process.

> [!NOTE]
> Disclaimer: I am still wrapping my head around pythons contexts, but this is a recommended way [in multiple docs](https://fastapi.tiangolo.com/deployment/manually/) - so I am following that.

## Proposed version

- [x] Patch