### PR TITLE
fix(data-in-pipeline): add relationships to dev duckdb response

### DIFF
--- a/data-in-pipeline/app/scripts/serve_duckdb.py
+++ b/data-in-pipeline/app/scripts/serve_duckdb.py
@@ -1,6 +1,6 @@
 import duckdb
 from fastapi import Depends, FastAPI, HTTPException, Query
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 DB_PATH = ".data_cache/documents.duckdb"
 


### PR DESCRIPTION
# Description

- adds the relationships to the response

While it might seem useful to bring the model we're using in the transformer here, I think they should stay decoupled as this is a dev mechanism and don't want it to affect decisions made on the production model.