### PR TITLE
fix: remove line length from markdown lint

### DIFF
--- a/.trunk/configs/.markdownlint.yaml
+++ b/.trunk/configs/.markdownlint.yaml
@@ -1,4 +1,25 @@
 # Autoformatter friendly markdownlint config (all formatting rules disabled)
 default: true
 
-MD013: false
+MD013:
+  # Number of characters
+  line_length: 80
+
+  # Number of characters for headings
+  heading_line_length: 80
+
+  # Number of characters for code blocks
+  code_block_line_length: 80
+
+  # Include
+  headings: true
+
+  # Don't include
+  tables: false
+  code_blocks: false
+
+  # Strict length checking
+  strict: false
+
+  # Stern length checking
+  stern: false

--- a/.trunk/configs/.prettierrc
+++ b/.trunk/configs/.prettierrc
@@ -1,0 +1,11 @@
+{
+  "overrides": [
+    {
+      "files": "*.md",
+      "options": {
+        "printWidth": 80,
+        "proseWrap": "always"
+      }
+    }
+  ]
+}

--- a/geographies-api/README.md
+++ b/geographies-api/README.md
@@ -12,7 +12,8 @@ TL;DR;
 - This data is colated into a JSON object
 - The JSON object is stored in S3
 - [This is made available via our CDN URL](https://cdn.climatepolicyradar.org/geographies/countries.json)
-- When a request is made we use requests to lookup this JSON and get the relevant data
+- When a request is made we use requests to lookup this JSON and get the
+  relevant data
 
 ```mermaid
 flowchart LR


### PR DESCRIPTION
# Description

- adds the architecture diagram for `families-api`
- removes markdown lint MD013. I find myself spending an inordinate amount of time trying to fix for this which isn't time well spent. [If there was an autofix](https://github.com/DavidAnson/markdownlint/issues/294), I'd happily leave it in.


The intention here is that if we want to make large changes going forward - we can express them in the diagram first and RFC before embarking on the work.

It's also useful for new starters to get their head around it.

This might be wrong as it's my reading of it from the code, so an 🦅 👁️ would be appreciated from @annaCPR and @odrakes-cpr 

[For ease of use - here's the rendered README](https://github.com/climatepolicyradar/navigator-backend/blob/7b3058f709ac7c0fc0a045b3fd19bd44afcc1fa3/geographies-api/README.md).