### PR TITLE
Feature/app 1087 refactor latest-published to only return newly added families

### DIFF
--- a/backend-api/app/api/api_v1/routers/families.py
+++ b/backend-api/app/api/api_v1/routers/families.py
@@ -61,7 +61,7 @@ def get_homepage_counts_latest_ingest_cycle(
 
 
 @families_router.get(
-    "/latest_published",
+    "/latest-published",
     summary="Gets five most recently published families.",
 )
 def latest_published(

--- a/backend-api/app/api/api_v1/routers/families.py
+++ b/backend-api/app/api/api_v1/routers/families.py
@@ -16,7 +16,7 @@ from sqlalchemy import func
 from sqlalchemy.orm import lazyload
 
 from app.clients.db.session import get_db
-from app.models.search import LatestUpdatedFamilyResponse
+from app.models.search import LatestFamilyResponse
 from app.repository.family import (
     _convert_to_dto,
     count_families_per_category_per_corpus,
@@ -61,24 +61,24 @@ def get_homepage_counts_latest_ingest_cycle(
 
 
 @families_router.get(
-    "/latest-published",
-    summary="Gets five most recently published families.",
+    "/latest",
+    summary="Gets five most recently added families.",
 )
-def latest_published(
+def latest(
     request: Request,
     app_token: Annotated[str, Header()],
     db=Depends(get_db),
-) -> list[LatestUpdatedFamilyResponse]:
-    """Retrieve the five most recently published families.
+) -> list[LatestFamilyResponse]:
+    """Retrieve the five most recently added families.
 
-    This endpoint returns the latest five published family records,
-    sorted by their modified date in descending order.
+    This endpoint returns the five most recently added family records,
+    sorted by their created date in descending order.
 
     :param Request request: The incoming request object.
     :param Annotated[str, Header()] app_token: App token containing
         the allowed corpora access.
     :param Depends[get_db] db: Database session dependency.
-    :return list[LatestUpdateFamilyResponse]: A list of the five most recently published
+    :return list[LatestFamilyResponse]: A list of the five most recently added
         families.
     """
 
@@ -101,7 +101,7 @@ def latest_published(
         )
 
     _LOGGER.info(
-        "Getting latest published families",
+        "Getting latest families",
         extra={
             "allowed_corpora_ids": allowed_corpora_ids,
         },
@@ -147,21 +147,22 @@ def latest_published(
     families = query.all()
 
     return [
-        to_latest_published_response_family(family, geographies, metadata)
+        to_latest_response_family(family, geographies, metadata)
         for family, geographies, metadata in families
     ]
 
 
-def to_latest_published_response_family(
+def to_latest_response_family(
     family: Family, geographies: list[str], metadata: FamilyMetadata
-) -> LatestUpdatedFamilyResponse:
-    return LatestUpdatedFamilyResponse(
+) -> LatestFamilyResponse:
+    return LatestFamilyResponse(
         import_id=str(family.import_id),
         title=str(family.title),
         description=str(family.description),
         family_category=str(family.family_category),
         published_date=str(family.published_date),  # type: ignore
         last_modified=str(family.last_modified),
+        created=str(family.created),
         metadata=dict(metadata.value),  # type: ignore
         geographies=geographies,
         slugs=[str(slug) for slug in family.slugs] if family.slugs else [],

--- a/backend-api/app/api/api_v1/routers/families.py
+++ b/backend-api/app/api/api_v1/routers/families.py
@@ -139,7 +139,7 @@ def latest_published(
         )
         .filter(geographies_subquery.c.family_import_id == Family.import_id)
         .filter(Corpus.import_id.in_(allowed_corpora_ids))
-        .order_by(Family.last_modified.desc())
+        .order_by(Family.created.desc())
         .limit(5)
         .options(lazyload("*"))
     )

--- a/backend-api/app/models/search.py
+++ b/backend-api/app/models/search.py
@@ -374,7 +374,7 @@ class GeographySummaryFamilyResponse(BaseModel):
     targets: Sequence[str]  # TODO: Placeholder for later
 
 
-class LatestUpdatedFamilyResponse(BaseModel):
+class LatestFamilyResponse(BaseModel):
     """Response model for the latest updated families endpoint."""
 
     model_config = ConfigDict(use_attribute_docstrings=True)
@@ -391,6 +391,8 @@ class LatestUpdatedFamilyResponse(BaseModel):
     """The date the family was published."""
     last_modified: str
     """The date the family was last modified."""
+    created: str
+    """The date the family was created."""
     metadata: dict[str, Any]
     """Metadata associated with the family."""
     geographies: list[str]

--- a/backend-api/tests/non_search/routers/families/test_latest_published.py
+++ b/backend-api/tests/non_search/routers/families/test_latest_published.py
@@ -27,7 +27,7 @@ def test_endpoint_does_not_return_unpublished_families(
 
     add_families(data_db, families=[family_data])
     response = data_client.get(
-        "/api/v1/latest_published", headers={"app-token": valid_token}
+        "/api/v1/latest-published", headers={"app-token": valid_token}
     )
 
     assert response.status_code == 200
@@ -44,7 +44,7 @@ def test_endpoint_returns_five_families(data_client, data_db, valid_token):
     assert len(all_families) > 5
 
     response = data_client.get(
-        "/api/v1/latest_published", headers={"app-token": valid_token}
+        "/api/v1/latest-published", headers={"app-token": valid_token}
     )
 
     assert response.status_code == 200
@@ -128,7 +128,7 @@ def test_returns_families_within_token_corpora(data_client, data_db, monkeypatch
     # Create a token that includes only one corpus
     token = create_token(monkeypatch)
 
-    response = data_client.get("/api/v1/latest_published", headers={"app-token": token})
+    response = data_client.get("/api/v1/latest-published", headers={"app-token": token})
 
     assert response.status_code == 200
     families = response.json()

--- a/backend-api/tests/non_search/routers/families/test_latest_published.py
+++ b/backend-api/tests/non_search/routers/families/test_latest_published.py
@@ -26,9 +26,7 @@ def test_endpoint_does_not_return_unpublished_families(
     }
 
     add_families(data_db, families=[family_data])
-    response = data_client.get(
-        "/api/v1/latest-published", headers={"app-token": valid_token}
-    )
+    response = data_client.get("/api/v1/latest", headers={"app-token": valid_token})
 
     assert response.status_code == 200
     assert isinstance(response.json(), list)
@@ -43,9 +41,7 @@ def test_endpoint_returns_five_families(data_client, data_db, valid_token):
     # Make sure we have more than 5 families in the DB
     assert len(all_families) > 5
 
-    response = data_client.get(
-        "/api/v1/latest-published", headers={"app-token": valid_token}
-    )
+    response = data_client.get("/api/v1/latest", headers={"app-token": valid_token})
 
     assert response.status_code == 200
 
@@ -58,6 +54,7 @@ def test_endpoint_returns_five_families(data_client, data_db, valid_token):
         "family_category",
         "published_date",
         "last_modified",
+        "created",
         "metadata",
         "geographies",
         "slugs",
@@ -88,7 +85,7 @@ def create_token(monkeypatch):
 
 
 def test_returns_families_within_token_corpora(data_client, data_db, monkeypatch):
-    """Test that the latest_published endpoint returns families within the token corpora."""
+    """Test that the latest endpoint returns families within the token corpora."""
 
     corpus = setup_new_corpus(
         data_db,
@@ -128,7 +125,7 @@ def test_returns_families_within_token_corpora(data_client, data_db, monkeypatch
     # Create a token that includes only one corpus
     token = create_token(monkeypatch)
 
-    response = data_client.get("/api/v1/latest-published", headers={"app-token": token})
+    response = data_client.get("/api/v1/latest", headers={"app-token": token})
 
     assert response.status_code == 200
     families = response.json()


### PR DESCRIPTION
# Description

- refactor the `/latest_published` endpoint to only return newly added families

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Refactor legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
