### PR TITLE
Remove requirements.txt from .gitignore

### DIFF
--- a/concepts-api/.gitignore
+++ b/concepts-api/.gitignore
@@ -10,7 +10,4 @@ initial-data/*.sql
 initial-data/*.json
 initial-data/*.db
 
-# we want and need this for building the Dockerfile
-!requirements.txt
-
 s3-concepts/

--- a/families-api/.gitignore
+++ b/families-api/.gitignore
@@ -7,6 +7,3 @@ __pycache__
 
 # we never want to commit DB dumps, even though they are provbably public somewhere
 initial-data/*.sql
-
-# we want and need this for building the Dockerfile
-!requirements.txt

--- a/geographies-api/.gitignore
+++ b/geographies-api/.gitignore
@@ -7,6 +7,3 @@ __pycache__
 
 # we never want to commit DB dumps, even though they are provbably public somewhere
 initial-data/*.sql
-
-# we want and need this for building the Dockerfile
-!requirements.txt


### PR DESCRIPTION
No longer needed as requirements.txt has been removed from the codebase.