### PR TITLE
refactor: update geo infra to allow us to push documents to s3 bucket

### DIFF
--- a/geographies-api/Dockerfile
+++ b/geographies-api/Dockerfile
@@ -19,5 +19,5 @@ RUN pip install --no-cache-dir --upgrade -r /app/requirements.txt
 
 COPY ./ /app/
 
-
+# @related: PORT_NUMBER
 CMD ["fastapi", "run", "./app/main.py", "--port", "8080", "--host", "0.0.0.0"]

--- a/geographies-api/docker-compose.yml
+++ b/geographies-api/docker-compose.yml
@@ -5,11 +5,11 @@ services:
       context: .
       dockerfile: Dockerfile
     ports:
-      - 8080:8080
+      - 8080:8080 # @related: PORT_NUMBER
     volumes:
       - .:/app
     working_dir: /app
-    command: [fastapi, dev, app/main.py, --port, "8080", --host, 0.0.0.0]
+    command: [fastapi, dev, app/main.py, --port, "8080", --host, 0.0.0.0] # @related: PORT_NUMBER
 
 volumes:
   navigator_postgres_data: {}

--- a/geographies-api/infra/Pulumi.production.yaml
+++ b/geographies-api/infra/Pulumi.production.yaml
@@ -1,2 +1,3 @@
 config:
   aws:region: eu-west-1
+  geographies-api:geographies_bucket: cpr-production-document-cache

--- a/geographies-api/infra/Pulumi.staging.yaml
+++ b/geographies-api/infra/Pulumi.staging.yaml
@@ -1,2 +1,3 @@
 config:
   aws:region: eu-west-1
+  geographies-api:geographies_bucket: cpr-staging-document-cache

--- a/geographies-api/infra/__main__.py
+++ b/geographies-api/infra/__main__.py
@@ -11,6 +11,9 @@ def generate_secret_key(project: str, aws_service: str, name: str):
     return f"/{project}/{aws_service}/{name}"
 
 
+config = pulumi.Config()
+
+
 # This stuff is being encapsulated in navigator-infra and we should use that once it is ready
 # IAM role trusted by App Runner
 geographies_api_role = aws.iam.Role(
@@ -132,7 +135,12 @@ geographies_api_apprunner_service = aws.apprunner.Service(
             "access_role_arn": geographies_api_role.arn,
         },
         "image_repository": {
-            "image_configuration": {},
+            "image_configuration": aws.apprunner.ServiceSourceConfigurationImageRepositoryImageConfigurationArgs(
+                port="8080",  # @related: PORT_NUMBER
+                runtime_environment_variables={
+                    "GEOGRAPHIES_BUCKET": config.require("geographies_bucket")
+                },
+            ),
             "image_identifier": f"{account_id}.dkr.ecr.eu-west-1.amazonaws.com/geographies-api:latest",
             "image_repository_type": "ECR",
         },


### PR DESCRIPTION
- we have decided to spike using a cdn to store the geographies data in an s3 bucket, as such we are updating the infrastructure code to allow us to do so whilst we are spiking

# Description

Please include:

- a summary of the changes
- links to any related issue/ticket
- any additional relevant motivation and context
- details of any dependency updates that are required for this change

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [x] Skip auto-tagging
- [ ] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Refactor legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
