### PR TITLE
Add concepts to family

### DIFF
--- a/families-api/app/main.py
+++ b/families-api/app/main.py
@@ -321,7 +321,3 @@ def health_check():
 
 
 app.include_router(router)
-
-
-
-

--- a/families-api/app/main.py
+++ b/families-api/app/main.py
@@ -28,7 +28,7 @@ class Corpus(SQLModel, table=True):
         back_populates="corpus", link_model=FamilyCorpusLink
     )
     organisation: Organisation = Relationship(back_populates="corpora")
-    organisation_id: str = Field(foreign_key="organisation.id")
+    organisation_id: int = Field(foreign_key="organisation.id")
 
 
 class FamilyGeographyLink(SQLModel, table=True):

--- a/families-api/app/main.py
+++ b/families-api/app/main.py
@@ -1,10 +1,11 @@
-from typing import Generic, Optional, TypeVar
+from typing import Any, Generic, Optional, TypeVar
 
 from fastapi import APIRouter, Depends, FastAPI, HTTPException
 from pydantic import BaseModel, computed_field
 from pydantic_settings import BaseSettings
 from sqlalchemy import create_engine
 from sqlalchemy.dialects.postgresql import ARRAY, JSONB
+from sqlalchemy.orm import validates
 from sqlmodel import Column, Field, Relationship, Session, SQLModel, func, select
 
 
@@ -78,7 +79,7 @@ class FamilyBase(SQLModel):
     import_id: str = Field(primary_key=True)
     title: str
     description: str
-    concepts: list[Concept]
+    concepts: list[dict[str, Any]]
 
 
 class Family(FamilyBase, table=True):
@@ -90,7 +91,7 @@ class Family(FamilyBase, table=True):
         back_populates="families", link_model=FamilyCorpusLink
     )
     family_documents: list["FamilyDocument"] = Relationship(back_populates="family")
-    concepts: list[Concept] = Field(
+    concepts: list[dict[str, Any]] = Field(
         default_factory=list, sa_column=Column(ARRAY(JSONB))
     )
 
@@ -255,8 +256,6 @@ class FamilyPublic(FamilyBase):
     def summary(self) -> str:
         return self.description
 
-    concepts: list[Concept]
-
 
 @router.get("/{family_id}", response_model=APIItemResponse[FamilyPublic])
 def read_family(*, session: Session = Depends(get_session), family_id: str):
@@ -330,3 +329,15 @@ def health_check():
 
 
 app.include_router(router)
+
+
+
+
+
+
+
+
+
+
+
+

--- a/families-api/app/main.py
+++ b/families-api/app/main.py
@@ -1,7 +1,7 @@
 from typing import Any, Generic, Optional, TypeVar
 
 from fastapi import APIRouter, Depends, FastAPI, HTTPException
-from pydantic import BaseModel, computed_field, field_serializer
+from pydantic import BaseModel, computed_field
 from pydantic_settings import BaseSettings
 from sqlalchemy import create_engine
 from sqlalchemy.dialects.postgresql import ARRAY, JSONB
@@ -29,7 +29,7 @@ class Corpus(SQLModel, table=True):
         back_populates="corpus", link_model=FamilyCorpusLink
     )
     organisation: Organisation = Relationship(back_populates="corpora")
-    organisation_id: str = Field(foreign_key="organisation.id")
+    organisation_id: int = Field(foreign_key="organisation.id")
 
 
 class FamilyGeographyLink(SQLModel, table=True):
@@ -64,14 +64,6 @@ class Geography(GeographyBase, table=True):
     families: list["Family"] = Relationship(
         back_populates="geographies", link_model=FamilyGeographyLink
     )
-
-
-class Concept(BaseModel):
-    id: str
-    ids: list[str]
-    type: str
-    relation: str
-    preferred_label: str
 
 
 class FamilyBase(SQLModel):
@@ -329,4 +321,7 @@ def health_check():
 
 
 app.include_router(router)
+
+
+
 

--- a/families-api/app/main.py
+++ b/families-api/app/main.py
@@ -1,7 +1,7 @@
 from typing import Generic, Optional, TypeVar
 
 from fastapi import APIRouter, Depends, FastAPI, HTTPException
-from pydantic import BaseModel, computed_field, field_serializer
+from pydantic import BaseModel, computed_field
 from pydantic_settings import BaseSettings
 from sqlalchemy import create_engine
 from sqlmodel import Field, Relationship, Session, SQLModel, func, select

--- a/families-api/app/main.py
+++ b/families-api/app/main.py
@@ -1,7 +1,7 @@
 from typing import Any, Generic, Optional, TypeVar
 
 from fastapi import APIRouter, Depends, FastAPI, HTTPException
-from pydantic import BaseModel, computed_field
+from pydantic import BaseModel, computed_field, field_serializer
 from pydantic_settings import BaseSettings
 from sqlalchemy import create_engine
 from sqlalchemy.dialects.postgresql import ARRAY, JSONB
@@ -37,7 +37,7 @@ class Corpus(SQLModel, table=True):
         back_populates="corpus", link_model=FamilyCorpusLink
     )
     organisation: Organisation = Relationship(back_populates="corpora")
-    organisation_id: int = Field(foreign_key="organisation.id")
+    organisation_id: str = Field(foreign_key="organisation.id")
 
 
 class FamilyGeographyLink(SQLModel, table=True):

--- a/families-api/app/main.py
+++ b/families-api/app/main.py
@@ -15,13 +15,6 @@ class Organisation(SQLModel, table=True):
     corpora: list["Corpus"] = Relationship(back_populates="organisation")
 
 
-class Organisation(SQLModel, table=True):
-    __tablename__ = "organisation"  # type: ignore[assignment]
-    id: str = Field(primary_key=True)
-    name: str
-    corpora: list["Corpus"] = Relationship(back_populates="organisation")
-
-
 class FamilyCorpusLink(SQLModel, table=True):
     __tablename__ = "family_corpus"  # type: ignore[assignment]
     corpus_import_id: str = Field(foreign_key="corpus.import_id", primary_key=True)
@@ -336,3 +329,4 @@ def health_check():
 
 
 app.include_router(router)
+

--- a/families-api/app/main.py
+++ b/families-api/app/main.py
@@ -5,7 +5,6 @@ from pydantic import BaseModel, computed_field, field_serializer
 from pydantic_settings import BaseSettings
 from sqlalchemy import create_engine
 from sqlalchemy.dialects.postgresql import ARRAY, JSONB
-from sqlalchemy.orm import validates
 from sqlmodel import Column, Field, Relationship, Session, SQLModel, func, select
 
 
@@ -337,15 +336,3 @@ def health_check():
 
 
 app.include_router(router)
-
-
-
-
-
-
-
-
-
-
-
-

--- a/families-api/app/test_main.py
+++ b/families-api/app/test_main.py
@@ -6,7 +6,6 @@ from sqlmodel import Session, SQLModel
 
 from .main import (
     APIItemResponse,
-    Concept,
     Corpus,
     Family,
     FamilyPublic,

--- a/families-api/app/test_main.py
+++ b/families-api/app/test_main.py
@@ -73,20 +73,20 @@ def test_read_family_200(client: TestClient, session: Session):
         description="Test family",
         corpus=corpus,
         concepts=[
-            Concept(
-                id="test concepts 1",
-                ids=[],
-                type="legal_entity",
-                relation="jurisdiction",
-                preferred_label="test concept 1",
-            ),
-            Concept(
-                id="test concepts 2",
-                ids=[],
-                type="legal_entity",
-                relation="jurisdiction",
-                preferred_label="test concept 2",
-            ),
+            {
+                "id": "test concepts 1",
+                "ids": [],
+                "type": "legal_entity",
+                "relation": "jurisdiction",
+                "preferred_label": "test concept 1",
+            },
+            {
+                "id": "test concepts 2",
+                "ids": [],
+                "type": "legal_entity",
+                "relation": "jurisdiction",
+                "preferred_label": "test concept 2",
+            },
         ],
     )
     session.add(corpus)

--- a/families-api/app/test_main.py
+++ b/families-api/app/test_main.py
@@ -6,6 +6,7 @@ from sqlmodel import Session, SQLModel
 
 from .main import (
     APIItemResponse,
+    Concept,
     Corpus,
     Family,
     FamilyPublic,
@@ -59,7 +60,7 @@ def test_read_family_404(client: TestClient):
 
 
 def test_read_family_200(client: TestClient, session: Session):
-    organisation = Organisation(id="org_1", name="Test Org")
+    organisation = Organisation(id=123, name="Test Org")
     corpus = Corpus(
         import_id="corpus_1",
         title="Test Corpus",
@@ -71,6 +72,22 @@ def test_read_family_200(client: TestClient, session: Session):
         import_id="family_123",
         description="Test family",
         corpus=corpus,
+        concepts=[
+            Concept(
+                id="test concepts 1",
+                ids=[],
+                type="legal_entity",
+                relation="jurisdiction",
+                preferred_label="test concept 1",
+            ),
+            Concept(
+                id="test concepts 2",
+                ids=[],
+                type="legal_entity",
+                relation="jurisdiction",
+                preferred_label="test concept 2",
+            ),
+        ],
     )
     session.add(corpus)
     session.add(family)

--- a/families-api/app/test_main.py
+++ b/families-api/app/test_main.py
@@ -9,6 +9,7 @@ from .main import (
     Corpus,
     Family,
     FamilyPublic,
+    Organisation,
     app,
     get_session,
     settings,
@@ -58,8 +59,19 @@ def test_read_family_404(client: TestClient):
 
 
 def test_read_family_200(client: TestClient, session: Session):
-    corpus = Corpus(import_id="corpus_1", title="Test Corpus")
-    family = Family(import_id="family_123", description="Test family", corpus=corpus)
+    organisation = Organisation(id="org_1", name="Test Org")
+    corpus = Corpus(
+        import_id="corpus_1",
+        title="Test Corpus",
+        organisation=organisation,
+        organisation_id=organisation.id,
+    )
+    family = Family(
+        title="Test family",
+        import_id="family_123",
+        description="Test family",
+        corpus=corpus,
+    )
     session.add(corpus)
     session.add(family)
     session.commit()


### PR DESCRIPTION
# Description

- fetches and renders concepts in the response

Test case is caught via the 200 response test.

```json
{
  "data": {
    "import_id": "Sabin.family.75886.0",
    "title": "Bowfin Keycon Holdings, LLC v. Pennsylvania Department of Environmental Protection",
    "description": "Challenge to Pennsylvania regulations implementing participation in the Regional Greenhouse Gas Initiative.",
    "concepts": [
      {
        "id": "Pa.",
        "ids": [],
        "type": "legal_entity",
        "relation": "jurisdiction",
        "preferred_label": "Pa.",
        "subconcept_of_labels": []
      }
    ],
    "corpus": {
      "organisation_id": 11,
      "import_id": "Academic.corpus.Litigation.n0000",
      "title": "Litigation"
    },
    "organisation": "Sabin",
    "summary": "Challenge to Pennsylvania regulations implementing participation in the Regional Greenhouse Gas Initiative."
  }
}
```

## Proposed version

- [x] Skip auto-tagging
