### PR TITLE
feat: add subconcept_of to Subdivision

### DIFF
--- a/geographies-api/app/model.py
+++ b/geographies-api/app/model.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import Generic, Literal, Optional, TypeVar
 
-from pydantic import BaseModel, Field, computed_field
+from pydantic import BaseModel, computed_field
 from slugify import slugify
 from sqlmodel import SQLModel
 
@@ -125,7 +125,7 @@ class Country(GeographyV2Base):
 class Subdivision(GeographyV2Base):
     type: Literal["subdivision"] = "subdivision"
 
-    subconcept_of: list["Country"] = Field(default_factory=list, exclude=True)
+    subconcept_of: list["Country"] = []
 
     @computed_field
     @property


### PR DESCRIPTION
# Description

- moves the logic as to whether to display fields or not to the router
- makes `subconcept_of` exclude on Subdivision on the list route
- let's `subconcept_of` render on the item route

## example response

```json
{
    "data": {
        "id": "US-CA",
        "name": "California",
        "type": "subdivision",
        "subconcept_of": [
            {
                "id": "USA",
                "name": "United States",
                "type": "country",
                "alpha_2": "US",
                "has_subconcept": [],
                "subconcept_of": [],
                "slug": "united-states"
            }
        ],
        "slug": "us-ca"
    }
}
```