### PR TITLE
Add tests for healthchecks

### DIFF
--- a/app/service/health.py
+++ b/app/service/health.py
@@ -26,22 +26,30 @@ def is_rds_online(db: Session) -> bool:
         return False
 
 
-def is_vespa_online(vespa_search_adapter: VespaSearchAdapter) -> bool:
+def is_vespa_online(
+    vespa_search_adapter: VespaSearchAdapter, timeout_seconds: int = 1
+) -> bool:
     """Check queries work against the vespa instance
 
     :param vespa_search_adapter: Vespa search adapter
     :type vespa_search_adapter: VespaSearchAdapter
+    :param timeout_seconds: Timeout for the query
+    :type timeout_seconds: int
     :return: True if Vespa is responsive
     :rtype: bool
     """
     try:
-        query_body = {"yql": "select * from sources * where true", "hits": "0"}
+        query_body = {
+            "yql": "select * from sources * where true",
+            "hits": "0",
+            "timeout": f"{timeout_seconds}",  # Default unit is seconds, otherwise specify unit
+        }
         vespa_search_adapter.client.query(query_body)
         return True
     except Exception as e:
         if DEVELOPMENT_MODE is False:
             _LOGGER.error(f"🔴 Vespa health check failed: {e}")
-        return False
+    return False
 
 
 def is_database_online(

--- a/app/service/health.py
+++ b/app/service/health.py
@@ -11,28 +11,50 @@ from app.service.vespa import get_vespa_search_adapter
 _LOGGER = logging.getLogger(__file__)
 
 
-def is_rds_online(db: Session):
-    """Runs a sql query against the db"""
-    return db.execute("SELECT 1") is not None
+def is_rds_online(db: Session) -> bool:
+    """Runs a heartbeat SQL query against the DB to check health.
+
+    :param db: Database session
+    :type db: Session
+    :return: True if database is responsive
+    :rtype: bool
+    """
+    try:
+        return db.execute("SELECT 1") is not None
+    except Exception as e:
+        _LOGGER.error(f"🔴 RDS health check failed: {e}")
+        return False
 
 
-def is_vespa_online(
-    vespa_search_adapter: VespaSearchAdapter,
-):
-    """Check queries work against the vespa instance"""
+def is_vespa_online(vespa_search_adapter: VespaSearchAdapter) -> bool:
+    """Check queries work against the vespa instance
+
+    :param vespa_search_adapter: Vespa search adapter
+    :type vespa_search_adapter: VespaSearchAdapter
+    :return: True if Vespa is responsive
+    :rtype: bool
+    """
     try:
         query_body = {"yql": "select * from sources * where true", "hits": "0"}
         vespa_search_adapter.client.query(query_body)
+        return True
     except Exception as e:
         if DEVELOPMENT_MODE is False:
-            _LOGGER.error(e)
+            _LOGGER.error(f"🔴 Vespa health check failed: {e}")
         return False
-    return True
 
 
 def is_database_online(
     db: Session = Depends(get_db),
     vespa_search_adapter: VespaSearchAdapter = Depends(get_vespa_search_adapter),
 ) -> bool:
-    """Checks database health."""
+    """Checks database health.
+
+    :param db: Database session, defaults to Depends(get_db)
+    :type db: Session
+    :param vespa_search_adapter: Vespa search adapter
+    :type vespa_search_adapter: VespaSearchAdapter
+    :return: True if all database components are online
+    :rtype: bool
+    """
     return all([is_rds_online(db), is_vespa_online(vespa_search_adapter)])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "navigator_backend"
-version = "1.24.1"
+version = "1.24.2"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]

--- a/tests/non_search/routers/test_main.py
+++ b/tests/non_search/routers/test_main.py
@@ -1,4 +1,10 @@
 import os
+from unittest.mock import Mock
+
+import pytest
+from fastapi import status
+
+HEALTH_ENDPOINT = "/health"
 
 
 def test_read_main(test_client):
@@ -18,3 +24,33 @@ def test_read_docs(test_client):
     else:
         assert docs_response.status_code == 404
         assert openapi_response.status_code == 404
+
+
+def test_health_endpoint_returns_200_when_all_healthy(test_client):
+    """Test health endpoint returns 200 when all services are healthy."""
+    response = test_client.get(HEALTH_ENDPOINT)
+    assert response.status_code == status.HTTP_200_OK
+
+
+@pytest.mark.parametrize(
+    "rds_online,vespa_online,expected_status",
+    [
+        (True, True, status.HTTP_200_OK),
+        (False, True, status.HTTP_503_SERVICE_UNAVAILABLE),
+        (True, False, status.HTTP_503_SERVICE_UNAVAILABLE),
+        (False, False, status.HTTP_503_SERVICE_UNAVAILABLE),
+    ],
+)
+def test_health_endpoint_returns_correct_status(
+    test_client, monkeypatch, rds_online, vespa_online, expected_status
+):
+    """Test health endpoint returns correct status based on service health."""
+    # Mock the database health check functions
+    mock_rds = Mock(return_value=rds_online)
+    mock_vespa = Mock(return_value=vespa_online)
+
+    monkeypatch.setattr("app.service.health.is_rds_online", mock_rds)
+    monkeypatch.setattr("app.service.health.is_vespa_online", mock_vespa)
+
+    response = test_client.get(HEALTH_ENDPOINT)
+    assert response.status_code == expected_status

--- a/tests/non_search/routers/test_main.py
+++ b/tests/non_search/routers/test_main.py
@@ -26,12 +26,6 @@ def test_read_docs(test_client):
         assert openapi_response.status_code == 404
 
 
-def test_health_endpoint_returns_200_when_all_healthy(test_client):
-    """Test health endpoint returns 200 when all services are healthy."""
-    response = test_client.get(HEALTH_ENDPOINT)
-    assert response.status_code == status.HTTP_200_OK
-
-
 @pytest.mark.parametrize(
     "rds_online,vespa_online,expected_status",
     [

--- a/tests/unit/app/service/test_health.py
+++ b/tests/unit/app/service/test_health.py
@@ -1,0 +1,84 @@
+from unittest.mock import Mock
+
+import pytest
+from sqlalchemy.exc import SQLAlchemyError
+
+from app.service.health import is_database_online, is_rds_online, is_vespa_online
+
+
+def test_is_rds_online_returns_true_when_db_healthy(caplog):
+    """Test RDS health check returns True when database is responsive."""
+    mock_db = Mock()
+    mock_db.execute.return_value = Mock()
+
+    assert is_rds_online(mock_db) is True
+    mock_db.execute.assert_called_once_with("SELECT 1")
+    assert "🔴 RDS health check failed" not in caplog.text
+
+
+def test_is_rds_online_returns_false_when_db_error(caplog):
+    """Test RDS health check returns False when database throws error."""
+    mock_db = Mock()
+    mock_db.execute.side_effect = SQLAlchemyError("Database error")
+
+    assert is_rds_online(mock_db) is False
+    mock_db.execute.assert_called_once_with("SELECT 1")
+    assert "🔴 RDS health check failed: Database error" in caplog.text
+
+
+def test_is_vespa_online_returns_true_when_vespa_healthy():
+    """Test Vespa health check returns True when Vespa is responsive."""
+    mock_vespa = Mock()
+    mock_vespa.client.query.return_value = Mock()
+
+    assert is_vespa_online(mock_vespa) is True
+
+    expected_query = {"yql": "select * from sources * where true", "hits": "0"}
+    mock_vespa.client.query.assert_called_once_with(expected_query)
+
+
+@pytest.mark.parametrize("dev_mode", [True, False])
+def test_is_vespa_online_returns_false_when_vespa_error(dev_mode, monkeypatch, caplog):
+    """Test Vespa health check returns False when Vespa throws error."""
+    monkeypatch.setattr("app.service.health.DEVELOPMENT_MODE", dev_mode)
+
+    mock_vespa = Mock()
+    mock_vespa.client.query.side_effect = Exception("Vespa error")
+
+    assert is_vespa_online(mock_vespa) is False
+
+    # Check error logging behaviour based on dev mode
+    if not dev_mode:
+        assert "🔴 Vespa health check failed: Vespa error" in caplog.text
+    else:
+        assert "🔴 Vespa health check failed: Vespa error" not in caplog.text
+
+
+@pytest.mark.parametrize(
+    "rds_health,vespa_health,expected_health",
+    [
+        (True, True, True),
+        (False, True, False),
+        (True, False, False),
+        (False, False, False),
+    ],
+)
+def test_is_database_online(rds_health, vespa_health, expected_health):
+    """Test overall database health check returns correct status."""
+    mock_db = Mock()
+    mock_vespa = Mock()
+
+    # Create mock functions with the expected return values
+    mock_rds_check = Mock(return_value=rds_health)
+    mock_vespa_check = Mock(return_value=vespa_health)
+
+    # Patch the individual health check functions
+    with pytest.MonkeyPatch().context() as m:
+        m.setattr("app.service.health.is_rds_online", mock_rds_check)
+        m.setattr("app.service.health.is_vespa_online", mock_vespa_check)
+
+        assert is_database_online(mock_db, mock_vespa) is expected_health
+
+        # Verify the mocked functions were called with correct arguments
+        mock_rds_check.assert_called_once_with(mock_db)
+        mock_vespa_check.assert_called_once_with(mock_vespa)


### PR DESCRIPTION
# Description

- Add healthcheck tests
- Fixed bug in is_rds_online so that we now return False if we can't connect to RDS

Trying to recreate the seg fault issue safely in our test environment at the moment for is_vespa_online, but have not yet managed. Will do this separately.

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Refactor legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
