### PR TITLE
fix: remove variable expansion from docker CMD in families-api

### DIFF
--- a/families-api/Dockerfile
+++ b/families-api/Dockerfile
@@ -30,4 +30,4 @@ COPY ./api /app/api/
 WORKDIR /app
 RUN uv sync --project $SERVICE
 
-CMD ["uv", "run", "fastapi", "run", "./$SERVICE/app/main.py", "--port", "8080", "--host", "0.0.0.0"]
+CMD ["uv", "run", "fastapi", "run", "./families-api/app/main.py", "--port", "8080", "--host", "0.0.0.0"]


### PR DESCRIPTION
# Description
- variable expansion does not work on the `CMD`, so we hardcode the value

---

> Variable expansion is only supported for [a limited set of Dockerfile instructions.](https://docs.docker.com/reference/dockerfile/#environment-replacement)

-- [Docker docs](https://docs.docker.com/reference/dockerfile/#using-arg-variables)

---

This was spotted in the logs

> `Path does not exist $SERVICE/app/main.py`

I'll look at removing this all together, but [it's being used by the `just deploy` recipe](https://github.com/climatepolicyradar/navigator-backend/blob/main/justfile#L17), so I will do it as the larger migration piece.

This gets `family-api` deploy working for now.

## 🧪 

This has been tested and working on `staging`