### PR TITLE
feat(data-in-pipeline): generate_s3_cache_key

### DIFF
--- a/data-in-pipeline/app/navigator_family_etl_pipeline.py
+++ b/data-in-pipeline/app/navigator_family_etl_pipeline.py
@@ -23,9 +23,7 @@ from app.transform.navigator_family import transform_navigator_family
 _LOGGER = logging.getLogger(__name__)
 
 
-def generate_s3_cache_key(
-    step: Literal["extract", "identify", "transform"], flow_run_id: str
-) -> str:
+def generate_s3_cache_key(step: Literal["extract", "identify", "transform"]) -> str:
     flow_run_id = flow_run.get_id() or "flow-run-etl-pipeline-families"
     return f"pipelines/data-in-pipeline/navigator_family/{step}/{flow_run_id}/result_{datetime.now().isoformat()}.json"
 


### PR DESCRIPTION
# What

Based on [this](https://github.com/climatepolicyradar/navigator-backend/pull/810/files#r2518929052) - I thought it might be worth trying to formalise how we structure our S3 directories.

I am not 100% sure about the `result_` - but I am not massively close to what we're trying to achieve.

Generates: https://linear.app/climate-policy-radar/issue/APP-1421/retention-policy-for-s3-specifically-cache-files