### PR TITLE
feat: remove ref: main from deploy to staging:

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -22,8 +22,6 @@ jobs:
       name: staging
     steps:
       - uses: actions/checkout@v5
-        with:
-          ref: main
 
       - name: Configure AWS credentials (staging)
         uses: aws-actions/configure-aws-credentials@v4.1.0


### PR DESCRIPTION
## What
removes the restriction of checking out `main` on deploy to staging

## why

This will allow us to deploy any branch to staging 