### PR TITLE
add navigator bucket title in cdn object so that it can be accessed

### DIFF
--- a/families-api/app/main.py
+++ b/families-api/app/main.py
@@ -463,7 +463,7 @@ class FamilyDocumentPublic(FamilyDocumentBase):
     @computed_field
     @property
     def cdn_object(self) -> str:
-        return f"{settings.cdn_url}/{self.physical_document.cdn_object}"
+        return f"{settings.cdn_url}/navigator/{self.physical_document.cdn_object}"
 
     @computed_field
     @property

--- a/families-api/app/main.py
+++ b/families-api/app/main.py
@@ -532,7 +532,7 @@ class FamilyDocumentPublic(FamilyDocumentBase):
         ]
 
 
-class FamilyDocumentPublicWithFamily(FamilyDocumentBase):
+class FamilyDocumentPublicWithFamily(FamilyDocumentPublic):
     family: FamilyPublic
 
 
@@ -830,7 +830,8 @@ def docs_by_geo(
         .join(Family, FamilyGeographyLink.family_import_id == Family.import_id)  # type: ignore
         .join(FamilyDocument, Family.import_id == FamilyDocument.family_import_id)  # type: ignore
         .join(
-            PhysicalDocument, FamilyDocument.physical_document_id == PhysicalDocument.id  # type: ignore
+            PhysicalDocument,
+            FamilyDocument.physical_document_id == PhysicalDocument.id,  # type: ignore
         )
         .group_by(Geography.id)  # type: ignore
         .order_by(func.count(PhysicalDocument.id).desc())  # type: ignore


### PR DESCRIPTION
# Description

We were missing `bucket` prefix from the cdn object which meant that the url was broken 

This works : 

https://cdn.climatepolicyradar.org/navigator/USA/2025/environmental-defense-fund-v-epa_ac6863a762177b969a6e4d708b2882bb.pdf

Whereas this doesnt

https://cdn.climatepolicyradar.org/USA/2025/environmental-defense-fund-v-epa_ac6863a762177b969a6e4d708b2882bb.pdf

## Type of change

Please select the option(s) below that are most relevant:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Refactor legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
