### PR TITLE
fix: return empty string if document role does not exist on metadata

### DIFF
--- a/families-api/app/main.py
+++ b/families-api/app/main.py
@@ -512,9 +512,7 @@ class FamilyDocumentPublic(FamilyDocumentBase):
     @computed_field
     @property
     def document_role(self) -> str | None:
-        return (
-            self.valid_metadata.get("role", [None])[0] if self.valid_metadata else None
-        )
+        return self.valid_metadata.get("role", [None])[0] if self.valid_metadata else ""
 
     @computed_field
     @property

--- a/families-api/app/main.py
+++ b/families-api/app/main.py
@@ -463,7 +463,7 @@ class FamilyDocumentPublic(FamilyDocumentBase):
     @computed_field
     @property
     def cdn_object(self) -> str:
-        return f"{settings.cdn_url}/{self.physical_document.cdn_object}"
+        return f"{settings.cdn_url}/navigator/{self.physical_document.cdn_object}"
 
     @computed_field
     @property

--- a/families-api/app/main.py
+++ b/families-api/app/main.py
@@ -532,7 +532,7 @@ class FamilyDocumentPublic(FamilyDocumentBase):
         ]
 
 
-class FamilyDocumentPublicWithFamily(FamilyDocumentBase):
+class FamilyDocumentPublicWithFamily(FamilyDocumentPublic):
     family: FamilyPublic
 
 
@@ -830,7 +830,8 @@ def docs_by_geo(
         .join(Family, FamilyGeographyLink.family_import_id == Family.import_id)  # type: ignore
         .join(FamilyDocument, Family.import_id == FamilyDocument.family_import_id)  # type: ignore
         .join(
-            PhysicalDocument, FamilyDocument.physical_document_id == PhysicalDocument.id  # type: ignore
+            PhysicalDocument,
+            FamilyDocument.physical_document_id == PhysicalDocument.id,  # type: ignore
         )
         .group_by(Geography.id)  # type: ignore
         .order_by(func.count(PhysicalDocument.id).desc())  # type: ignore


### PR DESCRIPTION
# Description

per title return empty string if document role does not exist on metadata, follows what we have done in the [backend api ](https://github.com/climatepolicyradar/navigator-backend/blob/b9aba42e4e2099097c219b9ff0a0f7061123db11/backend-api/app/repository/document.py#L160) and ensures that the frontend does not break. 

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Refactor legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
