### PR TITLE
feat: add subdivisions to geography filter query

### DIFF
--- a/backend-api/app/models/search.py
+++ b/backend-api/app/models/search.py
@@ -43,6 +43,7 @@ class FilterField(str, Enum):
     REGION = "regions"
     CATEGORY = "categories"
     LANGUAGE = "languages"
+    SUBDIVSION = "subdivisions"
 
 
 BackendFilterValues = Literal[

--- a/backend-api/app/repository/lookups.py
+++ b/backend-api/app/repository/lookups.py
@@ -72,6 +72,32 @@ def get_countries_by_iso_codes(
     ]
 
 
+def validate_subdivision_iso_codes(db: Session, geography_identifiers: Sequence[str]):
+    """
+    Validates subdivision ISO codes against the database.
+
+    Retrieves subdivisions from the database using the provided ISO codes.
+    Only returns subdivisions (geographies with parent_id).
+
+    :param Session db: Database session.
+    :param Sequence[str] geography_identifiers: Sequence of subdivision ISO codes.
+    :return list[str]: List of valid subdivision ISO codes.
+    """
+    if not geography_identifiers:
+        return []
+
+    slug_geographies = (
+        db.query(Geography)
+        .filter(
+            Geography.value.in_(list(geography_identifiers)),
+            Geography.parent_id.is_not(None),
+        )
+        .all()
+    )
+
+    return [geo.value for geo in slug_geographies]
+
+
 def get_geographies_as_iso_codes_with_fallback(
     db: Session,
     geography_identifiers: Sequence[str],

--- a/backend-api/app/service/search.py
+++ b/backend-api/app/service/search.py
@@ -377,6 +377,8 @@ def _convert_filters(
                 # TODO: remove this once frontend is updated to use ISO codes in favour of get_countries_by_iso_codes
                 get_geographies_as_iso_codes_with_fallback(db, values)
             )
+        elif field == FilterField.SUBDIVSION:
+            countries.append(get_geographies_as_iso_codes_with_fallback(db, values))
         else:
             new_values = values
             new_keyword_filters[new_field] = new_values

--- a/backend-api/app/service/search.py
+++ b/backend-api/app/service/search.py
@@ -50,7 +50,7 @@ from app.repository.lookups import (
     get_geographies_as_iso_codes_with_fallback,  # TODO: remove this once frontend is updated to use ISO codes in favour of get_countries_by_iso_codes
 )
 from app.repository.lookups import (
-    validate_subdivision_iso_codes,  # TODO: update this to use geographies api endpoint
+    validate_subdivision_iso_codes,  # TODO: update this to use geographies api endpoint when refactoring geographies
 )
 from app.repository.lookups import (
     doc_type_from_family_document_metadata,

--- a/backend-api/app/service/search.py
+++ b/backend-api/app/service/search.py
@@ -50,6 +50,9 @@ from app.repository.lookups import (
     get_geographies_as_iso_codes_with_fallback,  # TODO: remove this once frontend is updated to use ISO codes in favour of get_countries_by_iso_codes
 )
 from app.repository.lookups import (
+    validate_subdivision_iso_codes,  # TODO: update this to use geographies api endpoint
+)
+from app.repository.lookups import (
     doc_type_from_family_document_metadata,
     get_countries_for_region,
 )
@@ -378,7 +381,7 @@ def _convert_filters(
                 get_geographies_as_iso_codes_with_fallback(db, values)
             )
         elif field == FilterField.SUBDIVSION:
-            countries.append(get_geographies_as_iso_codes_with_fallback(db, values))
+            countries.extend(validate_subdivision_iso_codes(db, values))
         else:
             new_values = values
             new_keyword_filters[new_field] = new_values

--- a/backend-api/tests/search/test_search.py
+++ b/backend-api/tests/search/test_search.py
@@ -553,6 +553,8 @@ def test_create_browse_request_params(
         ),
         # Tests that valid ISO country codes work
         ({"countries": ["KHM"]}, {"family_geographies": ["KHM"]}),
+        # Tests that subdivisions iso codes are mapped to family_geographies
+        ({"subdivisions": ["US-CA"]}, {"family_geographies": ["KHM"]}),
         # # Tests that country names (not codes) return None
         # TODO: Reenable this test
         # ({"countries": ["cambodia"]}, None),
@@ -753,7 +755,7 @@ def _generate_search_response_hits(spec: FamSpec) -> Sequence[CprSdkHit]:
                     if doc_data[document_number]["content_type"] == "text/html"
                     else _generate_coords()
                 ),
-                text_block_id=f"block_{random.randint(1,15000)}",
+                text_block_id=f"block_{random.randint(1, 15000)}",
                 text_block_page=(
                     None
                     if doc_data[document_number]["content_type"] == "text/html"

--- a/backend-api/tests/search/test_search.py
+++ b/backend-api/tests/search/test_search.py
@@ -554,7 +554,15 @@ def test_create_browse_request_params(
         # Tests that valid ISO country codes work
         ({"countries": ["KHM"]}, {"family_geographies": ["KHM"]}),
         # Tests that subdivisions iso codes are mapped to family_geographies
-        ({"subdivisions": ["US-CA"]}, {"family_geographies": ["KHM"]}),
+        ({"subdivisions": ["US-CA"]}, {"family_geographies": ["US-CA"]}),
+        # Tests that subdivisions do not replace countries in family_geographies
+        (
+            {
+                "countries": ["united-states-of-america"],
+                "subdivisions": ["US-CA", "US-CO"],
+            },
+            {"family_geographies": ["USA", "US-CA", "US-CO"]},
+        ),
         # # Tests that country names (not codes) return None
         # TODO: Reenable this test
         # ({"countries": ["cambodia"]}, None),
@@ -633,6 +641,7 @@ def test__convert_filters(data_db, filters, expected):
         assert converted_filters == expected
 
     if converted_filters not in [None, []]:
+        print("This is the converted filters", converted_filters)
         assert isinstance(converted_filters, dict)
         assert set(converted_filters.keys()).issubset(filter_fields.values())
 

--- a/geographies-api/app/main.py
+++ b/geographies-api/app/main.py
@@ -3,14 +3,13 @@ import os
 from pathlib import Path
 from typing import TypeVar
 
+from api.telemetry import Telemetry
+from api.telemetry_config import ServiceManifest, TelemetryConfig
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.model import Settings
 from app.router import router as geographies_router
-
-from ...api.telemetry import Telemetry
-from ...api.telemetry_config import ServiceManifest, TelemetryConfig
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/geographies-api/app/main.py
+++ b/geographies-api/app/main.py
@@ -3,13 +3,14 @@ import os
 from pathlib import Path
 from typing import TypeVar
 
-from api.telemetry import Telemetry
-from api.telemetry_config import ServiceManifest, TelemetryConfig
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.model import Settings
 from app.router import router as geographies_router
+
+from ...api.telemetry import Telemetry
+from ...api.telemetry_config import ServiceManifest, TelemetryConfig
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/geographies-api/app/router.py
+++ b/geographies-api/app/router.py
@@ -39,7 +39,7 @@ async def list_all_regions() -> list[RegionResponse]:
 
 @router.get("/regions/{slug}", response_model=RegionResponse)
 async def get_region(
-    slug: str = Path(..., description="region slug")
+    slug: str = Path(..., description="region slug"),
 ) -> RegionResponse:
     """
     Get region with metadata by its slug.
@@ -59,7 +59,7 @@ async def get_region(
 
 @router.get("/regions/{slug}/countries", response_model=list[CountryResponse])
 async def get_countries_for_region(
-    slug: str = Path(..., description="region slug")
+    slug: str = Path(..., description="region slug"),
 ) -> list[CountryResponse]:
     """
     Get all countries for a requested region by its slug.
@@ -129,8 +129,7 @@ async def get_subdivisions() -> list[SubdivisionResponse]:
     Get subdivisions for all countries.
 
     NOTE: This endpoint retrieves first-level administrative subdivisions
-    (such as states, provinces, or regions) for a given country using
-    its ISO alpha-3 code (e.g., 'USA', 'AUS', 'CAN'). This can be used to
+    (such as states, provinces, or regions) for all countries. This can be used to
     support region-based filtering, selection menus, or geographic analysis.
 
     :return list[SubdivisionResponse]: A list of subdivision objects representing


### PR DESCRIPTION
# Description

We are updating our vespa query; adding subdivisions to the geography query. 

A subdivision in our code base is effectively a geography, so have updated the countries array that takes all the iso codes and passes them to vespa [see line 387].

Have added a function to validate the iso codes based on the objects in our geo database. Made the decision to use the db to validate the iso codes rather than the geo service endpoint as was concerned network latency might affect search performance.

Wonder if it is worth changing that array name from `countries` to `geographies`


## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Refactor legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
