### PR TITLE
fix(data-in-pipeline): unwrap extracted=>identified data

### DIFF
--- a/data-in-pipeline/app/identify/navigator_document.py
+++ b/data-in-pipeline/app/identify/navigator_document.py
@@ -3,6 +3,10 @@ from app.models import Extracted, Identified
 
 
 def identify_navigator_document(
-    extracted_document: Extracted[NavigatorDocument],
+    extracted: Extracted[NavigatorDocument],
 ) -> Identified[NavigatorDocument]:
-    return Identified(data=extracted_document, id=extracted_document.data.import_id)
+    return Identified(
+        data=extracted.data,
+        source=extracted.source,
+        id=extracted.data.import_id,
+    )

--- a/data-in-pipeline/app/identify/navigator_family.py
+++ b/data-in-pipeline/app/identify/navigator_family.py
@@ -3,6 +3,10 @@ from app.models import Extracted, Identified
 
 
 def identify_navigator_family(
-    extracted_document: Extracted[NavigatorFamily],
+    extracted: Extracted[NavigatorFamily],
 ) -> Identified[NavigatorFamily]:
-    return Identified(data=extracted_document, id=extracted_document.data.import_id)
+    return Identified(
+        data=extracted.data,
+        source=extracted.source,
+        id=extracted.data.import_id,
+    )

--- a/data-in-pipeline/app/models.py
+++ b/data-in-pipeline/app/models.py
@@ -17,8 +17,9 @@ class Extracted(BaseModel, Generic[ExtractedData]):
 
 
 class Identified(BaseModel, Generic[ExtractedData]):
-    data: Extracted[ExtractedData]
+    data: ExtractedData
     id: str
+    source: str
 
 
 class Document(BaseModel):


### PR DESCRIPTION
# Description

This unwraps the `Extracted` => `Identified` types.

This just makes it easier to work with in the transformation step which would be

```python
# before
def transform_navigator_document(input: Identified[NavigatorDocument]) -> Document:
  input.data.data.import_id # <= this is a bit cumbersome

# after
def transform_navigator_document(input: Identified[NavigatorDocument]) -> Document:
  input.data.import_id # <= this is a less cumbersome
```
