### PR TITLE
feat(data-in-pipeline): basic transform_navigator_family_with_litigation_corpus_type

### DIFF
--- a/data-in-pipeline/tests/transform/test_navigator_family.py
+++ b/data-in-pipeline/tests/transform/test_navigator_family.py
@@ -47,6 +47,25 @@ def navigator_family_with_no_matching_transformations() -> Identified[NavigatorF
     )
 
 
+@pytest.fixture
+def navigator_family_with_litigation_corpus_type() -> Identified[NavigatorFamily]:
+    return Identified(
+        id="123",
+        source="navigator_family",
+        data=NavigatorFamily(
+            import_id="123",
+            title="Litigation family",
+            corpus=NavigatorCorpus(import_id="Academic.corpus.Litigation.n0000"),
+            documents=[
+                NavigatorDocument(
+                    import_id="456",
+                    title="Litigation case",
+                ),
+            ],
+        ),
+    )
+
+
 def test_transform_navigator_document_with_single_matching_family(
     navigator_family_with_single_matching_title_document: Identified[NavigatorFamily],
 ):
@@ -92,3 +111,36 @@ def test_no_matching_transformations(
     result_failure = result.failure()
 
     assert isinstance(result_failure, NoMatchingTransformations)
+
+
+def test_transform_navigator_family_with_litigation_corpus_type(
+    navigator_family_with_litigation_corpus_type: Identified[NavigatorFamily],
+):
+    result = transform_navigator_family(navigator_family_with_litigation_corpus_type)
+    assert result == Success(
+        [
+            Document(
+                id="123",
+                title="Litigation family",
+                labels=[
+                    DocumentLabelRelationship(
+                        type="entity_type",
+                        label=Label(
+                            id="Legal case",
+                            title="Legal case",
+                            type="entity_type",
+                        ),
+                    ),
+                    DocumentLabelRelationship(
+                        type="transformer",
+                        label=TransformerLabel(
+                            id="transform_navigator_family_with_litigation_corpus_type",
+                            title="transform_navigator_family_with_litigation_corpus_type",
+                            type="transformer",
+                        ),
+                    ),
+                ],
+                relationships=[],
+            )
+        ]
+    )


### PR DESCRIPTION
# Description

- this work transforms the family => document if it is part of the litigation corpus
- adds `transform_navigator_family_with_litigation_corpus_type` with the initial part being adding a `Label` of `entity_type` with title of `Legal case` to the family

https://linear.app/climate-policy-radar/issue/APP-1457/dip-transformer-family-=-document-transformations