### PR TITLE
Make subconcept of optional

### DIFF
--- a/geographies-api/app/router.py
+++ b/geographies-api/app/router.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Annotated, TypeVar, cast
+from typing import TypeVar, cast
 
 import pycountry
 from fastapi import APIRouter, HTTPException, Path, Query


### PR DESCRIPTION
# Description

Makes `subconcept_of` optional so you can get a full list of geographies.

Unlike: https://api.climatepolicyradar.org/geographies/

```json
{
    "detail": [
        {
            "type": "missing",
            "loc": [
                "query",
                "subconcept_of"
            ],
            "msg": "Field required",
            "input": null
        }
    ]
}
```