### PR TITLE
refactor: strip down the response endpoint

### DIFF
--- a/backend-api/app/models/search.py
+++ b/backend-api/app/models/search.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, List, Literal, Mapping, Optional, Sequence
+from typing import List, Literal, Mapping, Optional, Sequence
 
 from cpr_sdk.models.search import Concept
 from cpr_sdk.models.search import SearchParameters as CprSdkSearchParameters
@@ -375,7 +375,7 @@ class GeographySummaryFamilyResponse(BaseModel):
 
 
 class LatestFamilyResponse(BaseModel):
-    """Response model for the latest updated families endpoint."""
+    """Response model for the latest created families endpoint."""
 
     model_config = ConfigDict(use_attribute_docstrings=True)
 
@@ -383,22 +383,10 @@ class LatestFamilyResponse(BaseModel):
     """The import ID of the family."""
     title: str
     """The title of the family."""
-    description: str
-    """The description of the family."""
-    family_category: str
-    """The category of the family."""
-    published_date: str
-    """The date the family was published."""
-    last_modified: str
-    """The date the family was last modified."""
     created: str
     """The date the family was created."""
-    metadata: dict[str, Any]
-    """Metadata associated with the family."""
-    geographies: list[str]
-    """List of geographies associated with the family."""
-    slugs: list[str]
-    """List of slugs associated with the family."""
+    slug: str | None
+    """The latest slug of the family."""
 
 
 class BrowseArgs(BaseModel):

--- a/backend-api/tests/non_search/routers/families/test_latest_published.py
+++ b/backend-api/tests/non_search/routers/families/test_latest_published.py
@@ -1,39 +1,18 @@
 from db_client.functions.dfce_helpers import add_families
-from db_client.models.dfce import Family
+from db_client.models.dfce import Family, Slug
 
+from app.api.api_v1.routers.families import get_latest_slug
 from app.service import custom_app
 from app.service.custom_app import AppTokenFactory
 from tests.non_search.setup_helpers import (
     generate_documents,
     setup_new_corpus,
     setup_with_six_families,
+    setup_with_two_docs_one_family,
 )
 
 
-def test_endpoint_does_not_return_unpublished_families(
-    data_client, data_db, valid_token
-):
-    family_data = {
-        "import_id": "CCLW.family.1001.0",
-        "corpus_import_id": "CCLW.corpus.i00000001.n0000",
-        "title": "Fam1",
-        "slug": "FamSlug1",
-        "description": "Summary1",
-        "geography_id": 1,
-        "category": "Executive",
-        "documents": [],
-        "metadata": {},
-    }
-
-    add_families(data_db, families=[family_data])
-    response = data_client.get("/api/v1/latest", headers={"app-token": valid_token})
-
-    assert response.status_code == 200
-    assert isinstance(response.json(), list)
-    assert len(response.json()) == 0
-
-
-def test_endpoint_returns_five_families(data_client, data_db, valid_token):
+def test_endpoint_returns_five_families_as_default(data_client, data_db, valid_token):
     setup_with_six_families(data_db)
 
     all_families = data_db.query(Family).all()
@@ -50,18 +29,43 @@ def test_endpoint_returns_five_families(data_client, data_db, valid_token):
     expected_fields = [
         "import_id",
         "title",
-        "description",
-        "family_category",
-        "published_date",
-        "last_modified",
         "created",
-        "metadata",
-        "geographies",
-        "slugs",
+        "slug",
     ]
 
     for i, family in enumerate(response.json()):
         missing_fields = [field for field in expected_fields if field not in family]
+        family_id = family.get("id", f"index {i}")
+        assert (
+            not missing_fields
+        ), f"Missing fields: {missing_fields} for family {family_id}: {family}"
+
+
+def test_endpoint_returns_families_with_limit_passed(data_client, data_db, valid_token):
+    setup_with_six_families(data_db)
+
+    all_families = data_db.query(Family).all()
+
+    # Make sure we have more than 5 families in the DB
+    assert len(all_families) > 5
+
+    response = data_client.get(
+        "/api/v1/latest?limit=3", headers={"app-token": valid_token}
+    )
+
+    assert response.status_code == 200
+
+    assert len(response.json()) == 3
+
+    expected_fields = [
+        "import_id",
+        "title",
+        "created",
+        "slug",
+    ]
+
+    for i, family in enumerate(response.json()):
+        missing_fields = [field for field in family if field not in expected_fields]
         family_id = family.get("id", f"index {i}")
         assert (
             not missing_fields
@@ -133,3 +137,34 @@ def test_returns_families_within_token_corpora(data_client, data_db, monkeypatch
 
     for family in families:
         assert family["import_id"].startswith("CCLW.family")
+
+
+def test_returns_one_slug_from_slugs(data_db):
+    setup_with_two_docs_one_family(data_db)
+
+    additional_slug = Slug(
+        family_import_id="CCLW.family.1001.0",
+        family_document_import_id=None,
+        name="AdditionalSlug",
+    )
+
+    new_slug = Slug(
+        family_import_id="CCLW.family.1001.0",
+        family_document_import_id=None,
+        name="NewSlug",
+    )
+
+    data_db.add_all([additional_slug, new_slug])
+    data_db.commit()
+
+    data_db.flush()
+
+    family = (
+        data_db.query(Family).filter(Family.import_id == "CCLW.family.1001.0").one()
+    )
+
+    # We can't reliably test that the slug is the latest unless we control the created timestamp
+    # This is not possible in a test environment as all modifications and additions to the test db are ran as one transaction
+    # So we just test that we get a string back from the function after passing the 3 slugs on the family (two we just added and one from setup)
+    assert len(family.slugs) == 3
+    assert isinstance(get_latest_slug(family.slugs), str)


### PR DESCRIPTION
Only send values that we need for the frontend component.

As a drive by add a limit to the request endpoint.

Limit

<img width="916" height="506" alt="Screenshot 2025-09-10 at 11 46 03" src="https://github.com/user-attachments/assets/e3671204-4171-4912-8a77-0ea3084a60b1" />


No limit - default of 5

<img width="936" height="684" alt="Screenshot 2025-09-10 at 11 46 38" src="https://github.com/user-attachments/assets/0c85efa4-317d-4e87-a4a9-6b446d77d94e" />


## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Refactor legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
