### PR TITLE
fix: use Depends on FastAPI route over implementation method

### DIFF
--- a/app/service/health.py
+++ b/app/service/health.py
@@ -11,13 +11,13 @@ from app.service.vespa import get_vespa_search_adapter
 _LOGGER = logging.getLogger(__file__)
 
 
-def is_rds_online(db):
+def is_rds_online(db: Session):
     """Runs a sql query against the db"""
     return db.execute("SELECT 1") is not None
 
 
 def is_vespa_online(
-    vespa_search_adapter: VespaSearchAdapter = Depends(get_vespa_search_adapter),
+    vespa_search_adapter: VespaSearchAdapter,
 ):
     """Check queries work against the vespa instance"""
     try:
@@ -30,6 +30,9 @@ def is_vespa_online(
     return True
 
 
-def is_database_online(db: Session = Depends(get_db)) -> bool:
+def is_database_online(
+    db: Session = Depends(get_db),
+    vespa_search_adapter: VespaSearchAdapter = Depends(get_vespa_search_adapter),
+) -> bool:
     """Checks database health."""
-    return all([is_rds_online(db), is_vespa_online()])
+    return all([is_rds_online(db), is_vespa_online(vespa_search_adapter)])

--- a/makefile-docker.defs
+++ b/makefile-docker.defs
@@ -125,9 +125,6 @@ test_non_search:
 test:
 	docker compose -f docker-compose.yml -f docker-compose.dev.yml run --rm backend pytest -vvv tests ${ARGS}
 
-t:
-	docker compose -f docker-compose.yml -f docker-compose.dev.yml run --rm backend pytest -vvv ./tests/search/test_search.py::test_process_vespa_search_response_page_ordering_regression
-
 # ----------------------------------
 # tasks
 # ----------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "navigator_backend"
-version = "1.23.24"
+version = "1.23.25"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]


### PR DESCRIPTION
# Description
- uses the [Depends](https://fastapi.tiangolo.com/tutorial/dependencies/#create-a-dependency-or-dependable) on the FastAPI route
- removes it from the method that isn't the FastAPI route as it isn't available at that point

I'll write a test post fix - but want to de-red our deployments.

## Proposed version

- [x] Patch
