### PR TITLE
Update db_client to latest

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -813,7 +813,7 @@ vision = ["Pillow (>=9.4.0)"]
 
 [[package]]
 name = "db-client"
-version = "3.9.10"
+version = "3.9.12"
 description = "All things to do with the datamodel and its storage. Including alembic migrations and datamodel code."
 optional = false
 python-versions = "^3.11"
@@ -834,8 +834,8 @@ SQLAlchemy-Utils = "^0.38.2"
 [package.source]
 type = "git"
 url = "https://github.com/climatepolicyradar/navigator-db-client.git"
-reference = "v3.9.10"
-resolved_reference = "c9420142e9653e8fa24d6a407673b5d44b033359"
+reference = "v3.9.12"
+resolved_reference = "fac0b04e70ecf1845fc729cabfaec6954319aeea"
 
 [[package]]
 name = "deprecated"
@@ -4799,4 +4799,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "68b22e91ef7ebdd10651dc16ea35f7303d4dd168dd662b3b8ceea161cb898dfd"
+content-hash = "a00dbdcbcd70ab2cf0cb486d979d8adcf17407825118efedcfcb804a9936ee4b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "navigator_backend"
-version = "1.24.15"
+version = "1.24.16"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]
@@ -31,7 +31,7 @@ starlette = "^0.27.0"
 tenacity = "^9.0.0"
 uvicorn = { extras = ["standard"], version = "^0.20.0" }
 botocore = "^1.34.19"
-db-client = { git = "https://github.com/climatepolicyradar/navigator-db-client.git", tag = "v3.9.10" }
+db-client = { git = "https://github.com/climatepolicyradar/navigator-db-client.git", tag = "v3.9.12" }
 urllib3 = "<2"
 apscheduler = "^3.10.4"
 numpy = "1.26.4"

--- a/tests/non_search/routers/geographies/setup_world_map_helpers.py
+++ b/tests/non_search/routers/geographies/setup_world_map_helpers.py
@@ -54,6 +54,10 @@ def _add_published_fams_and_docs(db: Session):
                 "date": "2019-12-25",
                 "type": "Passed/Approved",
                 "status": "OK",
+                "valid_metadata": {
+                    "event_type": ["Passed/Approved"],
+                    "datetime_event_name": ["Passed/Approved"],
+                },
             }
         ],
     }
@@ -76,6 +80,10 @@ def _add_published_fams_and_docs(db: Session):
                 "date": "2019-12-25",
                 "type": "Passed/Approved",
                 "status": "OK",
+                "valid_metadata": {
+                    "event_type": ["Passed/Approved"],
+                    "datetime_event_name": ["Passed/Approved"],
+                },
             }
         ],
     }
@@ -185,6 +193,10 @@ def setup_mixed_doc_statuses_world_map(db: Session):
                 "date": "2019-12-25",
                 "type": "Passed/Approved",
                 "status": "OK",
+                "valid_metadata": {
+                    "event_type": ["Passed/Approved"],
+                    "datetime_event_name": ["Passed/Approved"],
+                },
             }
         ],
     }
@@ -206,6 +218,10 @@ def setup_mixed_doc_statuses_world_map(db: Session):
                 "date": "2019-12-25",
                 "type": "Passed/Approved",
                 "status": "OK",
+                "valid_metadata": {
+                    "event_type": ["Passed/Approved"],
+                    "datetime_event_name": ["Passed/Approved"],
+                },
             }
         ],
     }
@@ -227,6 +243,10 @@ def setup_mixed_doc_statuses_world_map(db: Session):
                 "date": "2019-12-25",
                 "type": "Passed/Approved",
                 "status": "OK",
+                "valid_metadata": {
+                    "event_type": ["Passed/Approved"],
+                    "datetime_event_name": ["Passed/Approved"],
+                },
             }
         ],
     }
@@ -248,6 +268,10 @@ def setup_mixed_doc_statuses_world_map(db: Session):
                 "date": "2019-12-25",
                 "type": "Passed/Approved",
                 "status": "OK",
+                "valid_metadata": {
+                    "event_type": ["Passed/Approved"],
+                    "datetime_event_name": ["Passed/Approved"],
+                },
             }
         ],
     }
@@ -269,6 +293,10 @@ def setup_mixed_doc_statuses_world_map(db: Session):
                 "date": "2019-12-25",
                 "type": "Passed/Approved",
                 "status": "OK",
+                "valid_metadata": {
+                    "event_type": ["Passed/Approved"],
+                    "datetime_event_name": ["Passed/Approved"],
+                },
             }
         ],
     }

--- a/tests/non_search/routers/lookups/test_config.py
+++ b/tests/non_search/routers/lookups/test_config.py
@@ -29,7 +29,6 @@ EXPECTED_CCLW_TAXONOMY = {
     "hazard",
     "_document",
     "_event",
-    "event_type",
 }
 EXPECTED_CCLW_EVENTS = [
     "Amended",
@@ -55,7 +54,6 @@ EXPECTED_CCLW_EVENTS = [
 EXPECTED_UNFCCC_TAXONOMY = {
     "author",
     "author_type",
-    "event_type",
     "_document",
     "_event",
 }

--- a/tests/non_search/setup_helpers.py
+++ b/tests/non_search/setup_helpers.py
@@ -45,6 +45,10 @@ def get_default_documents():
                 "date": "2019-12-25",
                 "type": "Passed/Approved",
                 "status": "OK",
+                "valid_metadata": {
+                    "event_type": ["Passed/Approved"],
+                    "datetime_event_name": ["Passed/Approved"],
+                },
             }
         ],
     }
@@ -67,6 +71,10 @@ def get_default_documents():
                 "date": "2019-12-25",
                 "type": "Passed/Approved",
                 "status": "OK",
+                "valid_metadata": {
+                    "event_type": ["Passed/Approved"],
+                    "datetime_event_name": ["Passed/Approved"],
+                },
             }
         ],
     }

--- a/tests/unit/fixtures/CCLW.document.i00000002.n0000.json
+++ b/tests/unit/fixtures/CCLW.document.i00000002.n0000.json
@@ -18,7 +18,11 @@
       "title": "Published",
       "date": "2019-12-25",
       "type": "Passed/Approved",
-      "status": "OK"
+      "status": "OK",
+      "valid_metadata": {
+        "event_type": ["Passed/Approved"],
+        "datetime_event_name": ["Passed/Approved"]
+      }
     }
   ]
 }

--- a/tests/unit/fixtures/CCLW.document.i00000006.n0000.json
+++ b/tests/unit/fixtures/CCLW.document.i00000006.n0000.json
@@ -18,7 +18,11 @@
       "title": "Published",
       "date": "2019-12-25",
       "type": "Passed/Approved",
-      "status": "OK"
+      "status": "OK",
+      "valid_metadata": {
+        "event_type": ["Passed/Approved"],
+        "datetime_event_name": ["Passed/Approved"]
+      }
     }
   ]
 }

--- a/tests/unit/fixtures/CCLW.document.i00000008.n0000.json
+++ b/tests/unit/fixtures/CCLW.document.i00000008.n0000.json
@@ -18,7 +18,11 @@
       "title": "Published",
       "date": "2019-12-25",
       "type": "Passed/Approved",
-      "status": "OK"
+      "status": "OK",
+      "valid_metadata": {
+        "event_type": ["Passed/Approved"],
+        "datetime_event_name": ["Passed/Approved"]
+      }
     }
   ]
 }

--- a/tests/unit/fixtures/CCLW.document.i00000016.n0000.json
+++ b/tests/unit/fixtures/CCLW.document.i00000016.n0000.json
@@ -18,7 +18,11 @@
       "title": "Published",
       "date": "2019-12-25",
       "type": "Passed/Approved",
-      "status": "OK"
+      "status": "OK",
+      "valid_metadata": {
+        "event_type": ["Passed/Approved"],
+        "datetime_event_name": ["Passed/Approved"]
+      }
     }
   ]
 }

--- a/tests/unit/fixtures/CCLW.document.i00000018.n0000.json
+++ b/tests/unit/fixtures/CCLW.document.i00000018.n0000.json
@@ -18,7 +18,11 @@
       "title": "Published",
       "date": "2019-12-25",
       "type": "Passed/Approved",
-      "status": "OK"
+      "status": "OK",
+      "valid_metadata": {
+        "event_type": ["Passed/Approved"],
+        "datetime_event_name": ["Passed/Approved"]
+      }
     }
   ]
 }

--- a/tests/unit/fixtures/CCLW.document.i00000026.n0000.json
+++ b/tests/unit/fixtures/CCLW.document.i00000026.n0000.json
@@ -18,7 +18,11 @@
       "title": "Published",
       "date": "2019-12-25",
       "type": "Passed/Approved",
-      "status": "OK"
+      "status": "OK",
+      "valid_metadata": {
+        "event_type": ["Passed/Approved"],
+        "datetime_event_name": ["Passed/Approved"]
+      }
     }
   ]
 }

--- a/tests/unit/fixtures/CCLW.document.i00000030.n0000.json
+++ b/tests/unit/fixtures/CCLW.document.i00000030.n0000.json
@@ -18,7 +18,11 @@
       "title": "Published",
       "date": "2019-12-25",
       "type": "Passed/Approved",
-      "status": "OK"
+      "status": "OK",
+      "valid_metadata": {
+        "event_type": ["Passed/Approved"],
+        "datetime_event_name": ["Passed/Approved"]
+      }
     }
   ]
 }

--- a/tests/unit/fixtures/CCLW.document.i00000038.n0000.json
+++ b/tests/unit/fixtures/CCLW.document.i00000038.n0000.json
@@ -18,7 +18,11 @@
       "title": "Published",
       "date": "2019-12-25",
       "type": "Passed/Approved",
-      "status": "OK"
+      "status": "OK",
+      "valid_metadata": {
+        "event_type": ["Passed/Approved"],
+        "datetime_event_name": ["Passed/Approved"]
+      }
     }
   ]
 }

--- a/tests/unit/fixtures/CCLW.document.i00000040.n0000.json
+++ b/tests/unit/fixtures/CCLW.document.i00000040.n0000.json
@@ -18,7 +18,11 @@
       "title": "Published",
       "date": "2019-12-25",
       "type": "Passed/Approved",
-      "status": "OK"
+      "status": "OK",
+      "valid_metadata": {
+        "event_type": ["Passed/Approved"],
+        "datetime_event_name": ["Passed/Approved"]
+      }
     }
   ]
 }

--- a/tests/unit/fixtures/CCLW.document.i00000058.n0000.json
+++ b/tests/unit/fixtures/CCLW.document.i00000058.n0000.json
@@ -18,7 +18,11 @@
       "title": "Published",
       "date": "2019-12-25",
       "type": "Passed/Approved",
-      "status": "OK"
+      "status": "OK",
+      "valid_metadata": {
+        "event_type": ["Passed/Approved"],
+        "datetime_event_name": ["Passed/Approved"]
+      }
     }
   ]
 }

--- a/tests/unit/fixtures/CCLW.document.i00000066.n0000.json
+++ b/tests/unit/fixtures/CCLW.document.i00000066.n0000.json
@@ -18,7 +18,11 @@
       "title": "Published",
       "date": "2019-12-25",
       "type": "Passed/Approved",
-      "status": "OK"
+      "status": "OK",
+      "valid_metadata": {
+        "event_type": ["Passed/Approved"],
+        "datetime_event_name": ["Passed/Approved"]
+      }
     }
   ]
 }

--- a/tests/unit/fixtures/CCLW.document.i00000067.n0000.json
+++ b/tests/unit/fixtures/CCLW.document.i00000067.n0000.json
@@ -18,7 +18,11 @@
       "title": "Published",
       "date": "2019-12-25",
       "type": "Passed/Approved",
-      "status": "OK"
+      "status": "OK",
+      "valid_metadata": {
+        "event_type": ["Passed/Approved"],
+        "datetime_event_name": ["Passed/Approved"]
+      }
     }
   ]
 }

--- a/tests/unit/fixtures/CCLW.document.i00000144.n0000.json
+++ b/tests/unit/fixtures/CCLW.document.i00000144.n0000.json
@@ -18,7 +18,11 @@
       "title": "Published",
       "date": "2019-12-25",
       "type": "Passed/Approved",
-      "status": "OK"
+      "status": "OK",
+      "valid_metadata": {
+        "event_type": ["Passed/Approved"],
+        "datetime_event_name": ["Passed/Approved"]
+      }
     }
   ]
 }

--- a/tests/unit/fixtures/CCLW.document.i00000153.n0000.json
+++ b/tests/unit/fixtures/CCLW.document.i00000153.n0000.json
@@ -18,7 +18,11 @@
       "title": "Published",
       "date": "2019-12-25",
       "type": "Passed/Approved",
-      "status": "OK"
+      "status": "OK",
+      "valid_metadata": {
+        "event_type": ["Passed/Approved"],
+        "datetime_event_name": ["Passed/Approved"]
+      }
     }
   ]
 }

--- a/tests/unit/fixtures/CCLW.document.i00000192.n0000.json
+++ b/tests/unit/fixtures/CCLW.document.i00000192.n0000.json
@@ -19,7 +19,11 @@
       "title": "Published",
       "date": "2019-12-25",
       "type": "Passed/Approved",
-      "status": "OK"
+      "status": "OK",
+      "valid_metadata": {
+        "event_type": ["Passed/Approved"],
+        "datetime_event_name": ["Passed/Approved"]
+      }
     }
   ]
 }

--- a/tests/unit/fixtures/CCLW.document.i00000204.n0000.json
+++ b/tests/unit/fixtures/CCLW.document.i00000204.n0000.json
@@ -18,7 +18,11 @@
       "title": "Published",
       "date": "2019-12-25",
       "type": "Passed/Approved",
-      "status": "OK"
+      "status": "OK",
+      "valid_metadata": {
+        "event_type": ["Passed/Approved"],
+        "datetime_event_name": ["Passed/Approved"]
+      }
     }
   ]
 }

--- a/tests/unit/fixtures/CCLW.document.i00000214.n0000.json
+++ b/tests/unit/fixtures/CCLW.document.i00000214.n0000.json
@@ -18,7 +18,11 @@
       "title": "Published",
       "date": "2019-12-25",
       "type": "Passed/Approved",
-      "status": "OK"
+      "status": "OK",
+      "valid_metadata": {
+        "event_type": ["Passed/Approved"],
+        "datetime_event_name": ["Passed/Approved"]
+      }
     }
   ]
 }

--- a/tests/unit/fixtures/CCLW.document.i00000222.n0000.json
+++ b/tests/unit/fixtures/CCLW.document.i00000222.n0000.json
@@ -18,7 +18,11 @@
       "title": "Published",
       "date": "2019-12-25",
       "type": "Passed/Approved",
-      "status": "OK"
+      "status": "OK",
+      "valid_metadata": {
+        "event_type": ["Passed/Approved"],
+        "datetime_event_name": ["Passed/Approved"]
+      }
     }
   ]
 }

--- a/tests/unit/fixtures/CCLW.document.i00000247.n0000.json
+++ b/tests/unit/fixtures/CCLW.document.i00000247.n0000.json
@@ -18,7 +18,11 @@
       "title": "Published",
       "date": "2019-12-25",
       "type": "Passed/Approved",
-      "status": "OK"
+      "status": "OK",
+      "valid_metadata": {
+        "event_type": ["Passed/Approved"],
+        "datetime_event_name": ["Passed/Approved"]
+      }
     }
   ]
 }

--- a/tests/unit/fixtures/CCLW.document.i00000280.n0000.json
+++ b/tests/unit/fixtures/CCLW.document.i00000280.n0000.json
@@ -18,7 +18,11 @@
       "title": "Published",
       "date": "2019-12-25",
       "type": "Passed/Approved",
-      "status": "OK"
+      "status": "OK",
+      "valid_metadata": {
+        "event_type": ["Passed/Approved"],
+        "datetime_event_name": ["Passed/Approved"]
+      }
     }
   ]
 }

--- a/tests/unit/fixtures/CCLW.document.i00000287.n0000.json
+++ b/tests/unit/fixtures/CCLW.document.i00000287.n0000.json
@@ -18,7 +18,11 @@
       "title": "Published",
       "date": "2019-12-25",
       "type": "Passed/Approved",
-      "status": "OK"
+      "status": "OK",
+      "valid_metadata": {
+        "event_type": ["Passed/Approved"],
+        "datetime_event_name": ["Passed/Approved"]
+      }
     }
   ]
 }

--- a/tests/unit/fixtures/CCLW.document.i00000290.n0000.json
+++ b/tests/unit/fixtures/CCLW.document.i00000290.n0000.json
@@ -18,7 +18,11 @@
       "title": "Published",
       "date": "2019-12-25",
       "type": "Passed/Approved",
-      "status": "OK"
+      "status": "OK",
+      "valid_metadata": {
+        "event_type": ["Passed/Approved"],
+        "datetime_event_name": ["Passed/Approved"]
+      }
     }
   ]
 }

--- a/tests/unit/fixtures/CCLW.document.i00000291.n0000.json
+++ b/tests/unit/fixtures/CCLW.document.i00000291.n0000.json
@@ -18,7 +18,11 @@
       "title": "Published",
       "date": "2019-12-25",
       "type": "Passed/Approved",
-      "status": "OK"
+      "status": "OK",
+      "valid_metadata": {
+        "event_type": ["Passed/Approved"],
+        "datetime_event_name": ["Passed/Approved"]
+      }
     }
   ]
 }

--- a/tests/unit/fixtures/CCLW.document.i00000298.n0000.json
+++ b/tests/unit/fixtures/CCLW.document.i00000298.n0000.json
@@ -18,7 +18,11 @@
       "title": "Published",
       "date": "2019-12-25",
       "type": "Passed/Approved",
-      "status": "OK"
+      "status": "OK",
+      "valid_metadata": {
+        "event_type": ["Passed/Approved"],
+        "datetime_event_name": ["Passed/Approved"]
+      }
     }
   ]
 }

--- a/tests/unit/fixtures/CCLW.document.i00000305.n0000.json
+++ b/tests/unit/fixtures/CCLW.document.i00000305.n0000.json
@@ -18,7 +18,11 @@
       "title": "Published",
       "date": "2019-12-25",
       "type": "Passed/Approved",
-      "status": "OK"
+      "status": "OK",
+      "valid_metadata": {
+        "event_type": ["Passed/Approved"],
+        "datetime_event_name": ["Passed/Approved"]
+      }
     }
   ]
 }


### PR DESCRIPTION
# Description
- bump db_client to latest (3.9.10 -> 3.9.12)

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Refactor legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
