### PR TITLE
fix: move completely to python 3.12

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -64,7 +64,7 @@ jobs:
         run: cp .env.example .env
 
       - name: Get python Container
-        run: docker pull python:3.11
+        run: docker pull python:3.12
 
       - name: Build
         run: |
@@ -106,7 +106,7 @@ jobs:
         run: cp .env.example .env
 
       - name: Get python Container
-        run: docker pull python:3.11
+        run: docker pull python:3.12
 
       - name: Install latest Vespa CLI
         env:

--- a/backend-api/uv.lock
+++ b/backend-api/uv.lock
@@ -232,7 +232,6 @@ dependencies = [
 dev = [
     { name = "black" },
     { name = "moto", extra = ["s3"] },
-    { name = "psycopg2-binary" },
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -286,7 +285,6 @@ requires-dist = [
 dev = [
     { name = "black", specifier = ">=25.1.0" },
     { name = "moto", extras = ["s3"], specifier = ">=5.1.6" },
-    { name = "psycopg2-binary", specifier = ">=2.9.10" },
     { name = "pyright", specifier = "==1.1.361" },
     { name = "pytest", specifier = ">=8.4.0" },
     { name = "pytest-asyncio", specifier = ">=1.0.0" },

--- a/concepts-api/README.md
+++ b/concepts-api/README.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- Python 3.11 or higher
+- Python 3.12 or higher
 - uv (Python package manager)
 - Docker and Docker Compose
 - AWS CLI configured with appropriate credentials


### PR DESCRIPTION
# Description

- upgrade fully to python 3.12

We might want to investigate using [`.python-version`](https://docs.astral.sh/uv/concepts/python-versions/#python-version-files) - but don't want to create more work for myself.

Fixes https://linear.app/climate-policy-radar/issue/APP-594/update-python-version-in-nav-back