### PR TITLE
Geography relationships `subconcept_of` `related_concepts` + refactor

### DIFF
--- a/geographies-api/app/model.py
+++ b/geographies-api/app/model.py
@@ -93,7 +93,6 @@ class GeographyV2Base(BaseModel, Generic[Subconcept]):
     name: str
     statistics: CountryStatisticsResponse | None
 
-    @computed_field
     @property
     def subconcept_of(self) -> list[Subconcept]:
         return []  # default initialisation

--- a/geographies-api/app/model.py
+++ b/geographies-api/app/model.py
@@ -1,25 +1,24 @@
 from enum import Enum
 from typing import Generic, Literal, Optional, TypeVar
 
-from pydantic import BaseModel, computed_field
+from pydantic import BaseModel, Field, computed_field
 from slugify import slugify
-from sqlmodel import SQLModel
 
 APIDataType = TypeVar("APIDataType")
 
 
-class APIResponse(SQLModel, Generic[APIDataType]):
+class APIResponse(BaseModel, Generic[APIDataType]):
     data: list[APIDataType]
     total: int
     page: int
     page_size: int
 
 
-class GeographyBase(SQLModel):
+class GeographyBase(BaseModel):
     id: int
 
 
-class GeographyDocumentCount(SQLModel):
+class GeographyDocumentCount(BaseModel):
     alpha3: str
     name: str
     count: int
@@ -86,10 +85,18 @@ class GeographyType(str, Enum):
     subdivision = "subdivision"
 
 
-class GeographyV2Base(BaseModel):
+Subconcept = TypeVar("Subconcept", bound="GeographyV2Base")
+
+
+class GeographyV2Base(BaseModel, Generic[Subconcept]):
     id: str
     name: str
     statistics: CountryStatisticsResponse | None
+
+    @computed_field
+    @property
+    def subconcept_of(self) -> list[Subconcept]:
+        return []  # default initialisation
 
     # these are currently different / type while we work out how we want to standardise on this
     @computed_field
@@ -100,7 +107,6 @@ class GeographyV2Base(BaseModel):
 
 class Region(GeographyV2Base):
     type: Literal["region"] = "region"
-    subconcept_of: list["Region"] = []
 
     @computed_field
     @property
@@ -108,14 +114,10 @@ class Region(GeographyV2Base):
         return f"{slugify(self.name)}"
 
 
-class Country(GeographyV2Base):
+class Country(GeographyV2Base[Region]):
     type: Literal["country"] = "country"
 
-    alpha_2: str
-    # This language is useful because we use it in multiple ways to express graph/hierarchical data
-    # @see: https://github.com/climatepolicyradar/knowledge-graph/blob/main/src/concept.py#L51-L60
-    has_subconcept: list["Subdivision"] = []
-    subconcept_of: list["Region"] = []
+    alpha_2: str = Field(exclude=True)
 
     @computed_field
     @property
@@ -123,10 +125,10 @@ class Country(GeographyV2Base):
         return f"{slugify(self.name)}"
 
 
-class Subdivision(GeographyV2Base):
+class Subdivision(GeographyV2Base[Country]):
     type: Literal["subdivision"] = "subdivision"
 
-    subconcept_of: list["Country"] = []
+    country_code: str = Field(exclude=True)
 
     @computed_field
     @property

--- a/geographies-api/docker-compose.yml
+++ b/geographies-api/docker-compose.yml
@@ -72,7 +72,7 @@ services:
           sleep 2
         done
         curl -X GET http://localhost:8080/geographies/populate-s3-bucket
-        uv run --project geographies-api pytest geographies-api/ -vvv --color=yes
+        uv run --project geographies-api pytest geographies-api/ -vvv --color=yes -s
       '
     depends_on:
       localstack:

--- a/geographies-api/tests/test_main.py
+++ b/geographies-api/tests/test_main.py
@@ -3,7 +3,6 @@ from fastapi.testclient import TestClient
 
 from app.data.geography_statistics_by_countries import geography_statistics_by_countries
 from app.main import app
-from app.model import APIItemResponse, Geography
 
 client = TestClient(app)
 
@@ -25,10 +24,40 @@ def test_read_geography_statistics(slug: str, expected_statistics: dict | None):
     response = client.get(f"/geographies/{slug}")
 
     assert response.status_code == 200
-    response = APIItemResponse[Geography].model_validate(response.json())
-    statistics = response.data.statistics
+    response_json = response.json()
+    statistics = response_json["data"]["statistics"]
 
     if statistics is None:
         assert expected_statistics is None
     else:
-        assert statistics.model_dump(exclude_none=True) == expected_statistics
+        assert statistics == expected_statistics
+
+
+@pytest.mark.parametrize(
+    ("slug", "has_subconcept_of"),
+    [
+        # There are no subconcepts for regions
+        ("sub-saharan-africa", False),
+        # we do no _currently_ support subconcepts on countries
+        # TODO: add Region `subconcept_of` to Country
+        ("north-america", False),
+        # we do no _currently_ support subconcepts on countries
+        # TODO: add Region `subconcept_of` to Country
+        ("us-ca", True),
+    ],
+)
+def test_read_geography_subconcept(slug: str, has_subconcept_of: bool):
+    list_response = client.get("/geographies/")
+    list_json = list_response.json()
+    geography = next(
+        geography for geography in list_json["data"] if geography["slug"] == slug
+    )
+    assert geography is not None
+    # we should never include the relationship in the list response
+    assert "subconcept_of" not in geography
+
+    # check if we have the subconcept_of in the right place
+    item_response = client.get(f"/geographies/{slug}")
+    item_json = item_response.json()
+    geography = item_json["data"]
+    assert ("subconcept_of" in geography) == has_subconcept_of


### PR DESCRIPTION
# Description
- adds `related_concepts` to `Subdivision`
- refactor: moves the relationships to their own class in the service. This was to avoid overly heavy computation as I was seeing [^1] degraded response time performance
- refactor: uses a more generic type for the list view
- refactor: uses JSON traversal for tests as the `model_validate` was causing issues and not adding much to the test

This tries to encapsulate that we should never return the relationships in the list view, and only on the item view.

[^1]: I would like to get some SLO response time tests in soon