### PR TITLE
:robot: vespa test schema: enable document title bm25 search

### DIFF
--- a/tests/search/vespa/fixtures/vespa_test_schema/schemas/family_document.sd
+++ b/tests/search/vespa/fixtures/vespa_test_schema/schemas/family_document.sd
@@ -14,6 +14,16 @@ schema family_document {
         stemming: none
     }
 
+    field document_title_index type string {
+        indexing: input document_title | index
+        index: enable-bm25
+    }
+
+    field document_title_not_stemmed type string {
+        indexing: input document_title | index
+        stemming: none
+    }
+
     document family_document {
 
         field search_weights_ref type reference<search_weights> {
@@ -211,6 +221,16 @@ schema family_document {
             expression: (query(name_weight) * name_score()) + (query(description_weight) * description_score())
         }
         summary-features: name_score() description_score() bm25(family_name_index) bm25(family_description_index) closeness(family_description_embedding)
+    }
+    
+    rank-profile bm25_document_title inherits default_family {
+        function name_score() {
+            expression: bm25(document_title_index)
+        }
+        first-phase {
+            expression: (query(name_weight) * name_score())
+        }
+        summary-features: name_score() bm25(document_title_index)
     }
     
     rank-profile hybrid_nativerank inherits default_family {


### PR DESCRIPTION
# Description

See https://github.com/climatepolicyradar/navigator-infra/pull/1050

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [x] Skip auto-tagging
- [ ] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Refactor legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain