### PR TITLE
Migrate to SQLAlchemy v2

### DIFF
--- a/backend-api/app/api/api_v1/routers/summaries.py
+++ b/backend-api/app/api/api_v1/routers/summaries.py
@@ -9,6 +9,7 @@ from typing import Annotated
 
 from db_client.models.dfce import FamilyCategory, Geography
 from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
+from sqlalchemy import select
 
 from app.clients.db.session import get_db
 from app.models.search import BrowseArgs, GeographySummaryFamilyResponse
@@ -54,9 +55,8 @@ def search_by_geography(
         },
     )
 
-    exists = bool(
-        db.query(Geography).filter_by(slug=geography_slug).one_or_none() is not None
-    )
+    stmt = select(Geography).where(Geography.slug == geography_slug)
+    exists = bool(db.execute(stmt).scalar_one_or_none() is not None)
     if not exists:
         msg = (
             f"No geography with slug or country code matching '{geography_slug}' found"

--- a/backend-api/app/repository/corpus_type.py
+++ b/backend-api/app/repository/corpus_type.py
@@ -1,4 +1,5 @@
 from db_client.models.organisation import CorpusType
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 
@@ -10,4 +11,5 @@ def get(db: Session, corpus_type_name: str) -> CorpusType:
     :param corpus_type_name: The name of the corpus type
     :return: A CorpusType object
     """
-    return db.query(CorpusType).filter(CorpusType.name == corpus_type_name).one()
+    stmt = select(CorpusType).where(CorpusType.name == corpus_type_name)
+    return db.execute(stmt).scalar_one()

--- a/backend-api/app/repository/family.py
+++ b/backend-api/app/repository/family.py
@@ -7,7 +7,7 @@ from db_client.models.dfce.family import (
     FamilyCorpus,
     FamilyDocument,
 )
-from sqlalchemy import func
+from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from app.service.util import get_latest_ingest_start
@@ -26,23 +26,28 @@ def count_families_per_category_per_corpus(
     # Subquery to find families with at least one published document
     # Avoid using calculated family_status field for performance reasons
     published_families = (
-        db.query(FamilyDocument.family_import_id)
-        .filter(FamilyDocument.document_status == DocumentStatus.PUBLISHED)
+        select(FamilyDocument.family_import_id)
+        .where(FamilyDocument.document_status == DocumentStatus.PUBLISHED)
         .distinct()
         .subquery()
     )
 
-    query = db.query(Family.family_category, func.count()).join(
-        published_families,
-        published_families.c.family_import_id == Family.import_id,
+    query = (
+        select(Family.family_category, func.count())
+        .select_from(Family)
+        .join(
+            published_families,
+            published_families.c.family_import_id == Family.import_id,
+        )
     )
 
     if allowed_corpora_ids is not None and allowed_corpora_ids != []:
         query = query.join(
             FamilyCorpus, FamilyCorpus.family_import_id == Family.import_id
-        ).filter(FamilyCorpus.corpus_import_id.in_(allowed_corpora_ids))
+        ).where(FamilyCorpus.corpus_import_id.in_(allowed_corpora_ids))
 
-    return query.group_by(Family.family_category).all()
+    query = query.group_by(Family.family_category)
+    return [tuple(row) for row in db.execute(query).all()]
 
 
 def count_families_per_category_per_corpus_latest_ingest_cycle(
@@ -58,14 +63,15 @@ def count_families_per_category_per_corpus_latest_ingest_cycle(
     # Subquery to find families with at least one published document
     # Avoid using calculated family_status field for performance reasons
     published_families = (
-        db.query(FamilyDocument.family_import_id)
-        .filter(FamilyDocument.document_status == DocumentStatus.PUBLISHED)
+        select(FamilyDocument.family_import_id)
+        .where(FamilyDocument.document_status == DocumentStatus.PUBLISHED)
         .distinct()
         .subquery()
     )
 
     query = (
-        db.query(Family.family_category, func.count())
+        select(Family.family_category, func.count())
+        .select_from(Family)
         .join(
             published_families,
             published_families.c.family_import_id == Family.import_id,
@@ -76,13 +82,14 @@ def count_families_per_category_per_corpus_latest_ingest_cycle(
     if allowed_corpora_ids is not None and allowed_corpora_ids != []:
         query = query.join(
             FamilyCorpus, FamilyCorpus.family_import_id == Family.import_id
-        ).filter(FamilyCorpus.corpus_import_id.in_(allowed_corpora_ids))
+        ).where(FamilyCorpus.corpus_import_id.in_(allowed_corpora_ids))
 
     latest_ingest_start = get_latest_ingest_start()
     if latest_ingest_start is not None:
-        query = query.filter(FamilyDocument.last_modified < latest_ingest_start)
+        query = query.where(FamilyDocument.last_modified < latest_ingest_start)
 
-    return query.group_by(Family.family_category).all()
+    query = query.group_by(Family.family_category)
+    return [tuple(row) for row in db.execute(query).all()]
 
 
 def _convert_to_dto(counts: list[tuple[FamilyCategory, int]]) -> dict[str, int]:

--- a/backend-api/app/repository/organisation.py
+++ b/backend-api/app/repository/organisation.py
@@ -1,6 +1,8 @@
 from db_client.models.organisation import Organisation
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 
 def get(db: Session, org_id: int) -> Organisation:
-    return db.query(Organisation).filter(Organisation.id == org_id).one()
+    stmt = select(Organisation).where(Organisation.id == org_id)
+    return db.execute(stmt).scalar_one()

--- a/backend-api/app/repository/user.py
+++ b/backend-api/app/repository/user.py
@@ -1,10 +1,12 @@
 from db_client.models.organisation import AppUser, Organisation, OrganisationUser
 from fastapi import HTTPException
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 
 def get_app_user_by_email(db: Session, email: str) -> AppUser:
-    user = db.query(AppUser).filter(AppUser.email == email).first()
+    stmt = select(AppUser).where(AppUser.email == email)
+    user = db.execute(stmt).scalar_one_or_none()
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
     return user
@@ -13,9 +15,9 @@ def get_app_user_by_email(db: Session, email: str) -> AppUser:
 def get_app_user_authorisation(
     db: Session, app_user: AppUser
 ) -> list[tuple[OrganisationUser, Organisation]]:
-    return (
-        db.query(OrganisationUser, Organisation)
-        .filter(OrganisationUser.appuser_email == app_user.email)
+    stmt = (
+        select(OrganisationUser, Organisation)
+        .where(OrganisationUser.appuser_email == app_user.email)
         .join(Organisation, Organisation.id == OrganisationUser.organisation_id)
-        .all()
     )
+    return [tuple(row) for row in db.execute(stmt).all()]

--- a/backend-api/app/service/health.py
+++ b/backend-api/app/service/health.py
@@ -2,6 +2,7 @@ import logging
 
 from cpr_sdk.search_adaptors import VespaSearchAdapter
 from fastapi import Depends
+from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 from app.clients.db.session import get_db
@@ -20,7 +21,7 @@ def is_rds_online(db: Session) -> bool:
     :rtype: bool
     """
     try:
-        return db.execute("SELECT 1") is not None
+        return db.execute(text("SELECT 1")) is not None
     except Exception as e:
         _LOGGER.error(f"🔴 RDS health check failed: {e}")
         return False

--- a/backend-api/app/service/util.py
+++ b/backend-api/app/service/util.py
@@ -6,6 +6,7 @@ from typing import Any, Optional
 
 from db_client.models import AnyModel
 from fastapi import HTTPException, status
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.clients.aws.client import get_s3_client
@@ -54,7 +55,7 @@ def table_to_json(
 ) -> list[dict]:
     json_out = []
 
-    for row in db.query(table).all():
+    for row in db.execute(select(table)).scalars().all():
         row_object = {col.name: getattr(row, col.name) for col in row.__table__.columns}
         json_out.append(row_object)
 
@@ -68,7 +69,7 @@ def tree_table_to_json(
     json_out = []
     child_list_map: dict[int, Any] = {}
 
-    for row in db.query(table).order_by(table.id).all():
+    for row in db.execute(select(table).order_by(table.id)).scalars().all():
         row_object = {col.name: getattr(row, col.name) for col in row.__table__.columns}
         row_children: list[dict[str, Any]] = []
         child_list_map[row_object["id"]] = row_children

--- a/backend-api/pyproject.toml
+++ b/backend-api/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
   "python-slugify>=6.1.2",
   "requests>=2.32",
   "requests-toolbelt>=1.0.0",
-  "SQLAlchemy>=1.4.31",
+  "SQLAlchemy>=2.0.14",
   "SQLAlchemy-Utils>=0.38.2",
   "starlette==0.40.0",
   "tenacity>=9.0.0",
@@ -52,7 +52,7 @@ dev = [
   "pytest-asyncio>=1.0.0",
   "pytest-mock>=3.14.1",
   "ruff>=0.11.13",
-  "types-SQLAlchemy>=1.4.31",
+  "types-SQLAlchemy>=2.0.0",
   "surrogate>=0.1",
 ]
 

--- a/backend-api/tests/non_search/repository/test_download.py
+++ b/backend-api/tests/non_search/repository/test_download.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta
 
 from db_client.models.dfce.family import Corpus
+from sqlalchemy import select
 
 from app.repository.download import get_whole_database_dump
 from tests.non_search.setup_helpers import setup_with_two_unpublished_docs
@@ -10,7 +11,9 @@ def test_get_whole_db_dump_does_not_return_data_for_documents_that_are_not_publi
     data_db,
 ):
     setup_with_two_unpublished_docs(data_db)
-    all_corpora = [corpus.import_id for corpus in data_db.query(Corpus).all()]
+    all_corpora = [
+        corpus.import_id for corpus in data_db.execute(select(Corpus)).scalars().all()
+    ]
     ingest_cycle_date = (datetime.now() + timedelta(days=1)).strftime("%Y-%m-%d")
 
     db_dump = get_whole_database_dump(

--- a/backend-api/tests/non_search/routers/documents/test_get_document.py
+++ b/backend-api/tests/non_search/routers/documents/test_get_document.py
@@ -3,7 +3,7 @@ from db_client.models.dfce.family import Family, FamilyDocument, FamilyEvent
 from db_client.models.document.physical_document import PhysicalDocumentLanguage
 from fastapi import status
 from fastapi.testclient import TestClient
-from sqlalchemy import update
+from sqlalchemy import func, select, update
 from sqlalchemy.orm import Session
 
 from tests.non_search.routers.documents.setup_doc_fam_lookup import (
@@ -59,8 +59,10 @@ def test_documents_doc_slug_returns_not_found(
     data_client: TestClient, data_db: Session, valid_token
 ):
     setup_with_docs(data_db)
-    assert data_db.query(Family).count() == 1
-    assert data_db.query(FamilyEvent).count() == 1
+    assert data_db.execute(select(func.count()).select_from(Family)).scalar_one() == 1
+    assert (
+        data_db.execute(select(func.count()).select_from(FamilyEvent)).scalar_one() == 1
+    )
 
     # Test associations
     json_response = _make_doc_fam_lookup_request(

--- a/backend-api/tests/non_search/routers/documents/test_get_rds_family.py
+++ b/backend-api/tests/non_search/routers/documents/test_get_rds_family.py
@@ -2,7 +2,7 @@ import pytest
 from db_client.models.dfce.family import Family, FamilyDocument, FamilyEvent
 from fastapi import status
 from fastapi.testclient import TestClient
-from sqlalchemy import update
+from sqlalchemy import func, select, update
 from sqlalchemy.orm import Session
 
 from tests.non_search.routers.documents.setup_doc_fam_lookup import (
@@ -22,8 +22,10 @@ def test_documents_family_slug_returns_not_found(
     data_db: Session, data_client: TestClient, valid_token
 ):
     setup_with_docs(data_db)
-    assert data_db.query(Family).count() == 1
-    assert data_db.query(FamilyEvent).count() == 1
+    assert data_db.execute(select(func.count()).select_from(Family)).scalar_one() == 1
+    assert (
+        data_db.execute(select(func.count()).select_from(FamilyEvent)).scalar_one() == 1
+    )
 
     # Test by slug
     json_response = _make_doc_fam_lookup_request(

--- a/backend-api/tests/non_search/routers/summaries/test_geography_summaries.py
+++ b/backend-api/tests/non_search/routers/summaries/test_geography_summaries.py
@@ -3,6 +3,7 @@ from typing import Optional
 import pytest
 from db_client.models.dfce.family import Family
 from fastapi import status
+from sqlalchemy import select
 
 from tests.non_search.setup_helpers import (
     setup_with_six_families_same_geography,
@@ -102,7 +103,7 @@ def test_endpoint_returns_only_top_5_families_per_category(
 ):
     setup_with_six_families_same_geography(data_db)
 
-    all_families = data_db.query(Family).all()
+    all_families = data_db.execute(select(Family)).unique().scalars().all()
 
     assert len(all_families) > 5
 
@@ -116,7 +117,7 @@ def test_endpoint_returns_only_top_5_families_per_category(
 def test_top_5_families_ordered_by_published_date(data_client, data_db, valid_token):
     setup_with_six_families_same_geography(data_db)
 
-    all_families = data_db.query(Family).all()
+    all_families = data_db.execute(select(Family)).unique().scalars().all()
 
     expected_family_dates = sorted(
         [f.published_date.isoformat() for f in all_families]

--- a/backend-api/tests/non_search/service/pipeline/test_browse_rds_families.py
+++ b/backend-api/tests/non_search/service/pipeline/test_browse_rds_families.py
@@ -1,4 +1,5 @@
 from db_client.models.dfce import Geography
+from sqlalchemy import select
 
 from app.models.search import BrowseArgs
 from app.repository.search import browse_rds_families
@@ -7,7 +8,9 @@ from tests.non_search.setup_helpers import setup_with_two_docs
 
 def test_browse_rds_families(data_db):
     setup_with_two_docs(data_db)
-    geo = data_db.query(Geography).get(1)
+    geo = data_db.execute(
+        select(Geography).where(Geography.id == 1)
+    ).scalar_one_or_none()
     expected = 1
 
     args = BrowseArgs(

--- a/backend-api/tests/search/test_search.py
+++ b/backend-api/tests/search/test_search.py
@@ -25,6 +25,7 @@ from db_client.models.dfce import (
 )
 from db_client.models.document import PhysicalDocument
 from slugify import slugify
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.service.search import (
@@ -910,7 +911,9 @@ def populate_data_db(db: Session, fam_specs: Sequence[FamSpec]) -> None:
                 FamilyGeography(
                     family_import_id=fam_spec.family_import_id,
                     geography_id=(
-                        db.query(Geography).filter(Geography.value == fam_geo).one().id
+                        db.execute(select(Geography).where(Geography.value == fam_geo))
+                        .scalar_one()
+                        .id
                     ),
                 )
             )

--- a/backend-api/tests/unit/app/db/crud/test_get_family_document_and_context.py
+++ b/backend-api/tests/unit/app/db/crud/test_get_family_document_and_context.py
@@ -1,6 +1,7 @@
 from typing import Dict
 
 from db_client.models.dfce import FamilyDocument, FamilyGeography
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.models.document import FamilyDocumentWithContextResponse
@@ -13,11 +14,10 @@ def test_get_family_document_and_context(
     data_db: Session,
 ):
     setup_with_documents_large_with_families(documents_large, data_db)
-    doc = (
-        data_db.query(FamilyDocument)
-        .filter(FamilyDocument.import_id == "CCLW.document.i00000192.n0000")
-        .one()
+    stmt = select(FamilyDocument).where(
+        FamilyDocument.import_id == "CCLW.document.i00000192.n0000"
     )
+    doc = data_db.execute(stmt).unique().scalar_one()
 
     response: FamilyDocumentWithContextResponse = get_family_document_and_context(
         data_db, doc.import_id
@@ -32,11 +32,10 @@ def test_get_family_document_and_context_extra_geog(
     data_db: Session,
 ):
     setup_with_documents_large_with_families(documents_large, data_db)
-    doc = (
-        data_db.query(FamilyDocument)
-        .filter(FamilyDocument.import_id == "CCLW.document.i00000192.n0000")
-        .one()
+    stmt = select(FamilyDocument).where(
+        FamilyDocument.import_id == "CCLW.document.i00000192.n0000"
     )
+    doc = data_db.execute(stmt).unique().scalar_one()
     # add an extra geography
     data_db.add(
         FamilyGeography(

--- a/backend-api/tests/unit/app/service/test_health.py
+++ b/backend-api/tests/unit/app/service/test_health.py
@@ -1,6 +1,7 @@
 from unittest.mock import Mock
 
 import pytest
+from sqlalchemy import text
 from sqlalchemy.exc import SQLAlchemyError
 
 from app.service.health import is_database_online, is_rds_online, is_vespa_online
@@ -12,7 +13,12 @@ def test_is_rds_online_returns_true_when_db_healthy(caplog):
     mock_db.execute.return_value = Mock()
 
     assert is_rds_online(mock_db) is True
-    mock_db.execute.assert_called_once_with("SELECT 1")
+    # Check that execute was called with a text clause containing "SELECT 1"
+    assert mock_db.execute.call_count == 1
+    call_args = mock_db.execute.call_args[0]
+    assert len(call_args) == 1
+    assert isinstance(call_args[0], type(text("SELECT 1")))
+    assert str(call_args[0]) == "SELECT 1"
     assert "🔴 RDS health check failed" not in caplog.text
 
 
@@ -22,7 +28,12 @@ def test_is_rds_online_returns_false_when_db_error(caplog):
     mock_db.execute.side_effect = SQLAlchemyError("Database error")
 
     assert is_rds_online(mock_db) is False
-    mock_db.execute.assert_called_once_with("SELECT 1")
+    # Check that execute was called with a text clause containing "SELECT 1"
+    assert mock_db.execute.call_count == 1
+    call_args = mock_db.execute.call_args[0]
+    assert len(call_args) == 1
+    assert isinstance(call_args[0], type(text("SELECT 1")))
+    assert str(call_args[0]) == "SELECT 1"
     assert "🔴 RDS health check failed: Database error" in caplog.text
 
 

--- a/families-api/app/router.py
+++ b/families-api/app/router.py
@@ -112,7 +112,7 @@ def read_concepts(*, session: Session = Depends(get_session)):
     """
     )
 
-    results = session.connection().execute(stmt).all()
+    results = session.execute(stmt).all()
 
     unique_concepts = [
         ConceptPublic.model_validate(


### PR DESCRIPTION
# Description

SQLAlchemy v1 is approaching end of life. v2 provides better type safety and performance. This migration also allows us to configure our backend-api service as part of the nav backend uv workspace properly, so the language server recognises imports throughout the workspace.

## Key Changes (AI generated)

### 1. Dependency Updates
- **backend-api/pyproject.toml**: Updated `SQLAlchemy>=1.4.31` → `SQLAlchemy>=2.0.14`
- **backend-api/pyproject.toml**: Updated `types-SQLAlchemy>=1.4.31` → `types-SQLAlchemy>=2.0.0`

### 2. Query Pattern Migration

**Before (SQLAlchemy 1.x):**
```python
results = db.query(Model).filter(Model.field == value).all()
count = db.query(Model).count()
```

**After (SQLAlchemy 2.0):**
```python
stmt = select(Model).where(Model.field == value)
results = db.execute(stmt).scalars().all()

stmt = select(func.count()).select_from(Model)
count = db.execute(stmt).scalar_one()
```

### 3. Core API Changes
- Replace `db.query()` with `select()` + `db.execute()`
- Replace `.filter()` with `.where()`
- Replace `.filter_by()` with `.where(Model.field == value)`
- Replace `db.query(Model).get(id)` with `select(Model).where(Model.id == id).scalar_one_or_none()`
- Wrap raw SQL strings with `text()` function
- Add `.unique()` calls for queries that access ORM relationships
- Convert `Row` objects to tuples for type compatibility

### 4. Result Handling

**Single results:**
- `.first()` → `.scalar_one_or_none()`
- `.one()` → `.scalar_one()`
- `.one_or_none()` → `.scalar_one_or_none()`

**Multiple results:**
- `.all()` → `.scalars().all()` (for single ORM objects)
- `.all()` → `.all()` (for tuples/multiple columns)

**Count queries:**
```python
# Before
count = db.query(Model).count()

# After
stmt = select(func.count()).select_from(Model)
count = db.execute(stmt).scalar_one()
```

### 5. Relationship Access
Added `.unique()` to queries where ORM relationships are accessed later to prevent SQLAlchemy 2.0's stricter duplicate row detection:
```python
families = db.execute(stmt).unique().scalars().all()
for family in families:
    slug = family.slugs[0].name  # Accessing relationship
```

### 6. Type Handling
- Converted `Row` objects to tuples where functions return `list[tuple[...]]`
- Updated type annotations to remove `Row[...]` type arguments (not supported)


## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [x] Refactor legacy code
- [x] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
