### PR TITLE
fix(data-in-pipeline): inline env vars that are not used globally

### DIFF
--- a/data-in-pipeline/justfile
+++ b/data-in-pipeline/justfile
@@ -1,6 +1,3 @@
-AWS_ACCOUNT_ID := `aws sts get-caller-identity --query 'Account' --output text`
-DOCKER_REGISTRY := env_var_or_default("DOCKER_REGISTRY", AWS_ACCOUNT_ID + ".dkr.ecr.eu-west-1.amazonaws.com")
-
 dev:
     uv run python -m app.dev
 
@@ -8,8 +5,20 @@ test:
     uv run pytest -vv
 
 deploy-to-prefect-local:
+    #!/usr/bin/env bash
+    # we use a bash script here to have inline env variables
+    # @see: https://just.systems/man/en/setting-variables-in-a-recipe.html
+    set -euxo pipefail
+    AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query 'Account' --output text)
+    DOCKER_REGISTRY="${AWS_ACCOUNT_ID}.dkr.ecr.eu-west-1.amazonaws.com"
     uv run prefect cloud login
     just deploy-to-prefect
 
 deploy-to-prefect:
-    DOCKER_REGISTRY={{DOCKER_REGISTRY}} uv run python -m app.deploy
+    #!/usr/bin/env bash
+    # we use a bash script here to have inline env variables
+    # @see: https://just.systems/man/en/setting-variables-in-a-recipe.html
+    set -euxo pipefail
+    AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query 'Account' --output text)
+    DOCKER_REGISTRY="${AWS_ACCOUNT_ID}.dkr.ecr.eu-west-1.amazonaws.com"
+    uv run python -m app.deploy


### PR DESCRIPTION
# Description
- [Fixes trying to read aws without a `AWS_PROFILE` being set or configured](https://github.com/climatepolicyradar/navigator-backend/actions/runs/18933640236/job/54055675367)

This has the knock on benefit that we can run things like `just dev`, `just test` without needing to have our AWS creds.

[See just docs for the suggested solution](https://just.systems/man/en/setting-variables-in-a-recipe.html)