### PR TITLE
Use pulumi library to define infra

### DIFF
--- a/concepts-api/infra/__main__.py
+++ b/concepts-api/infra/__main__.py
@@ -1,5 +1,3 @@
-import json
-
 import pulumi
 import pulumi_aws as aws
 
@@ -15,91 +13,89 @@ def generate_secret_key(project: str, aws_service: str, name: str):
 # IAM role trusted by App Runner
 concepts_api_role = aws.iam.Role(
     "concepts-api-role",
-    assume_role_policy=json.dumps(
-        {
-            "Version": "2012-10-17",
-            "Statement": [
-                {
-                    "Effect": "Allow",
-                    "Principal": {"Service": "build.apprunner.amazonaws.com"},
-                    "Action": "sts:AssumeRole",
-                }
-            ],
-        }
-    ),
+    assume_role_policy=aws.iam.get_policy_document(
+        statements=[
+            aws.iam.GetPolicyDocumentStatementArgs(
+                effect="Allow",
+                principals=[
+                    aws.iam.GetPolicyDocumentStatementPrincipalArgs(
+                        type="Service",
+                        identifiers=["build.apprunner.amazonaws.com"],
+                    )
+                ],
+                actions=["sts:AssumeRole"],
+            )
+        ]
+    ).json,
 )
 
 # Attach ECR access policy to the role
 concepts_api_role_policy = aws.iam.RolePolicy(
     "concepts-api-role-ecr-policy",
     role=concepts_api_role.id,
-    policy=json.dumps(
-        {
-            "Version": "2012-10-17",
-            "Statement": [
-                {
-                    "Effect": "Allow",
-                    "Action": [
-                        "ecr:GetDownloadUrlForLayer",
-                        "ecr:BatchGetImage",
-                        "ecr:DescribeImages",
-                        "ecr:GetAuthorizationToken",
-                        "ecr:BatchCheckLayerAvailability",
-                    ],
-                    "Resource": "*",
-                }
-            ],
-        }
-    ),
+    policy=aws.iam.get_policy_document(
+        statements=[
+            aws.iam.GetPolicyDocumentStatementArgs(
+                effect="Allow",
+                actions=[
+                    "ecr:GetDownloadUrlForLayer",
+                    "ecr:BatchGetImage",
+                    "ecr:DescribeImages",
+                    "ecr:GetAuthorizationToken",
+                    "ecr:BatchCheckLayerAvailability",
+                ],
+                resources=["*"],
+            )
+        ]
+    ).json,
 )
 
 concepts_api_instance_role = aws.iam.Role(
     "concepts-api-instance-role",
-    assume_role_policy=json.dumps(
-        {
-            "Version": "2012-10-17",
-            "Statement": [
-                {
-                    "Effect": "Allow",
-                    "Principal": {"Service": "tasks.apprunner.amazonaws.com"},
-                    "Action": "sts:AssumeRole",
-                }
-            ],
-        }
-    ),
+    assume_role_policy=aws.iam.get_policy_document(
+        statements=[
+            aws.iam.GetPolicyDocumentStatementArgs(
+                effect="Allow",
+                principals=[
+                    aws.iam.GetPolicyDocumentStatementPrincipalArgs(
+                        type="Service",
+                        identifiers=["tasks.apprunner.amazonaws.com"],
+                    )
+                ],
+                actions=["sts:AssumeRole"],
+            )
+        ]
+    ).json,
 )
 
 # Allow access to specific SSM Parameter Store secrets
 concepts_api_ssm_policy = aws.iam.RolePolicy(
     "concepts-api-instance-role-ssm-policy",
     role=concepts_api_instance_role.id,
-    policy=json.dumps(
-        {
-            "Version": "2012-10-17",
-            "Statement": [
-                {
-                    "Effect": "Allow",
-                    "Action": ["ssm:GetParameters"],
-                    "Resource": [
-                        f"arn:aws:ssm:eu-west-1:{account_id}:parameter/concepts-api/apprunner/*"
-                    ],
-                }
-            ],
-        }
-    ),
+    policy=aws.iam.get_policy_document(
+        statements=[
+            aws.iam.GetPolicyDocumentStatementArgs(
+                effect="Allow",
+                actions=["ssm:GetParameters"],
+                resources=[
+                    f"arn:aws:ssm:eu-west-1:{account_id}:parameter/concepts-api/apprunner/*"
+                ],
+            )
+        ]
+    ).json,
 )
 
 
 concepts_api_ecr_repository = aws.ecr.Repository(
     "concepts-api-ecr-repository",
     encryption_configurations=[
-        {
-            "encryption_type": "AES256",
-        }
+        aws.ecr.RepositoryEncryptionConfigurationArgs(
+            encryption_type="AES256",
+        )
     ],
-    image_scanning_configuration={
-        "scan_on_push": False,
-    },
+    image_scanning_configuration=aws.ecr.RepositoryImageScanningConfigurationArgs(
+        scan_on_push=False,
+    ),
     image_tag_mutability="MUTABLE",
     name="concepts-api",
     opts=pulumi.ResourceOptions(protect=True),
@@ -109,37 +105,37 @@ concepts_api_ecr_repository = aws.ecr.Repository(
 concepts_api_apprunner_service = aws.apprunner.Service(
     "concepts-api-apprunner-service",
     auto_scaling_configuration_arn=f"arn:aws:apprunner:eu-west-1:{account_id}:autoscalingconfiguration/DefaultConfiguration/1/00000000000000000000000000000001",
-    health_check_configuration={
-        "interval": 10,
-        "protocol": "TCP",
-        "timeout": 5,
-    },
-    instance_configuration={
-        "instance_role_arn": concepts_api_instance_role.arn,
-    },
-    network_configuration={
-        "ingress_configuration": {
-            "is_publicly_accessible": True,
-        },
-        "ip_address_type": "IPV4",
-    },
-    observability_configuration={
-        "observability_enabled": False,
-    },
+    health_check_configuration=aws.apprunner.ServiceHealthCheckConfigurationArgs(
+        interval=10,
+        protocol="TCP",
+        timeout=5,
+    ),
+    instance_configuration=aws.apprunner.ServiceInstanceConfigurationArgs(
+        instance_role_arn=concepts_api_instance_role.arn,
+    ),
+    network_configuration=aws.apprunner.ServiceNetworkConfigurationArgs(
+        ingress_configuration=aws.apprunner.ServiceNetworkConfigurationIngressConfigurationArgs(
+            is_publicly_accessible=True,
+        ),
+        ip_address_type="IPV4",
+    ),
+    observability_configuration=aws.apprunner.ServiceObservabilityConfigurationArgs(
+        observability_enabled=False,
+    ),
     service_name="concepts-api",
-    source_configuration={
-        "authentication_configuration": {
-            "access_role_arn": concepts_api_role.arn,
-        },
-        "image_repository": {
-            "image_configuration": aws.apprunner.ServiceSourceConfigurationImageRepositoryImageConfigurationArgs(
+    source_configuration=aws.apprunner.ServiceSourceConfigurationArgs(
+        authentication_configuration=aws.apprunner.ServiceSourceConfigurationAuthenticationConfigurationArgs(
+            access_role_arn=concepts_api_role.arn,
+        ),
+        image_repository=aws.apprunner.ServiceSourceConfigurationImageRepositoryArgs(
+            image_configuration=aws.apprunner.ServiceSourceConfigurationImageRepositoryImageConfigurationArgs(
                 port="8080",
                 runtime_environment_variables={"Environment": pulumi.get_stack()},
             ),
-            "image_identifier": f"{account_id}.dkr.ecr.eu-west-1.amazonaws.com/concepts-api:latest",
-            "image_repository_type": "ECR",
-        },
-    },
+            image_identifier=f"{account_id}.dkr.ecr.eu-west-1.amazonaws.com/concepts-api:latest",
+            image_repository_type="ECR",
+        ),
+    ),
     opts=pulumi.ResourceOptions(protect=True),
 )
 


### PR DESCRIPTION
# Description

Instead of using raw JSON to define the infrastructure in this repo, use the pulumi AWS library.

Why?
- Clearer parameter names and types instead of guessing JSON structure
- Self-documenting code with explicit parameter names
- Easier to refactor and maintain the infrastructure
- More type safe

I've validated by doing a pulumi up -r (to refresh) for each stack that this PR introduces no new changes and leaves the existing pulumi states unchanged.

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Refactor legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
