### PR TITLE
fix: add attribution URL to corpus

### DIFF
--- a/families-api/app/models.py
+++ b/families-api/app/models.py
@@ -63,11 +63,13 @@ class CorpusBase(SQLModel):
     import_id: str
     title: str
     corpus_type_name: str
+    attribution_url: str | None
 
 
 class Corpus(CorpusBase, table=True):
     __tablename__ = "corpus"  # type: ignore[assignment]
     import_id: str = Field(primary_key=True)
+    attribution_url: str | None
     families: list["Family"] = Relationship(
         back_populates="corpus", link_model=FamilyCorpusLink
     )
@@ -80,6 +82,7 @@ class Corpus(CorpusBase, table=True):
 class CorpusPublic(CorpusBase):
     organisation: Organisation
     corpus_type: CorpusTypePublic
+    attribution_url: str | None
 
 
 # endregion


### PR DESCRIPTION
# Description
- reader `attribution_url` to corpus 

[This was added to the table via the db client here](https://github.com/climatepolicyradar/navigator-db-client/pull/104).

https://linear.app/climate-policy-radar/issue/APP-1259/add-attribution-url-to-families-api