### PR TITLE
feat: use famdoc public as base for document response

### DIFF
--- a/families-api/app/main.py
+++ b/families-api/app/main.py
@@ -532,7 +532,7 @@ class FamilyDocumentPublic(FamilyDocumentBase):
         ]
 
 
-class FamilyDocumentPublicWithFamily(FamilyDocumentBase):
+class FamilyDocumentPublicWithFamily(FamilyDocumentPublic):
     family: FamilyPublic
 
 
@@ -830,7 +830,8 @@ def docs_by_geo(
         .join(Family, FamilyGeographyLink.family_import_id == Family.import_id)  # type: ignore
         .join(FamilyDocument, Family.import_id == FamilyDocument.family_import_id)  # type: ignore
         .join(
-            PhysicalDocument, FamilyDocument.physical_document_id == PhysicalDocument.id  # type: ignore
+            PhysicalDocument,
+            FamilyDocument.physical_document_id == PhysicalDocument.id,  # type: ignore
         )
         .group_by(Geography.id)  # type: ignore
         .order_by(func.count(PhysicalDocument.id).desc())  # type: ignore


### PR DESCRIPTION
this model gives us more properties on the document object

Before
<img width="673" height="194" alt="Screenshot 2025-08-05 at 11 06 09" src="https://github.com/user-attachments/assets/09865d3e-d4b2-46e8-8793-b9825be85e4b" />

After

<img width="937" height="728" alt="Screenshot 2025-08-05 at 11 06 23" src="https://github.com/user-attachments/assets/dd0ba080-bfde-4667-bead-1cd4d85fe18e" />


## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Refactor legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
