### PR TITLE
refactor: pass aws variables to container when running locally

### DIFF
--- a/geographies-api/docker-compose.yml
+++ b/geographies-api/docker-compose.yml
@@ -6,8 +6,16 @@ services:
       dockerfile: Dockerfile
     ports:
       - 8080:8080 # @related: PORT_NUMBER
+    environment:
+      - AWS_PROFILE=${AWS_PROFILE:-staging}
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+      - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN}
+      - AWS_REGION=${AWS_REGION:-us-west-1}
+      - CDN_URL=${CDN_URL:-https://cdn.dev.climatepolicyradar.org}
     volumes:
       - .:/app
+      - ~/.aws:/root/.aws:ro
     working_dir: /app
     command: [fastapi, dev, app/main.py, --port, "8080", --host, 0.0.0.0] # @related: PORT_NUMBER
 


### PR DESCRIPTION
# Description

Please include:

Set up local containers for local development by passing aws variables to the container on startup.

This means that to access the variables you would need to run your various aws commands and export the profile. 


## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Refactor legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
