### PR TITLE
fix(families-api): remove indirection of page_size values

### DIFF
--- a/families-api/app/router.py
+++ b/families-api/app/router.py
@@ -24,7 +24,6 @@ from app.models import (
     PhysicalDocument,
     Slug,
 )
-from app.settings import settings
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -55,9 +54,9 @@ def read_families(
     session: Session = Depends(get_session),
     page: int = Query(1, ge=1),
     page_size: int = Query(
-        default=settings.families_default_page_size,
+        default=10,
         ge=1,
-        le=settings.families_max_page_size,
+        le=100,
     ),
     corpus_import_ids: list[str] = Query(
         default=[],

--- a/families-api/app/settings.py
+++ b/families-api/app/settings.py
@@ -6,8 +6,6 @@ class Settings(BaseSettings):
     navigator_database_url: SecretStr
     cdn_url: str
     github_sha: str = "unknown"
-    families_default_page_size: int = 10
-    families_max_page_size: int = 100
 
 
 # pydantic settings are set from the env variables passed in via docker / apprunner


### PR DESCRIPTION
# Description

- removes a level of indirection on values that have been stored in config, but we have no desire to configure AKA they are hardcoded