### PR TITLE
feat: add slack for a github deploy

### DIFF
--- a/.github/workflows/merge-to-main.yml
+++ b/.github/workflows/merge-to-main.yml
@@ -74,6 +74,8 @@ jobs:
         service: [families-api, geographies-api, concepts-api]
         environment: [staging, production]
     environment: ${{ matrix.environment }}
+    env:
+      SERVICES: "families-api geographies-api concepts-api"
     steps:
       - uses: actions/checkout@v4
       - uses: extractions/setup-just@v3
@@ -91,5 +93,7 @@ jobs:
       - working-directory: ${{ matrix.service }}
         run: uv sync
       - run: |
-          just deploy ${{ matrix.service }} ${{ matrix.environment }} latest
-          just deploy ${{ matrix.service }} ${{ matrix.environment }} ${{ github.sha }}
+          for service in $SERVICES; do
+            just deploy $service ${{ matrix.environment }} latest
+            just deploy $service ${{ matrix.environment }} ${{ github.sha }}
+          done

--- a/.github/workflows/send-slack-message-on-deploy.yml
+++ b/.github/workflows/send-slack-message-on-deploy.yml
@@ -1,0 +1,33 @@
+name: Send slack message on deployment
+on: deployment
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  send-slack-message-staging-updates:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # we can't use the github.event.deployment.environment directly in the environment property
+      # so we need to switch on this case to get the secret.
+      - id: webhook_url
+        run: |
+          if [ "${{ github.event.deployment.environment }}" = "staging" ]; then
+            echo "webhook_url=${{ secrets.SLACK_WEBHOOK_URL_STAGING_UPDATES_CHANNEL }}" >> $GITHUB_OUTPUT
+          elif [ "${{ github.event.deployment.environment }}" = "production" ]; then
+            echo "webhook_url=${{ secrets.SLACK_WEBHOOK_URL_PRODUCTION_UPDATES_CHANNEL }}" >> $GITHUB_OUTPUT
+          fi
+      - id: pr_number
+        run: |
+          PR_NUMBER=$(gh pr list --search "$(git rev-parse HEAD)" --state all --json number -q '.[0].number')
+          echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: slackapi/slack-github-action@v2.1.0
+        with:
+          webhook: ${{ steps.webhook_url.outputs.webhook_url }}
+          webhook-type: incoming-webhook
+          payload: |
+            text: "🚀 Deploying ${{ github.repository }} to ${{ github.event.deployment.environment }}\n• *PR*: https://github.com/${{ github.repository }}/pull/${{ steps.pr_number.outputs.pr_number }}"


### PR DESCRIPTION
# Description
- adds a new slack message on deploy to add more context of what's being deployed
- moves the service matrix to an env variable to avoid multiple deploys being triggered per service

This is a replica of [this](https://github.com/climatepolicyradar/navigator-frontend/pull/605) as I want to try out if it give us what we want i.e. more context, with no extra noise.