### PR TITLE
feat: hack the slugbar, slug the hackbar

### DIFF
--- a/families-api/pyproject.toml
+++ b/families-api/pyproject.toml
@@ -12,6 +12,8 @@ dependencies = [
   "pulumi>=3.166.0,<4.0.0",
   "pulumi-aws>=6.78.0,<7.0.0",
   "api",
+  "pycountry>=24.6.1",
+  "python-slugify>=8.0.4",
 ]
 
 [tool.uv.sources]

--- a/geographies-api/app/data/country_id_to_slugs_hack.py
+++ b/geographies-api/app/data/country_id_to_slugs_hack.py
@@ -1,0 +1,23 @@
+# these are values that were generated in our RDS DB that we need to maintain until we have a better strategy
+# for how we refernce our entities via APIs e.g. IDs
+country_id_to_slugs_hack = {
+    "MDA": "moldova",
+    "IRN": "iran",
+    "SYR": "syria",
+    "ESH": "sahrawi-republic",
+    "TZA": "tanzania",
+    "BOL": "bolivia",
+    "VEN": "venezuela",
+    "KOR": "south-korea",
+    "TWN": "taiwan",
+    "VNM": "vietnam",
+    "BHS": "bahamas-the",
+    "COD": "democratic-republic-of-congo",
+    "FSM": "micronesia",
+    "MKD": "north-macedonia-republic-of-north-macedonia",
+    "PRK": "korea-north",
+    "PSE": "palestine",
+    "RUS": "russia",
+    "TUR": "turkey",
+    "USA": "united-states-of-america",
+}

--- a/geographies-api/app/model.py
+++ b/geographies-api/app/model.py
@@ -4,6 +4,8 @@ from typing import Generic, Literal, Optional, TypeVar
 from pydantic import BaseModel, Field, computed_field
 from slugify import slugify
 
+from app.data.country_id_to_slugs_hack import country_id_to_slugs_hack
+
 APIDataType = TypeVar("APIDataType")
 
 
@@ -121,6 +123,8 @@ class Country(GeographyV2Base[Region]):
     @computed_field
     @property
     def slug(self) -> str:
+        if self.id in country_id_to_slugs_hack:
+            return country_id_to_slugs_hack[self.id]
         return f"{slugify(self.name)}"
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -324,7 +324,9 @@ dependencies = [
     { name = "psycopg2" },
     { name = "pulumi" },
     { name = "pulumi-aws" },
+    { name = "pycountry" },
     { name = "pydantic-settings" },
+    { name = "python-slugify" },
     { name = "sqlmodel" },
 ]
 
@@ -340,7 +342,9 @@ requires-dist = [
     { name = "psycopg2", specifier = ">=2.9.10,<3.0.0" },
     { name = "pulumi", specifier = ">=3.166.0,<4.0.0" },
     { name = "pulumi-aws", specifier = ">=6.78.0,<7.0.0" },
+    { name = "pycountry", specifier = ">=24.6.1" },
     { name = "pydantic-settings", specifier = ">=2.9.1,<3.0.0" },
+    { name = "python-slugify", specifier = ">=8.0.4" },
     { name = "sqlmodel", specifier = ">=0.0.24,<0.1.0" },
 ]
 


### PR DESCRIPTION
# Description

Adds the slugs that differ from `slugify(country.alpha_3)` to a hack list that we will support until we work out a better way forward on removing slugs.

This hack we moved to the edge of the frontend app, but the hack there [was getting messy and leaky](https://github.com/climatepolicyradar/navigator-frontend/pull/779).

The fix for this is also going to have to be in the API - so best have the hack here. 