### PR TITLE
Remove references to dev server

### DIFF
--- a/docs/custom_apps.md
+++ b/docs/custom_apps.md
@@ -29,7 +29,7 @@ want to generate the token for.
 export TOKEN_SECRET_KEY=secret_key
 export CORPORA_IDS=CCLW.corpus.i00000001.n0000,UNFCCC.corpus.i00000001.n0000
 export THEME=CPR
-export AUDIENCE=app.dev.climatepolicyradar.org
+export AUDIENCE=cpr.staging.climatepolicyradar.org
 poetry shell
 python -c "from app import config; from app.service.custom_app import AppTokenFactory; t = AppTokenFactory(); print(t.create_configuration_token('$CORPORA_IDS;$THEME;$AUDIENCE'))"
 ```

--- a/tests/non_search/routers/lookups/test_cors.py
+++ b/tests/non_search/routers/lookups/test_cors.py
@@ -7,8 +7,8 @@ import pytest
     [
         ("http://localhost:3000", True),  # local testing
         ("https://app.climatepolicyradar.org", True),  # main app URL
-        ("https://app.dev.climatepolicyradar.org", True),  # main staging URL
-        ("https://random.dev.climatepolicyradar.org", True),  # main staging URL
+        ("https://app.staging.climatepolicyradar.org", True),  # main staging URL
+        ("https://random.staging.climatepolicyradar.org", True),  # main staging URL
         ("https://some.sandbox.climatepolicyradar.org", True),  # sandbox test
         ("https://some-other.sandbox.climatepolicyradar.org", True),  # sandbox test
         ("https://climate-laws.org", True),  # base climate laws URL
@@ -16,7 +16,7 @@ import pytest
         ("http://app.climatepolicyradar.org", False),  # bad scheme
         ("https://.climatepolicyradar.org", False),  # empty subdomain
         ("https://app.climatepolicyradar.com", False),  # wrong domain
-        ("https://app.devclimatepolicyradar.com", False),  # prefixed wrong domain
+        ("https://app.stagingclimatepolicyradar.com", False),  # prefixed wrong domain
         ("https://app-climatepolicyradar.com", False),  # prefixed wrong domain
         ("https://prefix-climate-laws.org", False),  # climate laws prefixed domain
         ("https://.climateprojectexplorer.org", False),  # empty subdomain


### PR DESCRIPTION
# Description

Remove references to `dev` server as we now have `staging`

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [x] Skip auto-tagging
- [ ] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Refactor legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
