### PR TITLE
Feature/app 943 bug search results include other subdivisions if parent

### DIFF
--- a/backend-api/app/repository/lookups.py
+++ b/backend-api/app/repository/lookups.py
@@ -150,13 +150,11 @@ def get_country_by_slug(db: Session, country_slug: str) -> Optional[Geography]:
     return geography
 
 
-def get_parent_slugs_from_subdivision_iso_code(
+def get_parent_iso_codes_from_subdivisions(
     db: Session, iso_codes: Sequence[str]
 ) -> set[str]:
     """
-    Retrieve parent slugs for given subdivision ISO codes.
-    Example: iso_codes=["AU-NSW", "AU-QLD"] -> {"australia", "australia"}
-        (deduplicated to {"australia"})
+    Retrieve parent iso codes for given subdivision ISO codes.
 
     :param Session db: Database session.
     :param Sequence[str] iso_codes: Sequence of subdivision ISO codes.
@@ -174,7 +172,9 @@ def get_parent_slugs_from_subdivision_iso_code(
     )
 
     parent_slugs = (
-        db.query(Geography.slug).filter(Geography.id.in_(parent_ids_subquery)).all()
+        db.query(Geography.value)
+        .filter(Geography.id.in_(db.query(parent_ids_subquery.c.parent_id)))
+        .all()
     )
 
     return {slug[0] for slug in parent_slugs}

--- a/backend-api/app/repository/lookups.py
+++ b/backend-api/app/repository/lookups.py
@@ -158,7 +158,7 @@ def get_parent_iso_codes_from_subdivisions(
 
     :param Session db: Database session.
     :param Sequence[str] iso_codes: Sequence of subdivision ISO codes.
-    :return set[str]: set of parent slugs for valid subdivisions.
+    :return set[str]: set of parent iso_codes for valid subdivisions.
 
     """
     if not iso_codes:
@@ -171,13 +171,13 @@ def get_parent_iso_codes_from_subdivisions(
         .subquery()
     )
 
-    parent_slugs = (
+    parent_iso_codes = (
         db.query(Geography.value)
         .filter(Geography.id.in_(db.query(parent_ids_subquery.c.parent_id)))
         .all()
     )
 
-    return {slug[0] for slug in parent_slugs}
+    return {code[0] for code in parent_iso_codes}
 
 
 def get_country_slug_from_country_code(db: Session, country_code: str) -> Optional[str]:

--- a/backend-api/app/service/search.py
+++ b/backend-api/app/service/search.py
@@ -393,6 +393,7 @@ def _convert_filters(
             new_values = values
             new_keyword_filters[new_field] = new_values
 
+    # Remove any subdivision parent slugs from countries
     if countries and subdivision_parent_slugs:
         countries = list(set(countries) - subdivision_parent_slugs)
 

--- a/backend-api/app/service/search.py
+++ b/backend-api/app/service/search.py
@@ -55,6 +55,7 @@ from app.repository.lookups import (
 from app.repository.lookups import (
     doc_type_from_family_document_metadata,
     get_countries_for_region,
+    get_parent_slugs_from_subdivision_iso_code,
 )
 from app.service.util import to_cdn_url
 from app.telemetry import observe
@@ -367,6 +368,7 @@ def _convert_filters(
     new_keyword_filters = {}
     regions = []
     countries = []
+    subdivision_parent_slugs = set()
     for field, values in keyword_filters.items():
         if not values:
             continue
@@ -384,9 +386,15 @@ def _convert_filters(
             )
         elif field == FilterField.SUBDIVISION:
             countries.extend(validate_subdivision_iso_codes(db, values))
+            subdivision_parent_slugs.update(
+                get_parent_slugs_from_subdivision_iso_code(db, values)
+            )
         else:
             new_values = values
             new_keyword_filters[new_field] = new_values
+
+    if countries and subdivision_parent_slugs:
+        countries = list(set(countries) - subdivision_parent_slugs)
 
     # Regions and countries filters should only include the overlap
     geo_field = filter_fields["geographies"]

--- a/backend-api/app/service/search.py
+++ b/backend-api/app/service/search.py
@@ -393,14 +393,15 @@ def _convert_filters(
             new_values = values
             new_keyword_filters[new_field] = new_values
 
-    # Remove any subdivision parent slugs from countries
-    if countries and subdivision_parent_codes:
+    # Remove any subdivision parent slugs from countries and regions
+    if subdivision_parent_codes:
         countries = list(set(countries) - subdivision_parent_codes)
+        regions = list(set(regions) - subdivision_parent_codes)
 
     # Regions and countries filters should only include the overlap
     geo_field = filter_fields["geographies"]
     if regions and countries:
-        values = list(set(countries).intersection(regions))
+        values = list(set(regions + countries) - subdivision_parent_codes)
         if values:
             new_keyword_filters[geo_field] = values
     elif regions:

--- a/backend-api/app/service/search.py
+++ b/backend-api/app/service/search.py
@@ -12,8 +12,9 @@ from cpr_sdk.models.search import Document as CprSdkResponseDocument
 from cpr_sdk.models.search import Family as CprSdkResponseFamily
 from cpr_sdk.models.search import Filters as CprSdkKeywordFilters
 from cpr_sdk.models.search import Passage as CprSdkResponsePassage
-from cpr_sdk.models.search import SearchParameters, filter_fields
+from cpr_sdk.models.search import SearchParameters
 from cpr_sdk.models.search import SearchResponse as CprSdkSearchResponse
+from cpr_sdk.models.search import filter_fields
 from cpr_sdk.search_adaptors import VespaSearchAdapter
 from db_client.models.dfce import (
     Collection,
@@ -46,11 +47,15 @@ from app.models.search import (
     SearchResponseFamilyDocument,
 )
 from app.repository.lookups import (
+    get_geographies_as_iso_codes_with_fallback,  # TODO: remove this once frontend is updated to use ISO codes in favour of get_countries_by_iso_codes
+)
+from app.repository.lookups import (
+    validate_subdivision_iso_codes,  # TODO: update this to use geographies api endpoint when refactoring geographies to use iso codes
+)
+from app.repository.lookups import (
     doc_type_from_family_document_metadata,
     get_countries_for_region,
-    get_geographies_as_iso_codes_with_fallback,  # TODO: remove this once frontend is updated to use ISO codes in favour of get_countries_by_iso_codes
     get_parent_iso_codes_from_subdivisions,
-    validate_subdivision_iso_codes,  # TODO: update this to use geographies api endpoint when refactoring geographies to use iso codes
 )
 from app.service.util import to_cdn_url
 from app.telemetry import observe
@@ -388,7 +393,7 @@ def _convert_filters(
             new_values = values
             new_keyword_filters[new_field] = new_values
 
-    # Remove any subdivision parent slugs from countries and regions
+    # Remove any subdivision parent slugs from countries and regions.
     if subdivision_parent_codes:
         countries = list(set(countries) - subdivision_parent_codes)
         regions = list(set(regions) - subdivision_parent_codes)

--- a/backend-api/app/service/search.py
+++ b/backend-api/app/service/search.py
@@ -55,7 +55,7 @@ from app.repository.lookups import (
 from app.repository.lookups import (
     doc_type_from_family_document_metadata,
     get_countries_for_region,
-    get_parent_slugs_from_subdivision_iso_code,
+    get_parent_iso_codes_from_subdivisions,
 )
 from app.service.util import to_cdn_url
 from app.telemetry import observe
@@ -368,7 +368,7 @@ def _convert_filters(
     new_keyword_filters = {}
     regions = []
     countries = []
-    subdivision_parent_slugs = set()
+    subdivision_parent_codes = set()
     for field, values in keyword_filters.items():
         if not values:
             continue
@@ -386,16 +386,16 @@ def _convert_filters(
             )
         elif field == FilterField.SUBDIVISION:
             countries.extend(validate_subdivision_iso_codes(db, values))
-            subdivision_parent_slugs.update(
-                get_parent_slugs_from_subdivision_iso_code(db, values)
+            subdivision_parent_codes.update(
+                get_parent_iso_codes_from_subdivisions(db, values)
             )
         else:
             new_values = values
             new_keyword_filters[new_field] = new_values
 
     # Remove any subdivision parent slugs from countries
-    if countries and subdivision_parent_slugs:
-        countries = list(set(countries) - subdivision_parent_slugs)
+    if countries and subdivision_parent_codes:
+        countries = list(set(countries) - subdivision_parent_codes)
 
     # Regions and countries filters should only include the overlap
     geo_field = filter_fields["geographies"]

--- a/backend-api/tests/search/test_search.py
+++ b/backend-api/tests/search/test_search.py
@@ -571,6 +571,15 @@ def test_create_browse_request_params(
             },
             {"family_geographies": ["US-CA", "US-CO"]},
         ),
+        # Test that countries in the regions filter are respected and only parents of subdivisions are excluded in family_geographies
+        (
+            {
+                "regions": ["north-america"],
+                "countries": ["united-states-of-america"],
+                "subdivisions": ["US-CA", "US-CO"],
+            },
+            {"family_geographies": ["US-CA", "US-CO", "CAN"]},
+        ),
         # # Tests that country names (not codes) return None
         # TODO: Reenable this test
         # ({"countries": ["cambodia"]}, None),

--- a/backend-api/tests/search/test_search.py
+++ b/backend-api/tests/search/test_search.py
@@ -555,38 +555,30 @@ def test_create_browse_request_params(
         ({"countries": ["KHM"]}, {"family_geographies": ["KHM"]}),
         # Tests that subdivisions iso codes are mapped to family_geographies
         ({"subdivisions": ["US-CA"]}, {"family_geographies": ["US-CA"]}),
-        # Tests that subdivisions do not replace countries in family_geographies
+        # Tests that non-existent subdivisions iso codes are not mapped to family_geographies
+        ({"subdivisions": ["US-CA", "XX-ZZ-YY"]}, {"family_geographies": ["US-CA"]}),
+        # Tests that if selected only subdivisions are mapped to family_geographies
         (
             {
                 "countries": ["china", "united-states-of-america", "australia"],
-                "subdivisions": ["US-CA", "US-CO"],
+                "subdivisions": ["US-CA", "US-CO", "AU-NSW", "AU-QLD"],
             },
-            {"family_geographies": ["CHN", "US-CA", "US-CO", "AUS"]},
-        ),
-        # Tests that subdivisions parent countries are not included in family_geographies
-        (
             {
-                "countries": ["china", "united-states-of-america", "australia"],
-                "subdivisions": ["US-CA", "US-CO"],
+                "family_geographies": [
+                    "US-CA",
+                    "US-CO",
+                    "AU-NSW",
+                    "AU-QLD",
+                ]
             },
-            {"family_geographies": ["CHN", "US-CA", "US-CO", "AUS"]},
         ),
         # Tests that subdivisions parent countries are not included in family_geographies
         (
             {
                 "countries": ["united-states-of-america"],
-                "subdivisions": ["US-CA", "US-CO"],
+                "subdivisions": ["US-CA", "US-TX"],
             },
-            {"family_geographies": ["US-CA", "US-CO"]},
-        ),
-        # Test that countries in the regions filter are respected and only parents of subdivisions are excluded in family_geographies
-        (
-            {
-                "regions": ["north-america"],
-                "countries": ["united-states-of-america"],
-                "subdivisions": ["US-CA", "US-CO"],
-            },
-            {"family_geographies": ["US-CA", "US-CO", "CAN"]},
+            {"family_geographies": ["US-CA", "US-TX"]},
         ),
         # # Tests that country names (not codes) return None
         # TODO: Reenable this test

--- a/backend-api/tests/search/test_search.py
+++ b/backend-api/tests/search/test_search.py
@@ -558,10 +558,10 @@ def test_create_browse_request_params(
         # Tests that subdivisions do not replace countries in family_geographies
         (
             {
-                "countries": ["china"],
+                "countries": ["china", "united-states-of-america", "australia"],
                 "subdivisions": ["US-CA", "US-CO"],
             },
-            {"family_geographies": ["CHN", "US-CA", "US-CO"]},
+            {"family_geographies": ["CHN", "US-CA", "US-CO", "AUS"]},
         ),
         # Tests that subdivisions parent countries are not included in family_geographies
         (

--- a/backend-api/tests/search/test_search.py
+++ b/backend-api/tests/search/test_search.py
@@ -558,10 +558,18 @@ def test_create_browse_request_params(
         # Tests that subdivisions do not replace countries in family_geographies
         (
             {
+                "countries": ["china"],
+                "subdivisions": ["US-CA", "US-CO"],
+            },
+            {"family_geographies": ["CHN", "US-CA", "US-CO"]},
+        ),
+        # Tests that subdivisions parent countries are not included in family_geographies
+        (
+            {
                 "countries": ["united-states-of-america"],
                 "subdivisions": ["US-CA", "US-CO"],
             },
-            {"family_geographies": ["USA", "US-CA", "US-CO"]},
+            {"family_geographies": ["US-CA", "US-CO"]},
         ),
         # # Tests that country names (not codes) return None
         # TODO: Reenable this test


### PR DESCRIPTION
# Description

We are taking a step back with the filtering in the backend as it concerns subdivisions and respect the most granular filter and ignore everything else. So should a user select a subdivision in america but has regions selected alongside other countries we are just going to take the subdivision filters.


## Type of change

Please select the option(s) below that are most relevant:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Refactor legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
