### PR TITLE
fix: add compose file to test against admin-backend

### DIFF
--- a/families-api/docker-compose-admin-backend.yml
+++ b/families-api/docker-compose-admin-backend.yml
@@ -1,0 +1,33 @@
+# This allows us to run the families API against the navigator-admin-backend DB
+# this is useful for things like e2e testing e.g.
+# litigation-data-mapper -- JSON --> bulk-import --> navigator-admin-backend --> families-api
+services:
+  app:
+    container_name: families-api-app
+    build:
+      context: ..
+      dockerfile: families-api/Dockerfile
+    ports:
+      - 8080:8080
+    volumes:
+      - ..:/app
+    working_dir: /app
+    environment:
+      # this is taken from
+      # @see: https://github.com/climatepolicyradar/navigator-admin-backend/blob/main/docker-compose-dev.yml#L47-L49
+      NAVIGATOR_DATABASE_URL: postgresql://navigator_admin:password@host.docker.internal:5432/navigator
+    # override the command with `fastapi **dev**`
+    command:
+      [
+        uv,
+        run,
+        --project,
+        families-api,
+        fastapi,
+        dev,
+        families-api/app/main.py,
+        --port,
+        "8080",
+        --host,
+        0.0.0.0,
+      ]


### PR DESCRIPTION
# Description

Adds a compose file that allows us to connect to the admin-backend DB. (Or any other).

There might be better ways to do this going forward, but it allows us to all have a way to e2e when testing `litigation-data-mapper -- JSON --> bulk-import --> navigator-admin-backend --> families-api`.

This helps the DevX as we want to get all our data woes sorted before running a full reindex.


## mini runbook

- navigator-admin-backend
  - `make dev`
  - add 👇 into the DB to be used by the bulk-import
  - `insert into APP_USER(email, name, hashed_password, is_superuser) values ('user@navigator.com', 'TestUser', '$2b$12$hvxOvIgoGs35GQY/53ULIuTzLFJJ7BVxeD8e.mBPktQwZ0NZwp9iq', true);`
  - `insert into organisation_admin values ('user@navigator.com', 1, 'Tester', true, true);`

- navigator-backend:
  - from root or repo  
  - `docker compose -f families-api/docker-compose-admin-backend.yml up`
    
- litigation-data-mapper
  - `uv run litigation_data_mapper_with_vcr`
  - ☝️ creates the `output.json`
- bulk-import
  - .env
    ```bash
    LOCAL_API_HOST="http://localhost:8888"
    LOCAL_SUPERUSER_EMAIL="user@navigator.com"
    LOCAL_SUPERUSER_PASSWORD="password"
    ```
  - `poetry run python -m app.bulk_import ../litigation-data-mapper/output.json "Academic.corpus.Litigation.n0000"`
  


## GOTCHAS

- the navigator-admin-backend-dev webbapp container sometimes shuts down as unhealthy. I have just restarted it in Docker Desktop.