### PR TITLE
fix: we do not want to return none for document role

### DIFF
--- a/families-api/app/main.py
+++ b/families-api/app/main.py
@@ -511,8 +511,8 @@ class FamilyDocumentPublic(FamilyDocumentBase):
 
     @computed_field
     @property
-    def document_role(self) -> str | None:
-        return self.valid_metadata.get("role", [None])[0] if self.valid_metadata else ""
+    def document_role(self) -> str:
+        return self.valid_metadata.get("role", [""])[0] if self.valid_metadata else ""
 
     @computed_field
     @property


### PR DESCRIPTION
# Description
Fix `self.valid_metadata.get("role", [None])[0]` would still return the first element of the `[None]` list if there was valid metadata and role was not a property on that dict. We just want to return an empty string in all instances where document role does not exist

## Type of change

Please select the option(s) below that are most relevant:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Refactor legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
