### PR TITLE
fix(data-in-pipeline): remove env vars from deploy to prefect recipe

### DIFF
--- a/data-in-pipeline/justfile
+++ b/data-in-pipeline/justfile
@@ -12,13 +12,7 @@ deploy-to-prefect-local:
     AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query 'Account' --output text)
     DOCKER_REGISTRY="${AWS_ACCOUNT_ID}.dkr.ecr.eu-west-1.amazonaws.com"
     uv run prefect cloud login
-    just deploy-to-prefect
+    DOCKER_REGISTRY=${DOCKER_REGISTRY} just deploy-to-prefect
 
 deploy-to-prefect:
-    #!/usr/bin/env bash
-    # we use a bash script here to have inline env variables
-    # @see: https://just.systems/man/en/setting-variables-in-a-recipe.html
-    set -euxo pipefail
-    AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query 'Account' --output text)
-    DOCKER_REGISTRY="${AWS_ACCOUNT_ID}.dkr.ecr.eu-west-1.amazonaws.com"
     uv run python -m app.deploy


### PR DESCRIPTION
# Description

- sets the env vars locally, [as we do in CI](https://github.com/climatepolicyradar/navigator-backend/blob/main/.github/workflows/merge-to-main.yml#L124), and then runs the `deploy-to-prefect`

[Fixes the current broken workflow](https://github.com/climatepolicyradar/navigator-backend/actions/runs/19037897386/job/54367708049)