### PR TITLE
chore: remove deprecated reviewers field from dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,6 @@ updates:
       interval: monthly
     ignore:
       - dependency-name: cpr_sdk
-    reviewers:
-      - climatepolicyradar/software
     groups:
       all:
         applies-to: version-updates
@@ -17,8 +15,6 @@ updates:
     directory: /
     schedule:
       interval: monthly
-    reviewers:
-      - climatepolicyradar/software
     groups:
       all:
         applies-to: version-updates
@@ -30,6 +26,4 @@ updates:
       interval: daily
     allow:
       - dependency-name: cpr_sdk
-    reviewers:
-      - climatepolicyradar/deng
     target-branch: main


### PR DESCRIPTION
The reviewers field in dependabot.yml is being deprecated and will be removed soon. Use CODEOWNERS file instead for specifying reviewers for Dependabot PRs.

This repository already has a CODEOWNERS file in place with the appropriate reviewers.

Reference: https://github.blog/changelog/2024-02-01-dependabot-will-no-longer-automatically-request-reviews-from-the-reviewers-and-team-reviewers-specified-in-the-dependabot-yml-file/