### PR TITLE
fix: make bucket stack specific for deploy permissions

### DIFF
--- a/api/infra/__main__.py
+++ b/api/infra/__main__.py
@@ -236,13 +236,13 @@ navigator_backend_github_actions_deploy = aws.iam.Role(
                         {
                             "Action": ["s3:ListBucket"],
                             "Effect": "Allow",
-                            "Resource": "arn:aws:s3:::cpr-staging-document-cache",
+                            "Resource": "arn:aws:s3:::cpr-{stack}-document-cache",
                             "Condition": {"StringLike": {"s3:prefix": ["concepts/*"]}},
                         },
                         {
                             "Action": ["s3:GetObject"],
                             "Effect": "Allow",
-                            "Resource": "arn:aws:s3:::cpr-staging-document-cache/concepts/*",
+                            "Resource": "arn:aws:s3:::cpr-{stack}-document-cache/concepts/*",
                         },
                     ],
                 }


### PR DESCRIPTION
# Description

Makes concepts deployable to `production`


## Proposed version


- [x] Skip auto-tagging
