### PR TITLE
fix: add tests for family ordering

### DIFF
--- a/families-api/app/router.py
+++ b/families-api/app/router.py
@@ -6,7 +6,7 @@ from typing import Generic, TypeVar
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 from sqlalchemy import text
-from sqlmodel import Session, SQLModel, func, select
+from sqlmodel import Session, SQLModel, desc, func, select
 
 from app.database import get_session
 from app.models import (
@@ -69,7 +69,11 @@ def read_families(
         filters.append(Family.corpus.has(Corpus.import_id.in_(corpus_import_ids)))  # type: ignore
 
     families = session.exec(
-        Family.eager_loaded_select().offset(offset).limit(10).where(*filters)
+        Family.eager_loaded_select()
+        .order_by(desc(Family.last_modified))
+        .offset(offset)
+        .limit(limit)
+        .where(*filters)
     ).all()
 
     return APIListResponse(

--- a/families-api/tests/test_main.py
+++ b/families-api/tests/test_main.py
@@ -61,10 +61,11 @@ def test_read_families_ordering(client: TestClient, session: Session, make_famil
     response = client.get("/families/")
     assert response.status_code == 200
     response = APIListResponse[FamilyPublic].model_validate(response.json())
+    
     ids = ["family_2", "family_1"]
-
     assert [family.import_id for family in response.data] == ids
 
+    # explicitly update family 1 to be the most recent last_modified
     family1.last_modified = datetime.now()
     session.add(family1)
     session.commit()

--- a/families-api/tests/test_main.py
+++ b/families-api/tests/test_main.py
@@ -61,7 +61,7 @@ def test_read_families_ordering(client: TestClient, session: Session, make_famil
     response = client.get("/families/")
     assert response.status_code == 200
     response = APIListResponse[FamilyPublic].model_validate(response.json())
-    
+
     ids = ["family_2", "family_1"]
     assert [family.import_id for family in response.data] == ids
 

--- a/families-api/tests/test_main.py
+++ b/families-api/tests/test_main.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from fastapi.testclient import TestClient
 from sqlmodel import Session
 
@@ -26,6 +28,53 @@ def test_read_family_200(client: TestClient, session: Session, make_family):
     assert response.status_code == 200
     response = APIItemResponse[FamilyPublic].model_validate(response.json())
     assert response.data.import_id == "family_123"
+
+
+def test_read_families_ordering(client: TestClient, session: Session, make_family):
+    # we order by last_modified
+    (corpus_type1, corpus1, family1, family_document1, physical_document1) = (
+        make_family(1)
+    )
+    (corpus_type2, corpus2, family2, family_document2, physical_document2) = (
+        make_family(2)
+    )
+
+    session.add(corpus_type1)
+    session.add(corpus1)
+    session.add(family1)
+    session.add(family_document1)
+    session.add(physical_document1)
+
+    session.add(corpus_type2)
+    session.add(corpus2)
+    session.add(family2)
+    session.add(family_document2)
+    session.add(physical_document2)
+
+    session.commit()
+
+    # explicitly update the last_modified
+    family2.last_modified = datetime.now()
+    session.add(family2)
+    session.commit()
+
+    response = client.get("/families/")
+    assert response.status_code == 200
+    response = APIListResponse[FamilyPublic].model_validate(response.json())
+    ids = ["family_2", "family_1"]
+
+    assert [family.import_id for family in response.data] == ids
+
+    family1.last_modified = datetime.now()
+    session.add(family1)
+    session.commit()
+
+    response = client.get("/families/")
+    assert response.status_code == 200
+    response = APIListResponse[FamilyPublic].model_validate(response.json())
+
+    updated_ids = ["family_1", "family_2"]
+    assert [family.import_id for family in response.data] == updated_ids
 
 
 def test_aggregations_by_geography_returns_a_count_of_documents_per_geography(


### PR DESCRIPTION
# Description
- adds ordering to the families endpoint as we use `LIMIT` which can lead to unpredictable results

> When using LIMIT, it is important to use an ORDER BY clause that constrains the result rows into a unique order. Otherwise you will get an unpredictable subset of the query's rows. You might be asking for the tenth through twentieth rows, but tenth through twentieth in what ordering? The ordering is unknown, unless you specified ORDER BY.

-- [postgres docs](https://www.postgresql.org/docs/current/queries-limit.html)

[This was discovered while paginating through the API looking for deletions](https://github.com/climatepolicyradar/litigation-data-mapper/pull/93).