### PR TITLE
fix: return document.language as a string

### DIFF
--- a/families-api/app/main.py
+++ b/families-api/app/main.py
@@ -283,7 +283,11 @@ class FamilyPublic(FamilyBase):
                 "cdn_object": document.physical_document.cdn_object,
                 "source_url": document.physical_document.source_url,
                 "content_type": document.physical_document.content_type,
-                "language": document.physical_document.unparsed_languages[0],
+                "language": (
+                    document.physical_document.unparsed_languages[0].language_code
+                    if document.physical_document.unparsed_languages
+                    else None
+                ),
                 "languages": [
                     language.language_code
                     for language in document.physical_document.unparsed_languages
@@ -597,3 +601,4 @@ def health_check():
 
 
 app.include_router(router)
+


### PR DESCRIPTION
# Description

[As per the FE type - language should be a `string`](https://github.com/climatepolicyradar/navigator-frontend/blob/main/src/types/types.ts#L197).

<img width="789" alt="Screenshot 2025-06-23 at 09 39 39" src="https://github.com/user-attachments/assets/aa4605c2-496d-4ed5-a7d2-36529e5c1462" />


