### PR TITLE
Update corpus families stat in config

### DIFF
--- a/backend-api/app/repository/corpus.py
+++ b/backend-api/app/repository/corpus.py
@@ -1,4 +1,4 @@
-from db_client.models.dfce.family import Corpus, Family, FamilyCorpus
+from db_client.models.dfce.family import Corpus, Family, FamilyCorpus, FamilyStatus
 from sqlalchemy import func
 from sqlalchemy.orm import Session
 
@@ -15,6 +15,7 @@ def get_total_families_per_corpus(db: Session, corpus_import_id: str) -> int:
         db.query(Family)
         .join(FamilyCorpus, FamilyCorpus.family_import_id == Family.import_id)
         .filter(FamilyCorpus.corpus_import_id == corpus_import_id)
+        .filter(Family.family_status == FamilyStatus.PUBLISHED)
         .count()
     )
 
@@ -31,6 +32,7 @@ def get_family_count_by_category_per_corpus(db: Session, corpus_import_id: str):
         db.query(Family.family_category, func.count())
         .join(FamilyCorpus, FamilyCorpus.family_import_id == Family.import_id)
         .filter(FamilyCorpus.corpus_import_id == corpus_import_id)
+        .filter(Family.family_status == FamilyStatus.PUBLISHED)
         .group_by(Family.family_category)
         .all()
     )


### PR DESCRIPTION
# Description

- Update the config endpoint to only calculate the number of **published** families in a corpus 

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Refactor legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
