### PR TITLE
`families-api` deploy

### DIFF
--- a/.github/workflows/merge-to-main.yml
+++ b/.github/workflows/merge-to-main.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: aws-actions/configure-aws-credentials@v4.2.0
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/navigator-backend-github-actions-deploy
-          role-session-name: GitHub_to_AWS_via_FederatedOIDC
+          role-session-name: GitHub_to_AWS_via_FederatedOIDC_staging
           aws-region: eu-west-1
       - uses: aws-actions/amazon-ecr-login@v1
       - working-directory: families-api
@@ -33,8 +33,8 @@ jobs:
       - uses: aws-actions/configure-aws-credentials@v4.2.0
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/navigator-backend-github-actions-deploy
-          role-session-name: GitHub_to_AWS_via_FederatedOIDC
+          role-session-name: GitHub_to_AWS_via_FederatedOIDC_production
           aws-region: eu-west-1
       - uses: aws-actions/amazon-ecr-login@v1
       - working-directory: families-api
-        run: just deploy latest
+        run: just deploy latestz

--- a/.github/workflows/merge-to-main.yml
+++ b/.github/workflows/merge-to-main.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: aws-actions/amazon-ecr-login@v1
       - working-directory: families-api
         run: just deploy staging
-  deploy-families-api-github-sha:
+  deploy-families-api-staging-github-sha:
     runs-on: ubuntu-latest
     environment: staging
     steps:
@@ -53,3 +53,18 @@ jobs:
       - uses: aws-actions/amazon-ecr-login@v1
       - working-directory: families-api
         run: just deploy latest
+  deploy-families-api-production-github-sha:
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+      - uses: extractions/setup-just@v2
+      - uses: actions/checkout@v4
+      - uses: aws-actions/configure-aws-credentials@v4.2.0
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/navigator-backend-github-actions-deploy
+          role-session-name: GitHub_to_AWS_via_FederatedOIDC_production
+          aws-region: eu-west-1
+      - uses: aws-actions/amazon-ecr-login@v1
+      - working-directory: families-api
+        run: just deploy ${{ github.sha }}

--- a/.github/workflows/merge-to-main.yml
+++ b/.github/workflows/merge-to-main.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - geographies-api-deploy
 permissions:
   id-token: write
   contents: read

--- a/.github/workflows/merge-to-main.yml
+++ b/.github/workflows/merge-to-main.yml
@@ -20,5 +20,6 @@ jobs:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/navigator-backend-github-actions-deploy
           role-session-name: GitHub_to_AWS_via_FederatedOIDC
           aws-region: eu-west-1
+      - uses: aws-actions/amazon-ecr-login@v1
       - working-directory: families-api
         run: just deploy staging

--- a/.github/workflows/merge-to-main.yml
+++ b/.github/workflows/merge-to-main.yml
@@ -8,7 +8,22 @@ permissions:
   id-token: write
   contents: read
 jobs:
-  merge-to-main:
+  deploy-families-api-staging:
+    runs-on: ubuntu-latest
+    environment: staging
+    steps:
+      - uses: actions/checkout@v4
+      - uses: extractions/setup-just@v2
+      - uses: actions/checkout@v4
+      - uses: aws-actions/configure-aws-credentials@v4.2.0
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/navigator-backend-github-actions-deploy
+          role-session-name: GitHub_to_AWS_via_FederatedOIDC
+          aws-region: eu-west-1
+      - uses: aws-actions/amazon-ecr-login@v1
+      - working-directory: families-api
+        run: just deploy staging
+  deploy-families-api-production:
     runs-on: ubuntu-latest
     environment: production
     steps:
@@ -22,4 +37,4 @@ jobs:
           aws-region: eu-west-1
       - uses: aws-actions/amazon-ecr-login@v1
       - working-directory: families-api
-        run: just deploy staging
+        run: just deploy latest

--- a/.github/workflows/merge-to-main.yml
+++ b/.github/workflows/merge-to-main.yml
@@ -23,6 +23,21 @@ jobs:
       - uses: aws-actions/amazon-ecr-login@v1
       - working-directory: families-api
         run: just deploy staging
+  deploy-families-api-github-sha:
+    runs-on: ubuntu-latest
+    environment: staging
+    steps:
+      - uses: actions/checkout@v4
+      - uses: extractions/setup-just@v2
+      - uses: actions/checkout@v4
+      - uses: aws-actions/configure-aws-credentials@v4.2.0
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/navigator-backend-github-actions-deploy
+          role-session-name: GitHub_to_AWS_via_FederatedOIDC_staging
+          aws-region: eu-west-1
+      - uses: aws-actions/amazon-ecr-login@v1
+      - working-directory: families-api
+        run: just deploy ${{ github.sha }}
   deploy-families-api-production:
     runs-on: ubuntu-latest
     environment: production
@@ -37,4 +52,4 @@ jobs:
           aws-region: eu-west-1
       - uses: aws-actions/amazon-ecr-login@v1
       - working-directory: families-api
-        run: just deploy latestz
+        run: just deploy latest

--- a/.github/workflows/merge-to-main.yml
+++ b/.github/workflows/merge-to-main.yml
@@ -15,11 +15,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: extractions/setup-just@v2
       - uses: actions/checkout@v4
-      - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v4.2.0
+      - uses: aws-actions/configure-aws-credentials@v4.2.0
         with:
-          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/navigator-backend-github-actions
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/navigator-backend-github-actions-deploy
           role-session-name: GitHub_to_AWS_via_FederatedOIDC
           aws-region: eu-west-1
       - working-directory: families-api
-        run: just deploy
+        run: just deploy staging

--- a/.github/workflows/merge-to-main.yml
+++ b/.github/workflows/merge-to-main.yml
@@ -1,0 +1,25 @@
+name: Merge to Main
+on:
+  push:
+    branches:
+      - main
+      - geographies-api-deploy
+
+permissions: read-all
+
+jobs:
+  merge-to-main:
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+      - uses: extractions/setup-just@v2
+      - uses: actions/checkout@v4
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v4.2.0
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/navigator-backend-github-actions
+          role-session-name: GitHub_to_AWS_via_FederatedOIDC
+          aws-region: eu-west-1
+      - working-directory: families-api
+        run: just deploy

--- a/.github/workflows/merge-to-main.yml
+++ b/.github/workflows/merge-to-main.yml
@@ -4,9 +4,9 @@ on:
     branches:
       - main
       - geographies-api-deploy
-
-permissions: read-all
-
+permissions:
+  id-token: write
+  contents: read
 jobs:
   merge-to-main:
     runs-on: ubuntu-latest

--- a/api/infra/__main__.py
+++ b/api/infra/__main__.py
@@ -1,3 +1,5 @@
+import json
+
 import pulumi
 import pulumi_aws as aws
 
@@ -186,4 +188,52 @@ api_certificate_validation_dns_record = aws.route53.Record(
             "evaluate_target_health": False,
         }
     ],
+)
+
+# deployment
+navigator_backend_github_actions = aws.iam.Role(
+    "navigator-backend-github-actions",
+    assume_role_policy=json.dumps(
+        {
+            "Statement": [
+                {
+                    "Action": "sts:AssumeRoleWithWebIdentity",
+                    "Condition": {
+                        "StringEquals": {
+                            "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+                        },
+                        "StringLike": {
+                            "token.actions.githubusercontent.com:sub": "repo:climatepolicyradar/*"
+                        },
+                    },
+                    "Effect": "Allow",
+                    "Principal": {
+                        "Federated": f"arn:aws:iam::{account_id}:oidc-provider/token.actions.githubusercontent.com"
+                    },
+                }
+            ],
+            "Version": "2012-10-17",
+        }
+    ),
+    inline_policies=[
+        {
+            "name": "navigator-backend-github-actions",
+            "policy": json.dumps(
+                {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Action": [
+                                "ecr:*",
+                            ],
+                            "Effect": "Allow",
+                            "Resource": "*",
+                        }
+                    ],
+                }
+            ),
+        }
+    ],
+    managed_policy_arns=["arn:aws:iam::aws:policy/AWSAppRunnerFullAccess"],
+    name="navigator-backend-github-actions",
 )

--- a/api/infra/__main__.py
+++ b/api/infra/__main__.py
@@ -191,8 +191,8 @@ api_certificate_validation_dns_record = aws.route53.Record(
 )
 
 # deployment
-navigator_backend_github_actions = aws.iam.Role(
-    "navigator-backend-github-actions",
+navigator_backend_github_actions_deploy = aws.iam.Role(
+    "navigator-backend-github-actions-deploy",
     assume_role_policy=json.dumps(
         {
             "Statement": [
@@ -217,7 +217,7 @@ navigator_backend_github_actions = aws.iam.Role(
     ),
     inline_policies=[
         {
-            "name": "navigator-backend-github-actions",
+            "name": "navigator-backend-github-actions-deploy",
             "policy": json.dumps(
                 {
                     "Version": "2012-10-17",
@@ -235,5 +235,5 @@ navigator_backend_github_actions = aws.iam.Role(
         }
     ],
     managed_policy_arns=["arn:aws:iam::aws:policy/AWSAppRunnerFullAccess"],
-    name="navigator-backend-github-actions",
+    name="navigator-backend-github-actions-deploy",
 )

--- a/families-api/justfile
+++ b/families-api/justfile
@@ -34,8 +34,11 @@ docker-push:
     docker tag families-api:latest $(aws sts get-caller-identity --query 'Account' --output text).dkr.ecr.eu-west-1.amazonaws.com/families-api:latest
     docker push $(aws sts get-caller-identity --query 'Account' --output text).dkr.ecr.eu-west-1.amazonaws.com/families-api:latest
 
+deploy-local:
+    just ecr-login
+    just deploy
+
 deploy:
     just requirements
     just docker-build
-    just ecr-login
     just docker-push

--- a/families-api/justfile
+++ b/families-api/justfile
@@ -27,18 +27,18 @@ requirements:
 ecr-login:
     aws ecr get-login-password --region eu-west-1 | docker login --username AWS --password-stdin $(aws sts get-caller-identity --query 'Account' --output text).dkr.ecr.eu-west-1.amazonaws.com
 
-docker-build:
-    docker buildx build --platform linux/amd64 --output type=docker -t families-api:latest .
+docker-build tag:
+    docker buildx build --platform linux/amd64 --output type=docker -t families-api:{{tag}} .
 
-docker-push:
-    docker tag families-api:latest $(aws sts get-caller-identity --query 'Account' --output text).dkr.ecr.eu-west-1.amazonaws.com/families-api:latest
-    docker push $(aws sts get-caller-identity --query 'Account' --output text).dkr.ecr.eu-west-1.amazonaws.com/families-api:latest
+docker-push tag:
+    docker tag families-api:{{tag}} $(aws sts get-caller-identity --query 'Account' --output text).dkr.ecr.eu-west-1.amazonaws.com/families-api:{{tag}}
+    docker push $(aws sts get-caller-identity --query 'Account' --output text).dkr.ecr.eu-west-1.amazonaws.com/families-api:{{tag}}
 
-deploy-local:
+deploy-local tag:
     just ecr-login
-    just deploy
+    just deploy {{tag}}
 
-deploy:
+deploy tag:
     just requirements
-    just docker-build
-    just docker-push
+    just docker-build {{tag}}
+    just docker-push {{tag}}

--- a/families-api/justfile
+++ b/families-api/justfile
@@ -36,9 +36,9 @@ docker-push tag:
 
 deploy-local tag:
     just ecr-login
+    just requirements
     just deploy {{tag}}
 
 deploy tag:
-    just requirements
     just docker-build {{tag}}
     just docker-push {{tag}}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,6 @@
 [tool.poetry]
 name = "navigator_backend"
-<<<<<<< HEAD
 version = "1.24.13"
-=======
-version = "1.24.12"
->>>>>>> a0b4d70 (feat: geographies stub and api infra (#511))
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,10 @@
 [tool.poetry]
 name = "navigator_backend"
+<<<<<<< HEAD
 version = "1.24.13"
+=======
+version = "1.24.12"
+>>>>>>> a0b4d70 (feat: geographies stub and api infra (#511))
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "navigator_backend"
-version = "1.24.12"
+version = "1.24.13"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]


### PR DESCRIPTION
# Description

- adds `staging` deploy on merge-to-main for `families-api`
- adds "[reviewed deployment](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-deployments/reviewing-deployments)" deploy to `production` AKA `latest`
- releases a hashed deploy to github SHA

## The reviewed deploy
- is on the [`production` environment](https://github.com/climatepolicyradar/navigator-backend/settings/environments/6731733887/edit)
- GitHub protection are all-or-nothing, so any other action wanting to use the production `environment` will be protected
- A mitigation for the above is creating another environment called `production-protected` or similar
- It current requires @climatepolicyradar/tech-devs to review the deploy. While I can see this being a risk when wanting to deploy in urgency (and this is already pretty much the case) - mitigations are
  - remove the gate temporarily
  - GitHub managers can bypass the gate
  - deploy locally

[Here's an example](https://github.com/climatepolicyradar/navigator-backend/actions/runs/15038351394/job/42264241207?pr=514)

## GitHub environment setup
- We have two [environments](https://github.com/climatepolicyradar/navigator-backend/settings/environments) setup in GitHub for this repo
  - `staging`
  - `production`
- each environment has an `AWS_ACCOUNT_ID` setup (currently staging is pointing to production [until we do this](https://linear.app/climate-policy-radar/project/isolate-services-within-navigator-backend-abeb5f150aa4/issues))
- this replicates what we have in `navigator-infra`

Fixes: https://linear.app/climate-policy-radar/issue/APP-575/add-deployment-for-families-api

## Proposed version

- [x] Patch
