### PR TITLE
feat: add corpus_type to families response

### DIFF
--- a/families-api/app/models.py
+++ b/families-api/app/models.py
@@ -28,6 +28,28 @@ class Organisation(SQLModel, table=True):
 
 # endregion
 
+# region: CorpusType
+
+
+class BaseCorpusType(SQLModel):
+    name: str
+    description: str
+
+
+class CorpusType(BaseCorpusType, table=True):
+    __tablename__ = "corpus_type"  # type: ignore[assignment]
+    name: str = Field(primary_key=True)
+    valid_metadata: dict[str, Any] = Field(
+        default_factory=dict, sa_column=Column(JSONB)
+    )
+
+
+class CorpusTypePublic(BaseCorpusType):
+    pass
+
+
+# endregion
+
 
 # region: Corpus
 class FamilyCorpusLink(SQLModel, table=True):
@@ -50,10 +72,13 @@ class Corpus(CorpusBase, table=True):
     )
     organisation: Organisation = Relationship(back_populates="corpora")
     organisation_id: int = Field(foreign_key="organisation.id")
+    corpus_type: CorpusType = Relationship()
+    corpus_type_name: str = Field(foreign_key="corpus_type.name")
 
 
 class CorpusPublic(CorpusBase):
     organisation: Organisation
+    corpus_type: CorpusTypePublic
 
 
 # endregion


### PR DESCRIPTION
# Description

Adds `CorpusType` to the `/families` response and tests.

The tests on the `test_read_family_200` validates this as it does a `model_validate`.

```json
{
    "import_id": "CCLW.family.10882.0",
    "title": "Minister of Industry Decree No. 27/2020 on Specifications, Development of Roadmaps, and Provisions to Calculate the Domestic Component Standards for Domestic Battery Electric Vehicles (BEV)",
    "concepts": [],
    "corpus": {
        "import_id": "CCLW.corpus.i00000001.n0000",
        "title": "CCLW national policies",
        "corpus_type_name": "Laws and Policies",
        "organisation": {
            "name": "CCLW",
            "id": 1,
            "attribution_url": null
        },
        "corpus_type": {
            "name": "Laws and Policies",
            "description": "Laws and policies"
        }
    }
}
```