### PR TITLE
Feature/app 1056 return list of subdivisions with data

### DIFF
--- a/families-api/app/models.py
+++ b/families-api/app/models.py
@@ -1,5 +1,6 @@
 import logging
 from datetime import datetime, timezone
+from enum import Enum
 from pathlib import Path
 from typing import Any, Optional
 
@@ -391,10 +392,16 @@ class FamilyPublic(FamilyBase):
 
 
 # region: FamilyDocument & PhysicalDocument
+class FamilyDocumentStatus(Enum):
+    CREATED = "created"
+    PUBLISHED = "published"
+    DELETED = "deleted"
+
+
 class FamilyDocumentBase(SQLModel):
     import_id: str = Field(primary_key=True)
     variant_name: str | None
-    document_status: str
+    document_status: FamilyDocumentStatus
 
 
 class FamilyDocument(FamilyDocumentBase, table=True):

--- a/families-api/app/models.py
+++ b/families-api/app/models.py
@@ -394,6 +394,7 @@ class FamilyPublic(FamilyBase):
 class FamilyDocumentBase(SQLModel):
     import_id: str = Field(primary_key=True)
     variant_name: str | None
+    document_status: str
 
 
 class FamilyDocument(FamilyDocumentBase, table=True):

--- a/families-api/app/models.py
+++ b/families-api/app/models.py
@@ -242,9 +242,6 @@ class FamilyBase(SQLModel):
 
 class Family(FamilyBase, table=True):
     __tablename__ = "family"  # type: ignore[assignment]
-    unparsed_geographies: list[Geography] = Relationship(
-        back_populates="families", link_model=FamilyGeographyLink
-    )
     corpus: Corpus = Relationship(
         back_populates="families", link_model=FamilyCorpusLink
     )

--- a/families-api/app/models.py
+++ b/families-api/app/models.py
@@ -392,7 +392,7 @@ class FamilyPublic(FamilyBase):
 
 
 # region: FamilyDocument & PhysicalDocument
-class FamilyDocumentStatus(Enum):
+class FamilyDocumentStatus(str, Enum):
     CREATED = "created"
     PUBLISHED = "published"
     DELETED = "deleted"

--- a/families-api/app/router.py
+++ b/families-api/app/router.py
@@ -17,6 +17,7 @@ from app.models import (
     FamilyCorpusLink,
     FamilyDocument,
     FamilyDocumentPublicWithFamily,
+    FamilyDocumentStatus,
     FamilyGeographyLink,
     FamilyPublic,
     Geography,
@@ -259,19 +260,15 @@ def docs_by_geo(
         default=[],
         alias="corpus.import_id",
     ),
-    document_statuses: list[str] = Query(
+    document_statuses: list[FamilyDocumentStatus] = Query(
         default=[],
-        alias="document.status",
+        alias="document.document_status",
     ),
 ):
     filters = []
     if corpus_import_ids:
-        # We're filtering `Families.corpus` to tell SQLModel to generate the right SQL for filtering.
-        # Direct attribute access e.g. Corpus.import_id doesn't work because the ORM
-        # doesn't auto-join related tables in filters.
         filters.append(Corpus.import_id.in_(corpus_import_ids))  # type: ignore
     if document_statuses:
-        document_statuses = [status.upper() for status in document_statuses]
         filters.append(FamilyDocument.document_status.in_(document_statuses))  # type: ignore
 
     stmt = (

--- a/families-api/app/router.py
+++ b/families-api/app/router.py
@@ -259,6 +259,10 @@ def docs_by_geo(
         default=[],
         alias="corpus.import_id",
     ),
+    document_statuses: list[str] = Query(
+        default=[],
+        alias="document.status",
+    ),
 ):
     filters = []
     if corpus_import_ids:
@@ -266,6 +270,9 @@ def docs_by_geo(
         # Direct attribute access e.g. Corpus.import_id doesn't work because the ORM
         # doesn't auto-join related tables in filters.
         filters.append(Corpus.import_id.in_(corpus_import_ids))  # type: ignore
+    if document_statuses:
+        document_statuses = [status.upper() for status in document_statuses]
+        filters.append(FamilyDocument.document_status.in_(document_statuses))  # type: ignore
 
     stmt = (
         select(

--- a/families-api/app/router.py
+++ b/families-api/app/router.py
@@ -262,7 +262,7 @@ def docs_by_geo(
     ),
     document_statuses: list[FamilyDocumentStatus] = Query(
         default=[],
-        alias="document.document_status",
+        alias="documents.document_status",
     ),
 ):
     filters = []

--- a/families-api/tests/test_main.py
+++ b/families-api/tests/test_main.py
@@ -288,6 +288,83 @@ def test_aggregations_by_geography_returns_a_count_of_documents_per_geography(
     ]
 
 
+def test_aggregations_by_geography_returns_a_count_for_each_geo_when_document_has_multiple_geos(
+    client: TestClient, session: Session
+):
+    organisation = Organisation(id=123, name="Test Org")
+    corpus = Corpus(
+        import_id="corpus_1",
+        title="Test Corpus",
+        organisation=organisation,
+        organisation_id=organisation.id,
+        corpus_type_name="Intl. agreements",
+    )
+    physical_document = PhysicalDocument(
+        id=123,
+        title="Test Physical Document",
+        source_url="https://example.com/test-physical-document",
+        md5_sum="test_md5_sum",
+        cdn_object="https://cdn.example.com/test-physical-document",
+        content_type="application/pdf",
+    )
+    family_document = FamilyDocument(
+        import_id="family_document_1",
+        variant_name="MAIN",
+        family_import_id="family_123",
+        physical_document_id=123,
+        valid_metadata={"title": "Test Family Document"},
+        unparsed_events=[],
+    )
+    family = Family(
+        title="Test family",
+        import_id="family_123",
+        description="Test family",
+        corpus=corpus,
+        concepts=[],
+        unparsed_slug=[],
+        unparsed_geographies=[
+            Geography(
+                id=1,
+                slug="germany",
+                value="DE",
+                display_value="Germany",
+                type="ISO 3166-1",
+            ),
+            Geography(
+                id=2,
+                slug="france",
+                value="FR",
+                display_value="France",
+                type="ISO 3166-1",
+            ),
+        ],
+        family_category="Legislative",
+        unparsed_metadata=FamilyMetadata(
+            family_import_id="family_123",
+            value={
+                "topic": ["Adaptation"],
+            },
+        ),
+        unparsed_events=[],
+    )
+
+    session.add(corpus)
+    session.add(family)
+    session.add(family_document)
+    session.add(physical_document)
+
+    response = client.get("/families/aggregations/by-geography")
+
+    assert response.status_code == 200
+    response = APIListResponse[GeographyDocumentCount].model_validate(response.json())
+    assert len(response.data) == 2
+
+    assert response.data == [
+        GeographyDocumentCount(code="FR", name="France", type="ISO 3166-1", count=1),
+        GeographyDocumentCount(code="DE", name="Germany", type="ISO 3166-1", count=1),
+    ]
+
+
 def test_aggregations_by_geography_does_not_include_geographies_without_documents_in_response(
     client: TestClient, session: Session
 ):

--- a/families-api/tests/test_main.py
+++ b/families-api/tests/test_main.py
@@ -491,7 +491,7 @@ def test_aggregations_by_geography_response_filters_response_by_document_status(
     session.commit()
 
     response = client.get(
-        "/families/aggregations/by-geography?document.document_status=published"
+        "/families/aggregations/by-geography?documents.document_status=published"
     )
     assert response.status_code == 200
     response = APIListResponse[GeographyDocumentCount].model_validate(response.json())
@@ -540,7 +540,7 @@ def test_aggregations_by_geography_response_filters_response_by_multiple_documen
     session.commit()
 
     response = client.get(
-        "/families/aggregations/by-geography?document.document_status=published&document.document_status=created"
+        "/families/aggregations/by-geography?documents.document_status=published&documents.document_status=created"
     )
     assert response.status_code == 200
     response = APIListResponse[GeographyDocumentCount].model_validate(response.json())
@@ -611,7 +611,7 @@ def test_aggregations_by_geography_returns_422_unprocessable_entity_when_documen
     session.commit()
 
     response = client.get(
-        "/families/aggregations/by-geography?document.document_status=invalid"
+        "/families/aggregations/by-geography?documents.document_status=invalid"
     )
 
     assert response.status_code == 422

--- a/families-api/tests/test_main.py
+++ b/families-api/tests/test_main.py
@@ -488,7 +488,7 @@ def test_aggregations_by_geography_response_filtered_by_document_status(
     session.commit()
 
     response = client.get(
-        "/families/aggregations/by-geography?document-status=published"
+        "/families/aggregations/by-geography?document.status=published"
     )
     assert response.status_code == 200
     response = APIListResponse[GeographyDocumentCount].model_validate(response.json())

--- a/families-api/tests/test_models.py
+++ b/families-api/tests/test_models.py
@@ -6,6 +6,7 @@ def test_FamilyDocumentPublic_cdn_object_computed_field_prepends_cdn_url_and_nav
 
     family = FamilyDocumentPublic(
         import_id="123",
+        document_status="CREATED",
         valid_metadata={},
         physical_document=PhysicalDocument(
             id=123,

--- a/families-api/tests/test_models.py
+++ b/families-api/tests/test_models.py
@@ -1,4 +1,4 @@
-from app.models import FamilyDocumentPublic, PhysicalDocument
+from app.models import FamilyDocumentPublic, FamilyDocumentStatus, PhysicalDocument
 from app.settings import settings
 
 
@@ -6,7 +6,7 @@ def test_FamilyDocumentPublic_cdn_object_computed_field_prepends_cdn_url_and_nav
 
     family = FamilyDocumentPublic(
         import_id="123",
-        document_status="CREATED",
+        document_status=FamilyDocumentStatus.CREATED,
         valid_metadata={},
         physical_document=PhysicalDocument(
             id=123,


### PR DESCRIPTION
# Description

- add query parameters to the `/families/aggregations/by-geography` endpoint to allow for filtering by corpus import_id and document status (e.g published)


## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Refactor legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
