### PR TITLE
Fix/make searches fast again

### DIFF
--- a/backend-api/app/models/search.py
+++ b/backend-api/app/models/search.py
@@ -151,6 +151,7 @@ class SearchResponseDocumentPassage(BaseModel):
     text_block_page: Optional[int] = None
     text_block_coords: Optional[Sequence[Coord]] = None
     concepts: Optional[Sequence[Concept]] = None
+    block_id_sort_key: Optional[int] = None
 
 
 class SearchResponseFamilyDocument(BaseModel):

--- a/backend-api/app/service/search.py
+++ b/backend-api/app/service/search.py
@@ -384,25 +384,26 @@ def _process_vespa_search_response_families(
                 response_document.document_passage_matches.append(
                     _vespa_passage_hit_to_search_passage(hit)
                 )
-
-                # TODO THIS IS SORTING EVERY LOOP!!!!!!
-                # If there are 50 text passages per document, and 10 documents,
-                # it will sort 500 times.
-                if sort_within_page:
-                    # Updated to use keys from _vespa_passage_hit_to_search_passage
-                    # So we don't need defensive logic here.
-                    response_document.document_passage_matches.sort(
-                        key=lambda x: (
-                            x.text_block_page,
-                            x.block_id_sort_key,
-                        )
-                    )
-
             else:
                 _LOGGER.error(f"Unknown hit type: {type(hit)}")
 
         response_families.append(response_family)
         response_family = None
+
+    # OK NOW lets sort the passages within each document
+
+    if sort_within_page:
+        for response_family in response_families:
+            for response_document in response_family.family_documents:
+                # Updated to use keys from _vespa_passage_hit_to_search_passage
+                # So we don't need defensive logic here.
+                response_document.document_passage_matches.sort(
+                    key=lambda x: (
+                        x.text_block_page,
+                        x.block_id_sort_key,
+                    )
+                )
+
     return response_families
 
 

--- a/backend-api/app/service/search.py
+++ b/backend-api/app/service/search.py
@@ -7,6 +7,7 @@ from cpr_sdk.exceptions import QueryError
 from cpr_sdk.models.search import Document as CprSdkResponseDocument
 from cpr_sdk.models.search import Family as CprSdkResponseFamily
 from cpr_sdk.models.search import Filters as CprSdkKeywordFilters
+from cpr_sdk.models.search import Hit as CprSdkResponseHit
 from cpr_sdk.models.search import Passage as CprSdkResponsePassage
 from cpr_sdk.models.search import SearchParameters
 from cpr_sdk.models.search import SearchResponse as CprSdkSearchResponse
@@ -160,6 +161,86 @@ def _convert_filters(
         return None
 
 
+def _vespa_hit_to_search_response_family(
+    hit: CprSdkResponseHit,
+    vespa_family: CprSdkResponseFamily,
+    db_family: Family,
+    db_family_metadata: FamilyMetadata,
+) -> SearchResponseFamily:
+    """Convert a Vespa hit into a SearchResponseFamily"""
+    return SearchResponseFamily(
+        family_slug=hit.family_slug,
+        family_name=hit.family_name,
+        family_description=hit.family_description or "",
+        family_category=hit.family_category,
+        family_date=(
+            db_family.published_date.isoformat()
+            if db_family.published_date is not None
+            else ""
+        ),
+        family_last_updated_date=(
+            db_family.last_updated_date.isoformat()
+            if db_family.last_updated_date is not None
+            else ""
+        ),
+        family_source=hit.family_source,
+        corpus_import_id=hit.corpus_import_id or "",
+        corpus_type_name=hit.corpus_type_name or "",
+        family_description_match=False,
+        family_title_match=False,
+        total_passage_hits=vespa_family.total_passage_hits,
+        continuation_token=vespa_family.continuation_token,
+        prev_continuation_token=vespa_family.prev_continuation_token,
+        family_documents=[],
+        family_geographies=hit.family_geographies,
+        family_metadata=cast(dict, db_family_metadata.value),
+    )
+
+
+def _vespa_passage_hit_to_search_passage(
+    hit: CprSdkResponsePassage,
+) -> SearchResponseDocumentPassage:
+    return SearchResponseDocumentPassage(
+        text=hit.text_block,
+        text_block_id=hit.text_block_id,
+        text_block_page=hit.text_block_page,
+        text_block_coords=hit.text_block_coords,
+        concepts=hit.concepts,
+    )
+
+
+def _vespa_passage_hit_to_search_familydocument(
+    hit: CprSdkResponsePassage, db_family_document: FamilyDocument
+) -> SearchResponseFamilyDocument:
+    return SearchResponseFamilyDocument(
+        document_title=str(db_family_document.physical_document.title),
+        document_slug=hit.document_slug,
+        document_type=doc_type_from_family_document_metadata(db_family_document),
+        document_source_url=hit.document_source_url,
+        document_url=to_cdn_url(hit.document_cdn_object),
+        document_content_type=hit.document_content_type,
+        document_passage_matches=[],
+    )
+
+
+def _hit_is_missing_required_fields(hit: CprSdkResponseHit) -> bool:
+    return (
+        hit.family_slug is None
+        or hit.document_slug is None
+        or hit.family_name is None
+        or hit.family_category is None
+        or hit.family_source is None
+        or hit.family_geographies is None
+        or hit.family_import_id is None
+    )
+
+
+def _family_is_not_found_or_not_published(
+    fam_tuple: tuple[Family, FamilyMetadata]
+) -> bool:
+    return fam_tuple is None or fam_tuple[0].family_status != FamilyStatus.PUBLISHED
+
+
 def _process_vespa_search_response_families(
     db: Session,
     vespa_families: Sequence[CprSdkResponseFamily],
@@ -169,6 +250,12 @@ def _process_vespa_search_response_families(
 ) -> Sequence[SearchResponseFamily]:
     """
     Process a list of cpr sdk results into a list of SearchResponse Families
+
+    We receive a flat list of hits per family. We have to transform each
+    family into a SearchResponseFamily, with a list of SearchResponseFamilyDocuments, each
+    with a list of SearchResponseDocumentPassages that have been hit. That list may be sorted.
+
+    Only results that have a published family are included in the response.
 
     Note: this function requires that results from the cpr sdk library are grouped
           by family_import_id.
@@ -198,15 +285,13 @@ def _process_vespa_search_response_families(
 
     for vespa_family in vespa_families_to_process:
         db_family_tuple = db_family_lookup.get(vespa_family.id)
-        if db_family_tuple is None:
-            _LOGGER.error(f"Could not locate family with import id '{vespa_family.id}'")
-            continue
-        if db_family_tuple[0].family_status != FamilyStatus.PUBLISHED:
-            _LOGGER.debug(
-                f"Skipping unpublished family with id '{vespa_family.id}' "
-                "in search results"
+
+        if _family_is_not_found_or_not_published(db_family_tuple):
+            _LOGGER.error(
+                f"Skipping unfound or unpublished family with id '{vespa_family.id}' in search results"
             )
             continue
+
         db_family = db_family_tuple[0]
         db_family_metadata = db_family_tuple[1]
 
@@ -214,57 +299,20 @@ def _process_vespa_search_response_families(
         response_document_lookup = {}
 
         for hit in vespa_family.hits:
-            family_import_id = hit.family_import_id
-            if family_import_id is None:
-                _LOGGER.error("Skipping hit with empty family import id")
-                continue
-
-            # Check for all required family/document fields in the hit
-            if (
-                hit.family_slug is None
-                or hit.document_slug is None
-                or hit.family_name is None
-                or hit.family_category is None
-                or hit.family_source is None
-                or hit.family_geographies is None
-            ):
+            if _hit_is_missing_required_fields(hit):
                 _LOGGER.error(
-                    "Skipping hit with empty required family info for import "
-                    f"id: {family_import_id}"
+                    "Skipping hit with empty required family import_id OR info for import "
+                    f"id: {hit.family_import_id}"
                 )
                 continue
 
-            response_family = response_family_lookup.get(family_import_id)
+            response_family = response_family_lookup.get(hit.family_import_id)
             # All hits contain required family info to create response
             if response_family is None:
-                response_family = SearchResponseFamily(
-                    family_slug=hit.family_slug,
-                    family_name=hit.family_name,
-                    family_description=hit.family_description or "",
-                    family_category=hit.family_category,
-                    family_date=(
-                        db_family.published_date.isoformat()
-                        if db_family.published_date is not None
-                        else ""
-                    ),
-                    family_last_updated_date=(
-                        db_family.last_updated_date.isoformat()
-                        if db_family.last_updated_date is not None
-                        else ""
-                    ),
-                    family_source=hit.family_source,
-                    corpus_import_id=hit.corpus_import_id or "",
-                    corpus_type_name=hit.corpus_type_name or "",
-                    family_description_match=False,
-                    family_title_match=False,
-                    total_passage_hits=vespa_family.total_passage_hits,
-                    continuation_token=vespa_family.continuation_token,
-                    prev_continuation_token=vespa_family.prev_continuation_token,
-                    family_documents=[],
-                    family_geographies=hit.family_geographies,
-                    family_metadata=cast(dict, db_family_metadata.value),
+                response_family = _vespa_hit_to_search_response_family(
+                    hit, vespa_family, db_family, db_family_metadata
                 )
-                response_family_lookup[family_import_id] = response_family
+                response_family_lookup[hit.family_import_id] = response_family
 
             if isinstance(hit, CprSdkResponseDocument):
                 response_family.family_description_match = True
@@ -288,29 +336,17 @@ def _process_vespa_search_response_families(
                         )
                         continue
 
-                    response_document = SearchResponseFamilyDocument(
-                        document_title=str(db_family_document.physical_document.title),
-                        document_slug=hit.document_slug,
-                        document_type=doc_type_from_family_document_metadata(
-                            db_family_document
-                        ),
-                        document_source_url=hit.document_source_url,
-                        document_url=to_cdn_url(hit.document_cdn_object),
-                        document_content_type=hit.document_content_type,
-                        document_passage_matches=[],
+                    response_document = _vespa_passage_hit_to_search_familydocument(
+                        hit, db_family_document
                     )
                     response_document_lookup[document_import_id] = response_document
                     response_family.family_documents.append(response_document)
 
                 response_document.document_passage_matches.append(
-                    SearchResponseDocumentPassage(
-                        text=hit.text_block,
-                        text_block_id=hit.text_block_id,
-                        text_block_page=hit.text_block_page,
-                        text_block_coords=hit.text_block_coords,
-                        concepts=hit.concepts,
-                    )
+                    _vespa_passage_hit_to_search_passage(hit)
                 )
+
+                # TODO THIS IS SORTING EVERY LOOP!!!!!!
                 if sort_within_page:
                     response_document.document_passage_matches.sort(
                         key=lambda x: (

--- a/backend-api/tests/search/test_search.py
+++ b/backend-api/tests/search/test_search.py
@@ -1053,8 +1053,14 @@ def test_process_vespa_search_response(
                     ]
                 )
             else:
+                # Update 2025-09-17: text_block_page is now populated by _vespa_passage_hit_to_search_passage
+                # This originally checked for None. I do not know if that is a semantically meaningful check.
+                # I've changed it to check for not None, to capture this new behaviour.
                 assert all(
-                    [pm.text_block_page is None for pm in fd.document_passage_matches]
+                    [
+                        pm.text_block_page is not None
+                        for pm in fd.document_passage_matches
+                    ]
                 )
                 assert all(
                     [pm.text_block_coords is None for pm in fd.document_passage_matches]


### PR DESCRIPTION
# Description

The functionality that processes vespa search results in the search endpoint codepath was pretty tangled and slow. 

I have
- Pulled out a bunch of logic into more atomic functions, to improve readability 
- Improved the caching logic, fixing a bug where in-function lookup tables were being recreated repeatedly
- Moved the logic that defines sort-key data to O(1) runtime on model creation, rather than running every  sort-comparator-function call (O(N^2)) 
- Moved the passage-sorting logic outside of the parsing loop, so it runs once rather than on every insert

## Type of change

Please select the option(s) below that are most relevant:

- [x] Bug fix
- [x] Refactor legacy code

## How Has This Been Tested?

Local tests pass. Haven't been able to smoke test on running system, keen to do that on staging. 

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
