### PR TITLE
fix: deploy backend-api by pushing to ECR latest

### DIFF
--- a/.github/workflows/deploy-backend-api-to-production.yml
+++ b/.github/workflows/deploy-backend-api-to-production.yml
@@ -25,7 +25,7 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Build, tag, and push image to Amazon ECR
-        id: build-image-staging
+        id: build-image-production
         env:
           ECR_REGISTRY: ${{ secrets.DOCKER_REGISTRY_PRODUCTION }}
           IMAGE_TAG: latest


### PR DESCRIPTION
# Description

Adds deployment for backend-api via the push-to-latest mechanism.

Similarly to frontend we are maintaining this for confidence / testing reasons.

## question?

Should we just auto deploy on merge-to-main?