### PR TITLE
Feature/app 1264 update mcf data download columns

### DIFF
--- a/backend-api/app/repository/download.py
+++ b/backend-api/app/repository/download.py
@@ -32,6 +32,8 @@ def get_whole_database_dump(
     """
     if theme and theme.upper() == "CCC":
         filename = "ccc-download.sql"
+    elif theme and theme.upper() == "MCF":
+        filename = "mcf-download.sql"
     else:
         filename = "download.sql"
 

--- a/backend-api/app/repository/sql/mcf-download.sql
+++ b/backend-api/app/repository/sql/mcf-download.sql
@@ -1,4 +1,3 @@
--- Optimised version with improved performance
 WITH
 -- Single CTE for all slug deduplication (family and document)
 recent_slugs AS (

--- a/backend-api/app/repository/sql/mcf-download.sql
+++ b/backend-api/app/repository/sql/mcf-download.sql
@@ -188,8 +188,6 @@ SELECT
     CONCAT(
         :url_base, '/documents/', rs_doc.name
     ) AS "Document URL",
-    INITCAP(d.valid_metadata::JSON #>> '{role,0}') AS "Document Role",
-    INITCAP(d.valid_metadata::JSON #>> '{type,0}') AS "Document Type",
     CASE
         WHEN f.family_category = 'UNFCCC' THEN 'UNFCCC'
         WHEN f.family_category = 'MCF' THEN 'MCF'

--- a/backend-api/app/repository/sql/mcf-download.sql
+++ b/backend-api/app/repository/sql/mcf-download.sql
@@ -188,6 +188,7 @@ SELECT
     CONCAT(
         :url_base, '/documents/', rs_doc.name
     ) AS "Document URL",
+    INITCAP(d.valid_metadata::JSON #>> '{type,0}') AS "Document Type",
     CASE
         WHEN f.family_category = 'UNFCCC' THEN 'UNFCCC'
         WHEN f.family_category = 'MCF' THEN 'MCF'

--- a/backend-api/app/repository/sql/mcf-download.sql
+++ b/backend-api/app/repository/sql/mcf-download.sql
@@ -1,0 +1,219 @@
+-- Optimised version with improved performance
+WITH
+-- Single CTE for all slug deduplication (family and document)
+recent_slugs AS (
+    SELECT DISTINCT ON (
+        COALESCE(family_import_id::TEXT, '')
+        || '|'
+        || COALESCE(family_document_import_id::TEXT, '')
+    )
+        family_import_id,
+        family_document_import_id,
+        name,
+        created
+    FROM slug
+    WHERE family_import_id IS NOT NULL OR family_document_import_id IS NOT NULL
+    ORDER BY
+        COALESCE(family_import_id::TEXT, '')
+        || '|'
+        || COALESCE(family_document_import_id::TEXT, ''),
+        created DESC,
+        ctid DESC
+),
+
+-- Pre-filter families based on corpus membership and document status
+eligible_families AS (
+    SELECT DISTINCT f.import_id
+    FROM family AS f
+    INNER JOIN family_corpus AS fc ON f.import_id = fc.family_import_id
+    INNER JOIN family_document AS fd ON f.import_id = fd.family_import_id
+    WHERE fc.corpus_import_id = ANY(:allowed_corpora_ids)
+      AND fd.document_status = 'PUBLISHED'
+      AND fd.last_modified < :ingest_cycle_start
+),
+
+-- Combine event aggregations
+family_events_agg AS (
+    SELECT
+        fe.family_import_id,
+        -- Event dates calculation (simplified logic)
+        CASE
+            WHEN COUNT(*) FILTER (
+                WHERE fe.event_type_name
+                = (fe.valid_metadata -> 'datetime_event_name' ->> 0)
+            ) > 0 THEN
+                MIN(CASE
+                    WHEN
+                        fe.event_type_name
+                        = (fe.valid_metadata -> 'datetime_event_name' ->> 0)
+                    THEN fe.date::TIMESTAMPTZ
+                END)
+            ELSE MIN(fe.date::TIMESTAMPTZ)
+        END AS published_date,
+        MAX(fe.date::DATE) AS last_changed,
+        -- Event timeline aggregations
+        STRING_AGG(fe.import_id, ';') AS event_import_ids,
+        STRING_AGG(fe.title, ';') AS event_titles,
+        STRING_AGG(fe.event_type_name, ';') AS event_type_names,
+        STRING_AGG(fe.date::DATE::TEXT, ';') AS event_dates
+    FROM family_event AS fe
+    INNER JOIN eligible_families AS ef ON fe.family_import_id = ef.import_id
+    GROUP BY fe.family_import_id
+),
+
+-- Geography aggregation
+family_geo_agg AS (
+    SELECT
+        fg.family_import_id,
+        STRING_AGG(g.value, ';') AS geo_isos,
+        STRING_AGG(g.display_value, ';') AS geo_display_values
+    FROM family_geography AS fg
+    INNER JOIN geography AS g ON fg.geography_id = g.id
+    INNER JOIN eligible_families AS ef ON fg.family_import_id = ef.import_id
+    GROUP BY fg.family_import_id
+),
+
+-- Collection aggregation
+family_collections_agg AS (
+    SELECT
+        cf.family_import_id,
+        STRING_AGG(c.import_id, ';') AS collection_import_ids,
+        STRING_AGG(c.title, ';') AS collection_titles,
+        STRING_AGG(c.description, ';') AS collection_descriptions
+    FROM collection_family AS cf
+    INNER JOIN collection AS c ON cf.collection_import_id = c.import_id
+    INNER JOIN eligible_families AS ef ON cf.family_import_id = ef.import_id
+    GROUP BY cf.family_import_id
+),
+
+-- Language aggregation
+doc_languages AS (
+    SELECT
+        pd.id,
+        STRING_AGG(l.name, ';' ORDER BY l.name) AS display_name
+    FROM physical_document AS pd
+    LEFT JOIN physical_document_language AS pdl ON pd.id = pdl.document_id
+    LEFT JOIN language AS l ON pdl.language_id = l.id
+    GROUP BY pd.id
+),
+
+-- Pre-compute metadata extractions to avoid repeated JSONB operations
+family_metadata_extracted AS (
+    SELECT
+        fm.family_import_id,
+        ARRAY_TO_STRING(
+            ARRAY(SELECT JSONB_ARRAY_ELEMENTS_TEXT(fm.value -> 'region')),
+            ';'
+        ) AS region,
+        ARRAY_TO_STRING(
+            ARRAY(SELECT JSONB_ARRAY_ELEMENTS_TEXT(fm.value -> 'status')), ';'
+        ) AS status,
+        ARRAY_TO_STRING(
+            ARRAY(SELECT JSONB_ARRAY_ELEMENTS_TEXT(fm.value -> 'project_id')),
+            ';'
+        ) AS project_id,
+        ARRAY_TO_STRING(
+            ARRAY(SELECT JSONB_ARRAY_ELEMENTS_TEXT(fm.value -> 'sector')), ';'
+        ) AS sector,
+        ARRAY_TO_STRING(
+            ARRAY(SELECT JSONB_ARRAY_ELEMENTS_TEXT(fm.value -> 'project_url')),
+            ';'
+        ) AS project_url,
+        ARRAY_TO_STRING(
+            ARRAY(
+                SELECT
+                    JSONB_ARRAY_ELEMENTS_TEXT(fm.value -> 'implementing_agency')
+            ),
+            ';'
+        ) AS implementing_agency,
+        ARRAY_TO_STRING(
+            ARRAY(
+                SELECT
+                    JSONB_ARRAY_ELEMENTS_TEXT(
+                        fm.value -> 'project_value_fund_spend'
+                    )
+            ),
+            ';'
+        ) AS project_value_fund_spend,
+        ARRAY_TO_STRING(
+            ARRAY(
+                SELECT
+                    JSONB_ARRAY_ELEMENTS_TEXT(
+                        fm.value -> 'project_value_co_financing'
+                    )
+            ),
+            ';'
+        ) AS project_value_co_financing
+    FROM family_metadata AS fm
+    INNER JOIN eligible_families AS ef ON fm.family_import_id = ef.import_id
+)
+
+-- Main query with optimised joins
+SELECT
+    rs_doc.name AS "Document ID",
+    p.title AS "Document Title",
+    rs_fam.name AS "Family ID",
+    f.title AS "Family Title",
+    f.description AS "Family Summary",
+    fca.collection_titles AS "Collection Title(s)",
+    fca.collection_descriptions AS "Collection Description(s)",
+    d.variant_name AS "Document Variant",
+    p.source_url AS "Document Content URL",
+    dl.display_name AS "Language",
+    o.name AS "Source",
+    fme.region AS "Region",
+    fga.geo_isos AS "Geography ISOs",
+    fga.geo_display_values AS "Geographies",
+    fme.status AS "Status",
+    fme.implementing_agency AS "Implementing Agency",
+    fme.sector AS "Sector",
+    fme.project_id AS "External Project ID",
+    fme.project_url AS "Project URL",
+    fme.project_value_co_financing
+        AS "Project Value $ (Co-financing)", -- noqa:disable=RF05
+    fme.project_value_fund_spend
+        AS "Project Value $ (Fund Spend)", -- noqa:disable=RF05
+    fea.published_date AS "First event in timeline",
+    fea.last_changed AS "Last event in timeline",
+    fea.event_type_names AS "Full timeline of events (types)",
+    fea.event_dates AS "Full timeline of events (dates)",
+    d.created::DATE AS "Date Added to System",
+    f.last_modified::DATE AS "Last Modified on System",
+    d.import_id AS "Internal Document ID",
+    f.import_id AS "Internal Family ID",
+    fc.corpus_import_id AS "Internal Corpus ID",
+    fca.collection_import_ids AS "Internal Collection ID(s)",
+    CONCAT(
+        :url_base, '/document/', rs_fam.name
+    ) AS "Family URL",
+    CONCAT(
+        :url_base, '/documents/', rs_doc.name
+    ) AS "Document URL",
+    INITCAP(d.valid_metadata::JSON #>> '{role,0}') AS "Document Role",
+    INITCAP(d.valid_metadata::JSON #>> '{type,0}') AS "Document Type",
+    CASE
+        WHEN f.family_category = 'UNFCCC' THEN 'UNFCCC'
+        WHEN f.family_category = 'MCF' THEN 'MCF'
+        ELSE INITCAP(f.family_category::TEXT)
+    END AS "Category"
+FROM family_document AS d
+INNER JOIN physical_document AS p ON d.physical_document_id = p.id
+INNER JOIN family AS f ON d.family_import_id = f.import_id
+INNER JOIN family_corpus AS fc ON f.import_id = fc.family_import_id
+INNER JOIN corpus AS c ON fc.corpus_import_id = c.import_id
+INNER JOIN organisation AS o ON c.organisation_id = o.id
+INNER JOIN
+    family_metadata_extracted AS fme
+    ON f.import_id = fme.family_import_id
+LEFT JOIN family_collections_agg AS fca ON f.import_id = fca.family_import_id
+LEFT JOIN family_geo_agg AS fga ON f.import_id = fga.family_import_id
+LEFT JOIN family_events_agg AS fea ON f.import_id = fea.family_import_id
+LEFT JOIN doc_languages AS dl ON p.id = dl.id
+LEFT JOIN
+    recent_slugs AS rs_doc
+    ON d.import_id = rs_doc.family_document_import_id
+LEFT JOIN recent_slugs AS rs_fam ON f.import_id = rs_fam.family_import_id
+WHERE d.last_modified < :ingest_cycle_start
+  AND fc.corpus_import_id = ANY(:allowed_corpora_ids)
+  AND d.document_status = 'PUBLISHED'
+ORDER BY d.last_modified DESC, d.created DESC, d.ctid DESC, f.import_id ASC;

--- a/backend-api/app/service/download.py
+++ b/backend-api/app/service/download.py
@@ -35,7 +35,6 @@ from app.telemetry import observe
 
 _LOGGER = getLogger(__name__)
 
-
 _CSV_SEARCH_RESPONSE_COLUMNS = [
     "Collection Name",
     "Collection Summary",

--- a/backend-api/app/service/download.py
+++ b/backend-api/app/service/download.py
@@ -35,6 +35,7 @@ from app.telemetry import observe
 
 _LOGGER = getLogger(__name__)
 
+
 _CSV_SEARCH_RESPONSE_COLUMNS = [
     "Collection Name",
     "Collection Summary",
@@ -576,11 +577,9 @@ def convert_dump_to_xlsx(df: pd.DataFrame):
             df_copy[col] = df_copy[col].dt.tz_localize(None)
 
     xlsx_buffer = BytesIO()
-    # There is a known issue with pandas' type stubs and the way that Pyright checks
-    # protocol compatibility for file like objects. Pandas' `WriteExcelBuffer` protocol
-    # is stricter than the actual requirements, and the signature of `truncate` in
-    # `BytesIO` does not match the protocol exactly, so we will ignore the type error.
-    with pd.ExcelWriter(xlsx_buffer, engine="openpyxl") as writer:  # type: ignore
+    # Use XlsxWriter as its lenient with special characters and doesn't require
+    # sanitisation
+    with pd.ExcelWriter(xlsx_buffer, engine="xlsxwriter") as writer:  # type: ignore
         df_copy.to_excel(writer, index=False, sheet_name="Data")
     return xlsx_buffer
 

--- a/backend-api/pyproject.toml
+++ b/backend-api/pyproject.toml
@@ -33,7 +33,6 @@ dependencies = [
   "urllib3<3",
   "apscheduler>=3.10.4",
   "numpy==1.26.4",
-  "openpyxl>=3.1.0",
   "python-dateutil>=2.9.0.post0",
   "opentelemetry-instrumentation-fastapi>=0.54b0",
   "opentelemetry-sdk>=1.33.0",

--- a/backend-api/uv.lock
+++ b/backend-api/uv.lock
@@ -204,7 +204,6 @@ dependencies = [
     { name = "itsdangerous" },
     { name = "json-logging" },
     { name = "numpy" },
-    { name = "openpyxl" },
     { name = "opentelemetry-exporter-otlp" },
     { name = "opentelemetry-instrumentation-fastapi" },
     { name = "opentelemetry-instrumentation-sqlalchemy" },
@@ -258,7 +257,6 @@ requires-dist = [
     { name = "itsdangerous", specifier = ">=2.1.0" },
     { name = "json-logging", specifier = ">=1.3.0" },
     { name = "numpy", specifier = "==1.26.4" },
-    { name = "openpyxl", specifier = ">=3.1.0" },
     { name = "opentelemetry-exporter-otlp", specifier = ">=1.33.0" },
     { name = "opentelemetry-instrumentation-fastapi", specifier = ">=0.54b0" },
     { name = "opentelemetry-instrumentation-sqlalchemy", specifier = ">=0.54b0" },
@@ -638,15 +636,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c", size = 117834, upload-time = "2024-05-23T11:13:57.216Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0", size = 147774, upload-time = "2024-05-23T11:13:55.01Z" },
-]
-
-[[package]]
-name = "et-xmlfile"
-version = "2.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d3/38/af70d7ab1ae9d4da450eeec1fa3918940a5fafb9055e934af8d6eb0c2313/et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54", size = 17234, upload-time = "2024-10-25T17:25:40.039Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa", size = 18059, upload-time = "2024-10-25T17:25:39.051Z" },
 ]
 
 [[package]]
@@ -1401,18 +1390,6 @@ version = "12.8.90"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a2/eb/86626c1bbc2edb86323022371c39aa48df6fd8b0a1647bc274577f72e90b/nvidia_nvtx_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5b17e2001cc0d751a5bc2c6ec6d26ad95913324a4adb86788c944f8ce9ba441f", size = 89954, upload-time = "2025-03-07T01:42:44.131Z" },
-]
-
-[[package]]
-name = "openpyxl"
-version = "3.1.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "et-xmlfile" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/f9/88d94a75de065ea32619465d2f77b29a0469500e99012523b91cc4141cd1/openpyxl-3.1.5.tar.gz", hash = "sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050", size = 186464, upload-time = "2024-06-28T14:03:44.161Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c0/da/977ded879c29cbd04de313843e76868e6e13408a94ed6b987245dc7c8506/openpyxl-3.1.5-py2.py3-none-any.whl", hash = "sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2", size = 250910, upload-time = "2024-06-28T14:03:41.161Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Description

We were hardcoding CCLW corpus specific fields to all of our data download files. This PR splits the MCF data download into its own SQL file for maintainability and driveby updates the excel engine used in the CCC data download logic as it is more forgiving of special characters & encodings, and prevents us needing a separate library (which my previous implementation required).

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Refactor legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
