### PR TITLE
fix: Add Just setup for deploying to Prefect

### DIFF
--- a/.github/workflows/merge-to-main.yml
+++ b/.github/workflows/merge-to-main.yml
@@ -111,6 +111,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+      - uses: extractions/setup-just@v3
       - uses: astral-sh/setup-uv@v6
       - name: Sync dependencies
         working-directory: data-in-pipeline


### PR DESCRIPTION
# Description

It's missing, causing this job to fail[^1].

[^1]: https://github.com/climatepolicyradar/navigator-backend/actions/runs/18907348172/job/53969699618

## Type of change

Please select the option(s) below that are most relevant:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Refactor legacy code
- [ ] Dependency update

## How Has This Been Tested?

None. I've used the same setup as done in other jobs.

## Reviewer Checklist

- [x] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [x] The PR represents a single feature (small driveby fixes are also ok)
- [x] The PR includes tests that are sufficient for the level of risk
- [x] The code is sufficiently commented, particularly in hard-to-understand
      areas
- [x] Any required documentation updates have been made
- [x] Any TODOs added are captured in future tickets
- [x] No FIXMEs remain
