### PR TITLE
Don't run microservice tests for data in yet

### DIFF
--- a/.github/workflows/merge-to-main.yml
+++ b/.github/workflows/merge-to-main.yml
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        service: [families-api, geographies-api, concepts-api, data-in-pipeline]
+        service: [families-api, geographies-api, concepts-api]
     steps:
       - uses: actions/checkout@v5
       - uses: extractions/setup-just@v3
@@ -84,7 +84,7 @@ jobs:
         environment: [staging, production]
     environment: ${{ matrix.environment }}
     env:
-      SERVICES: families-api geographies-api concepts-api, data-in-pipeline
+      SERVICES: families-api geographies-api concepts-api data-in-pipeline
     steps:
       - uses: actions/checkout@v5
       - uses: extractions/setup-just@v3


### PR DESCRIPTION
# Description

Using the new test job won't work yet because we don't have a docker compose yet, this was left in in the last PR by mistake.

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Refactor legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
