### PR TITLE
Add page num ordering as option rather than default

### DIFF
--- a/app/models/search.py
+++ b/app/models/search.py
@@ -91,6 +91,11 @@ class SearchRequestBody(CprSdkSearchParameters):
         le=500,
     )
 
+    """Whether or not to sort passage matches by the order in which they
+    appear in a document.
+    """
+    sort_within_page: bool = False
+
     @field_validator("offset", mode="after")
     @classmethod
     def offset_below_limit(cls, offset: int, info: ValidationInfo):

--- a/app/service/search.py
+++ b/app/service/search.py
@@ -569,7 +569,7 @@ def process_vespa_search_response(
     vespa_search_response: CprSdkSearchResponse,
     limit: int,
     offset: int,
-    sort_within_page: bool = False,
+    sort_within_page: bool,
 ) -> SearchResponse:
     """Process a Vespa search response into a F/E search response"""
 
@@ -647,17 +647,7 @@ def make_search_request(
             cpr_sdk_search_response,
             limit=search_body.page_size,
             offset=search_body.offset,
-            # Set default sort to within page.
-            sort_within_page=(
-                True
-                if search_body.sort_by is None
-                or (
-                    search_body.concept_filters is not None
-                    and len(search_body.concept_filters) > 0
-                )
-                or search_body.exact_match
-                else False
-            ),
+            sort_within_page=search_body.sort_within_page,
         ).increment_pages()
     except QueryError as e:
         _LOGGER.error(f"make_search_request QueryError: {e}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "navigator_backend"
-version = "1.24.3"
+version = "1.24.4"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]

--- a/tests/search/test_search.py
+++ b/tests/search/test_search.py
@@ -891,6 +891,7 @@ def test_process_vespa_search_response(
         vespa_search_response=vespa_response,
         limit=page_size,
         offset=offset,
+        sort_within_page=False,
     )
 
     assert len(search_response.families) == min(len(fam_specs), page_size)
@@ -1286,6 +1287,7 @@ def test_process_vespa_search_response_page_ordering_regression(
         concept_filters=[],  # Empty list, not None
         document_ids=[f"{test_spec.family_import_id}"],
         continuation_tokens=[],
+        sort_within_page=True,
     )
 
     response = make_search_request(


### PR DESCRIPTION
# Description

https://www.notion.so/climatepolicyradar/Brief-Give-users-option-to-change-ordering-of-matches-on-document-viewer-and-change-default-back-t-1e59109609a480738f3bfaa6c0f23939

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Refactor legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
