### PR TITLE
fix: using ENV to create_duckdb for classifiers_spec file

### DIFF
--- a/concepts-api/create_duckdb.py
+++ b/concepts-api/create_duckdb.py
@@ -21,7 +21,7 @@ def fetch_classifier_specs_file() -> str:
     branch = "main"
 
     classifier_file_name = "prod.yaml"
-    if os.getenv("Environment") == "staging":
+    if os.getenv("ENV") == "staging":
         classifier_file_name = "staging.yaml"
 
     path = f"flows/classifier_specs/{classifier_file_name}"

--- a/concepts-api/justfile
+++ b/concepts-api/justfile
@@ -6,7 +6,8 @@ bootstrap:
 initial-data environment:
     @echo "🔄 downloading latest data from s3"
     aws s3 sync s3://cpr-{{environment}}-document-cache/concepts initial-data
-    uv run python create_duckdb.py
+    # ENV is used in create_duckdb to calculate which classifier_spec file to use
+    ENV={{environment}} uv run python create_duckdb.py
 
 dev:
     uv sync


### PR DESCRIPTION
# Description

Uses `ENV` to calculate which [classifiers_spec](https://github.com/climatepolicyradar/knowledge-graph/tree/main/flows/classifier_specs) file to use.

[This is based on env var we use for oTel](https://github.com/climatepolicyradar/navigator-backend/blob/dfd32c2da4157cf8e61341a22d781d688f7bd14f/concepts-api/app/main.py#L24)

Fixes https://linear.app/climate-policy-radar/issue/APP-617/use-correct-env-file-from-concepts-store-to-get-concepts-with