### PR TITLE
feat: add events to familes response

### DIFF
--- a/families-api/app/main.py
+++ b/families-api/app/main.py
@@ -359,6 +359,16 @@ class FamilyPublic(FamilyBase):
                     if document.valid_metadata
                     else None
                 ),
+                "events": [
+                    {
+                        "title": event.title,
+                        "date": event.date,
+                        "event_type": event.event_type_name,
+                        "status": event.status,
+                        "metadata": event.valid_metadata,
+                    }
+                    for event in document.unparsed_events
+                ],
             }
             for document in self.family_documents
             if document.physical_document

--- a/families-api/app/test_main.py
+++ b/families-api/app/test_main.py
@@ -10,11 +10,13 @@ from .main import (
     APIItemResponse,
     Corpus,
     Family,
+    FamilyDocument,
     FamilyEvent,
     FamilyMetadata,
     FamilyPublic,
     Geography,
     Organisation,
+    PhysicalDocument,
     Slug,
     app,
     get_session,
@@ -72,6 +74,46 @@ def test_read_family_200(client: TestClient, session: Session):
         organisation=organisation,
         organisation_id=organisation.id,
         corpus_type_name="Intl. agreements",
+    )
+    physical_document = PhysicalDocument(
+        id=123,
+        title="Test Physical Document",
+        source_url="https://example.com/test-physical-document",
+        md5_sum="test_md5_sum",
+        cdn_object="https://cdn.example.com/test-physical-document",
+        content_type="application/pdf",
+    )
+    family_document = FamilyDocument(
+        import_id="family_document_1",
+        variant_name="MAIN",
+        family_import_id="family_123",
+        physical_document_id=123,
+        valid_metadata={
+            "title": "Test Family Document",
+            "slug": "test-family-document",
+            "corpus": "Test Corpus",
+            "corpus_id": "corpus_1",
+            "type": "Legislative",
+            "status": "Active",
+            "language": ["en"],
+            "jurisdiction": ["DE", "FR"],
+        },
+        unparsed_events=[
+            FamilyEvent(
+                import_id="family_document_event_1",
+                title="Family event 1",
+                date=datetime.fromisoformat("2016-12-01T00:00:00+00:00"),
+                event_type_name="Passed/Approved",
+                status="OK",
+            ),
+            FamilyEvent(
+                import_id="family_document_event_2",
+                title="Family event 2",
+                date=datetime.fromisoformat("2023-11-17T00:00:00+00:00"),
+                event_type_name="Updated",
+                status="OK",
+            ),
+        ],
     )
     family = Family(
         title="Test family",
@@ -164,6 +206,9 @@ def test_read_family_200(client: TestClient, session: Session):
     )
     session.add(corpus)
     session.add(family)
+    session.add(family_document)
+    session.add(physical_document)
+
     session.commit()
 
     response = client.get("/families/family_123")


### PR DESCRIPTION
# Description

- adds events to `FamilyDocument` response

Towards https://linear.app/climate-policy-radar/issue/APP-816/render-family-page-via-the-new-families-api-for-new-family-page

## Example response

For this https://api.climatepolicyradar.org/families/Sabin.family.92131.0

```json
{
    "documents": [
        {
            "import_id": "Sabin.document.92131.92132",
            "variant": "Original Language",
            "slug": "lawsuit-sought-to-compel-updating-of-development-and-production-plans-prior-to-resumption-of-oil-and-gas-activities_4767",
            "title": "Lawsuit Sought to Compel Updating of Development and Production Plans Prior to Resumption of Oil and Gas Activities",
            "md5_sum": "51f6cb7684518f508332c39bbf547cdf",
            "cdn_object": "https://cdn.climatepolicyradar.org/USA/2025/center-for-biological-diversity-v-burgum_51f6cb7684518f508332c39bbf547cdf.pdf",
            "source_url": "https://climatecasechart.com/wp-content/uploads/case-documents/2025/20250402_docket-225-cv-02840_complaint.pdf",
            "content_type": "application/pdf",
            "language": "eng",
            "languages": [
                "eng"
            ],
            "document_type": null,
            "document_role": null,
            "events": [
                {
                    "title": "complaint",
                    "date": "2025-04-02T00:00:00Z",
                    "event_type": "Complaint",
                    "status": "OK",
                    "metadata": {
                        "event_type": [
                            "Complaint"
                        ],
                        "description": [
                            "Center for Biological Diversity and Wishtoyo Foundation filed a lawsuit in the federal district court for the Central District of California alleging that the Bureau of Ocean Energy Management (BOEM) violated the Outer Continental Shelf Lands Act (OCSLA) and the Administrative Procedure Act when it failed to require revision of development and production plans (DPPs) for resumption of oil and gas activities at the Santa Ynez Unit in the Santa Barbara Channel. Production at the unit was shut down after an onshore pipeline ruptured in 2015; the complaint alleged that the new owner of the offshore platforms in the unit had informed investors that it planned to restart production in the second quarter of 2025. The plaintiffs alleged that OCSLA implementing regulations’ triggers for DPP revisions were met and that without revisions the owner “will operate under DPPs that do not reflect current science or the true scope of activities and emissions at the platforms” and that both BOEM and the public “will be left in the dark about the full scope of harms from restarting production at the Santa Ynez Unit and further environmental safeguards will go unaddressed.” The complaint’s allegations included that the DPPs, which were originally approved in the 1970s and 1980s “have not been meaningfully revised since then,” “are silent on the issue of greenhouse gas emissions” and that the onshore processing facilities for the Unit had been Santa Barbara County’s largest facility source of greenhouse gas emissions prior to the shutdown of the Unit after the pipeline spill. The plaintiffs asked the court to require revisions of the DPPs and to prohibit the defendants from authorizing new oil and gas drilling activity until the revisions were complete."
                        ],
                        "datetime_event_name": [
                            "Filing Year For Action"
                        ]
                    }
                }
            ]
        }
    ]
}
```