### PR TITLE
fix: adds testing to root of project

### DIFF
--- a/concepts-api/docker-compose.yml
+++ b/concepts-api/docker-compose.yml
@@ -24,3 +24,13 @@ services:
         --host,
         0.0.0.0,
       ]
+  test:
+    profiles: [test]
+    container_name: concepts-api-test
+    build:
+      context: ..
+      dockerfile: concepts-api/Dockerfile
+    volumes:
+      - ..:/app
+    working_dir: /app
+    command: [echo, No tests]

--- a/concepts-api/justfile
+++ b/concepts-api/justfile
@@ -14,9 +14,6 @@ dev:
     just initial-data production
     docker compose up
 
-test:
-    @echo "😔 no tests yet"
-
 # You need to run this version if you have made changes to the requirements.txt file
 dev-rebuild:
     just initial-data production

--- a/families-api/app/main.py
+++ b/families-api/app/main.py
@@ -175,7 +175,7 @@ class Family(FamilyBase, table=True):
 
 class FamilyPublic(FamilyBase):
     import_id: str
-    corpus: Corpus = Field(exclude=True)
+    corpus: Corpus = Field()
     unparsed_geographies: list[Geography] = Field(default_factory=list, exclude=True)
     unparsed_slug: list[Slug] = Field(exclude=True, default=list())
     unparsed_metadata: Optional[FamilyMetadata] = Field(exclude=True, default=None)

--- a/families-api/justfile
+++ b/families-api/justfile
@@ -24,9 +24,6 @@ dev:
     uv sync
     docker compose --profile dev up
 
-test:
-    docker compose --profile test up --abort-on-container-exit --exit-code-from test
-
 # build
 # TODO: this needs to be tied into a lifecycle somewhere to make sure it is run if something is added
 requirements:

--- a/geographies-api/justfile
+++ b/geographies-api/justfile
@@ -26,9 +26,6 @@ dev:
     uv sync
     docker compose --profile dev up
 
-test:
-    docker compose --profile test up --abort-on-container-exit --exit-code-from test
-
 # build
 # TODO: this needs to be tied into a lifecycle somewhere to make sure it is run if something is added
 requirements:

--- a/justfile
+++ b/justfile
@@ -4,6 +4,10 @@ dev service environment="production":
     just _prebuild {{service}} {{environment}}
     docker compose -f {{service}}/docker-compose.yml --profile dev up --build
 
+# test
+test service:
+    docker compose -f {{service}}/docker-compose.yml --profile test up --abort-on-container-exit --exit-code-from test --remove-orphans
+
 # build/deploy
 build service environment tag:
     just _prebuild {{service}} {{environment}}


### PR DESCRIPTION
# Description

Moves the testing to the root of the project based on the patterns formed previously. e.g. using Docker test profiles to run the tests.

Needed to add this properly to CI:
https://github.com/climatepolicyradar/navigator-backend/pull/609