### PR TITLE
fix: deploy microservices to staging on merge to main

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -5,7 +5,6 @@ on:
   pull_request:
     # there is a micro-optimisation here in only running test if it's a relevant label
     # but this isn't currently a performance bottleneck so we're leaving it to run on all labels to reduce complexity
-    # a. deploys the service to staging if the pull request is (re)labelled with 'deploy:staging'
     types: [opened, synchronize, reopened, labeled] # This needs to be the American spelling, don't change it
   workflow_dispatch: {}
 permissions:
@@ -23,8 +22,6 @@ jobs:
       - run: just test ${{ matrix.service }}
   deploy:
     needs: test
-    # a. deploys the service to staging if the pull request is (re)labelled with 'deploy:staging'
-    if: contains(github.event.pull_request.labels.*.name, 'deploy:staging')
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION


per title - we were trying to mitigate against mix up of feature branches being overwritten with staging deploys when someone would merge their pr. After an internal discussions we discussed that this is not too much of a common occurence for the current implementation so we are reverting those changes and deploying straight to staging as we do for production on merge to main

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] GitHub workflow update
- [ ] Documentation update
- [ ] Refactor legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
