### PR TITLE
feat: corpus.import_id filter on read_families

### DIFF
--- a/families-api/tests/test_main.py
+++ b/families-api/tests/test_main.py
@@ -152,7 +152,7 @@ def make_family():
             ],
         )
 
-        return (corpus, physical_document, family_document, family)
+        return (corpus, family, family_document, physical_document)
 
     return _make_family
 
@@ -237,13 +237,17 @@ def test_read_family_corpus_import_id_filter(
     session.commit()
 
     # joins on OR
+    expected_family_ids1 = [family1.import_id, family2.import_id]
     response1 = client.get(
         f"/families/?corpus.import_id={corpus1.import_id}&corpus.import_id={corpus2.import_id}"
     )
     assert response1.status_code == 200  # nosec B101
     data1 = APIListResponse[FamilyPublic].model_validate(response1.json())
     assert len(data1.data) == 2
+    assert {family.import_id for family in data1.data} == set(expected_family_ids1)
 
+    expected_family_ids2 = [family1.import_id]
     response2 = client.get(f"/families/?corpus.import_id={corpus1.import_id}")
     data2 = APIListResponse[FamilyPublic].model_validate(response2.json())
     assert len(data2.data) == 1
+    assert {family.import_id for family in data2.data} == set(expected_family_ids2)

--- a/families-api/tests/test_main.py
+++ b/families-api/tests/test_main.py
@@ -15,13 +15,146 @@ from app.models import (
     FamilyEvent,
     FamilyMetadata,
     FamilyPublic,
-    Geography,
     Organisation,
     PhysicalDocument,
     Slug,
 )
-from app.router import APIItemResponse
+from app.router import APIItemResponse, APIListResponse
 from app.settings import settings
+
+
+# Base on
+# @see: https://docs.pytest.org/en/stable/how-to/fixtures.html#factories-as-fixtures
+@pytest.fixture
+def make_family():
+    def _make_family(id: int):
+        organisation = Organisation(id=id, name="Test Org")
+        corpus = Corpus(
+            import_id=f"corpus_{id}",
+            title=f"Test Corpus {id}",
+            organisation=organisation,
+            organisation_id=organisation.id,
+            corpus_type_name="Intl. agreements",
+        )
+        physical_document = PhysicalDocument(
+            id=id,
+            title=f"Test Physical Document {id}",
+            source_url="https://example.com/test-physical-document",
+            md5_sum="test_md5_sum",
+            cdn_object="https://cdn.example.com/test-physical-document",
+            content_type="application/pdf",
+        )
+        family_document = FamilyDocument(
+            import_id=f"family_document_{id}",
+            variant_name="MAIN",
+            family_import_id=f"family_{id}",
+            physical_document_id=id,
+            valid_metadata={
+                "title": "Test Family Document",
+                "slug": "test-family-document",
+                "corpus": "Test Corpus",
+                "corpus_id": "corpus_1",
+                "type": "Legislative",
+                "status": "Active",
+                "language": ["en"],
+                "jurisdiction": ["DE", "FR"],
+            },
+            unparsed_events=[
+                FamilyEvent(
+                    import_id=f"family_document_event_{id}_1",
+                    title=f"Family event {id} 1",
+                    date=datetime.fromisoformat("2016-12-01T00:00:00+00:00"),
+                    event_type_name="Passed/Approved",
+                    status="OK",
+                ),
+                FamilyEvent(
+                    import_id=f"family_document_event_{id}_2",
+                    title=f"Family event {id} 2",
+                    date=datetime.fromisoformat("2023-11-17T00:00:00+00:00"),
+                    event_type_name="Updated",
+                    status="OK",
+                ),
+            ],
+        )
+        family = Family(
+            title=f"Test family {id}",
+            import_id=f"family_{id}",
+            description="Test family",
+            corpus=corpus,
+            concepts=[
+                {
+                    "id": "test concepts 1",
+                    "ids": [],
+                    "type": "legal_entity",
+                    "relation": "jurisdiction",
+                    "preferred_label": "test concept 1",
+                },
+                {
+                    "id": "test concepts 2",
+                    "ids": [],
+                    "type": "legal_entity",
+                    "relation": "jurisdiction",
+                    "preferred_label": "test concept 2",
+                },
+            ],
+            unparsed_slug=[
+                Slug(
+                    name=f"test-family-{id}",
+                    family_import_id=f"family_{id}",
+                    family_document_import_id=None,
+                    collection_import_id=None,
+                )
+            ],
+            unparsed_geographies=[],
+            family_category="Legislative",
+            unparsed_metadata=FamilyMetadata(
+                family_import_id=f"family_{id}",
+                value={
+                    "topic": ["Adaptation"],
+                    "hazard": [
+                        "Heat Waves And Heat Stress",
+                        "Storms",
+                        "Floods",
+                        "Droughts",
+                        "Sea Level Rise",
+                    ],
+                    "sector": [
+                        "Agriculture",
+                        "Energy",
+                        "Health",
+                        "LULUCF",
+                        "Tourism",
+                        "Transport",
+                        "Water",
+                    ],
+                    "keyword": ["Adaptation"],
+                    "framework": ["Adaptation"],
+                    "instrument": [
+                        "Research & Development, knowledge generation|Information"
+                    ],
+                },
+            ),
+            unparsed_events=[
+                FamilyEvent(
+                    import_id=f"event_{id}_1",
+                    title="Law passed",
+                    date=datetime.fromisoformat("2016-12-01T00:00:00+00:00"),
+                    event_type_name="Passed/Approved",
+                    status="OK",
+                ),
+                FamilyEvent(
+                    import_id=f"event_{id}_2",
+                    title="National Implementation Programme on Climate Adaptation (NUPKA)",
+                    date=datetime.fromisoformat("2023-11-17T00:00:00+00:00"),
+                    event_type_name="Updated",
+                    status="OK",
+                ),
+            ],
+        )
+
+        return (corpus, physical_document, family_document, family)
+
+    return _make_family
 
 
 # Mostly inspired by
@@ -67,145 +200,9 @@ def test_read_family_404(client: TestClient):
     assert response.status_code == 404  # nosec B101
 
 
-def test_read_family_200(client: TestClient, session: Session):
-    organisation = Organisation(id=123, name="Test Org")
-    corpus = Corpus(
-        import_id="corpus_1",
-        title="Test Corpus",
-        organisation=organisation,
-        organisation_id=organisation.id,
-        corpus_type_name="Intl. agreements",
-    )
-    physical_document = PhysicalDocument(
-        id=123,
-        title="Test Physical Document",
-        source_url="https://example.com/test-physical-document",
-        md5_sum="test_md5_sum",
-        cdn_object="https://cdn.example.com/test-physical-document",
-        content_type="application/pdf",
-    )
-    family_document = FamilyDocument(
-        import_id="family_document_1",
-        variant_name="MAIN",
-        family_import_id="family_123",
-        physical_document_id=123,
-        valid_metadata={
-            "title": "Test Family Document",
-            "slug": "test-family-document",
-            "corpus": "Test Corpus",
-            "corpus_id": "corpus_1",
-            "type": "Legislative",
-            "status": "Active",
-            "language": ["en"],
-            "jurisdiction": ["DE", "FR"],
-        },
-        unparsed_events=[
-            FamilyEvent(
-                import_id="family_document_event_1",
-                title="Family event 1",
-                date=datetime.fromisoformat("2016-12-01T00:00:00+00:00"),
-                event_type_name="Passed/Approved",
-                status="OK",
-            ),
-            FamilyEvent(
-                import_id="family_document_event_2",
-                title="Family event 2",
-                date=datetime.fromisoformat("2023-11-17T00:00:00+00:00"),
-                event_type_name="Updated",
-                status="OK",
-            ),
-        ],
-    )
-    family = Family(
-        title="Test family",
-        import_id="family_123",
-        description="Test family",
-        corpus=corpus,
-        concepts=[
-            {
-                "id": "test concepts 1",
-                "ids": [],
-                "type": "legal_entity",
-                "relation": "jurisdiction",
-                "preferred_label": "test concept 1",
-            },
-            {
-                "id": "test concepts 2",
-                "ids": [],
-                "type": "legal_entity",
-                "relation": "jurisdiction",
-                "preferred_label": "test concept 2",
-            },
-        ],
-        unparsed_slug=[
-            Slug(
-                name="test-family",
-                family_import_id="family_123",
-                family_document_import_id=None,
-                collection_import_id=None,
-            )
-        ],
-        unparsed_geographies=[
-            Geography(
-                id=1,
-                slug="germany",
-                value="DE",
-                display_value="Germany",
-                type="ISO 3166-1",
-            ),
-            Geography(
-                id=2,
-                slug="france",
-                value="FR",
-                display_value="France",
-                type="ISO 3166-1",
-            ),
-        ],
-        family_category="Legislative",
-        unparsed_metadata=FamilyMetadata(
-            family_import_id="family_123",
-            value={
-                "topic": ["Adaptation"],
-                "hazard": [
-                    "Heat Waves And Heat Stress",
-                    "Storms",
-                    "Floods",
-                    "Droughts",
-                    "Sea Level Rise",
-                ],
-                "sector": [
-                    "Agriculture",
-                    "Energy",
-                    "Health",
-                    "LULUCF",
-                    "Tourism",
-                    "Transport",
-                    "Water",
-                ],
-                "keyword": ["Adaptation"],
-                "framework": ["Adaptation"],
-                "instrument": [
-                    "Research & Development, knowledge generation|Information"
-                ],
-            },
-        ),
-        unparsed_events=[
-            FamilyEvent(
-                import_id="event_1",
-                title="Law passed",
-                date=datetime.fromisoformat("2016-12-01T00:00:00+00:00"),
-                event_type_name="Passed/Approved",
-                status="OK",
-            ),
-            FamilyEvent(
-                import_id="event_2",
-                title="National Implementation Programme on Climate Adaptation (NUPKA)",
-                date=datetime.fromisoformat("2023-11-17T00:00:00+00:00"),
-                event_type_name="Updated",
-                status="OK",
-            ),
-        ],
-    )
+def test_read_family_200(client: TestClient, session: Session, make_family):
+    (corpus, family, family_document, physical_document) = make_family(123)
+
     session.add(corpus)
     session.add(family)
     session.add(family_document)
@@ -219,3 +216,34 @@ def test_read_family_200(client: TestClient, session: Session):
     assert response.status_code == 200  # nosec B101
     response = APIItemResponse[FamilyPublic].model_validate(response.json())
     assert response.data.import_id == "family_123"  # nosec B101
+
+
+def test_read_family_corpus_import_id_filter(
+    client: TestClient, session: Session, make_family
+):
+    (corpus1, family1, family_document1, physical_document1) = make_family(1)
+    (corpus2, family2, family_document2, physical_document2) = make_family(2)
+
+    session.add(corpus1)
+    session.add(family1)
+    session.add(family_document1)
+    session.add(physical_document1)
+
+    session.add(corpus2)
+    session.add(family2)
+    session.add(family_document2)
+    session.add(physical_document2)
+
+    session.commit()
+
+    # joins on OR
+    response1 = client.get(
+        f"/families/?corpus.import_id={corpus1.import_id}&corpus.import_id={corpus2.import_id}"
+    )
+    assert response1.status_code == 200  # nosec B101
+    data1 = APIListResponse[FamilyPublic].model_validate(response1.json())
+    assert len(data1.data) == 2
+
+    response2 = client.get(f"/families/?corpus.import_id={corpus1.import_id}")
+    data2 = APIListResponse[FamilyPublic].model_validate(response2.json())
+    assert len(data2.data) == 1


### PR DESCRIPTION
# Description

Implements an `OR` query for `corpus.import_id` on the `read_families` endpoint.

This will allow us to then cross reference whether we have families for certain `geos` on the frontend once we have implemented to `geos` filter.

In short the filters will work like

```
corpus.import_id=1&corpus.import_id=2&geography.id=US-CAL&geography.id=AUS

(corpus.import_id=1 OR corpus.import_id=2) AND (geography.id=USA OR geography=US-CAL OR geography.id=AUS)
```

Which could be broken down into and run in this order
- all filters with the same name are joined with `OR`
- all ☝️ filters are joined by `AND`

This will get us all the way we need to for litigation.

---

### Longer term thinking

@annaCPR and I had a great discussion around designing our filters and thought there is more we could do - but this would be the simplest and easiest to back out of.

We spoke about
- more support for logical operators like `gt`, `lt` etc
- this lead to more chat about using specs like
  - https://jsonapi.org/format/#query-parameters-families
  - https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part2-url-conventions.html#_Toc31360955
  - https://django-filter.readthedocs.io/en/stable/
  - https://github.com/arthurio/fastapi-filter
- It also got us talking about DSLs that support this out the box like GrpahQL

**Conclusion: We had decided that keeping it simple for now but with an eye on created a _standard_ way of accessing all our APIs would be beneficial not only to access but to us creating them** 



