### PR TITLE
fix: allow ORIGIN header as part of the cache key

### DIFF
--- a/api/infra/__main__.py
+++ b/api/infra/__main__.py
@@ -64,7 +64,8 @@ api_cache_policy = aws.cloudfront.CachePolicy(
             "cookie_behavior": "none",
         },
         "headers_config": {
-            "header_behavior": "none",
+            "header_behavior": "whitelist",
+            "headers": {"items": ["Origin"]},
         },
         "query_strings_config": {
             "query_string_behavior": "all",


### PR DESCRIPTION
# Description
- Allows the `ORIGIN` header to act as part of the cache key

this is because the endpoint if being cached with the `access-control-allow-origin` value of whatever app hits it first.

e.g.

- cpr app hits options endpoint
- endpoint is cached with `access-control-allow-origin: cpr.climatepolicyradar.org`
- cclw hits it
- cache returns `access-control-allow-origin: cpr.climatepolicyradar.org`
- does not work

This allows the cache to VARY on ORIGIN.

This does mean all we vary on all ORIGN requests which then hit origin, which is not great - [tech debt tracked here](https://linear.app/climate-policy-radar/issue/APP-805/find-a-way-to-cache-options-method-on-apienv).

Fixes https://linear.app/climate-policy-radar/issue/APP-807/cors-issues-on-cclwmcf-when-hitting-new-microservice-endpoints