### PR TITLE
Fix: FINALLY, logs goes to prefect and otel and local console (as app…

### DIFF
--- a/data-in-pipeline/app/bootstrap_telemetry.py
+++ b/data-in-pipeline/app/bootstrap_telemetry.py
@@ -26,10 +26,12 @@ _ROOT_DIR = _APP_DIR.parent
 _SERVICE_MANIFEST_PATH = _ROOT_DIR / "service-manifest.json"
 _PREFECT_LOGGING_CONFIG_PATH = _APP_DIR / "prefect_logging.yaml"
 
+os.environ["OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED"] = "True"
+
 # Set Prefect logging config path
 if _PREFECT_LOGGING_CONFIG_PATH.exists():
     os.environ.setdefault(
-        "PREFECT_LOGGING_CONF_PATH", str(_PREFECT_LOGGING_CONFIG_PATH)
+        "PREFECT_LOGGING_SETTINGS_PATH", str(_PREFECT_LOGGING_CONFIG_PATH)
     )
 
 # Load configuration
@@ -47,62 +49,14 @@ metrics_service = MetricsService(config=_config)
 
 pipeline_metrics = PipelineMetrics(metrics_service=metrics_service)
 
-if telemetry.logger:
-    telemetry.logger.info("Telemetry bootstrap complete for %s", _config.service_name)
-
-    telemetry.logger.info(
-        "OTEL_SERVICE_NAME: " + os.getenv("OTEL_SERVICE_NAME", "not set")
-    )
-    telemetry.logger.info(
-        "OTEL_TRACES_EXPORTER: " + os.getenv("OTEL_TRACES_EXPORTER", "not set")
-    )
-    telemetry.logger.info(
-        "OTEL_METRICS_EXPORTER: " + os.getenv("OTEL_METRICS_EXPORTER", "not set")
-    )
-    telemetry.logger.info(
-        "OTEL_LOGS_EXPORTER: " + os.getenv("OTEL_LOGS_EXPORTER", "not set")
-    )
-    telemetry.logger.info(
-        "OTEL_EXPORTER_OTLP_ENDPOINT: "
-        + os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "not set")
-    )
-    telemetry.logger.info(
-        "OTEL_EXPORTER_OTLP_PROTOCOL: "
-        + os.getenv("OTEL_EXPORTER_OTLP_PROTOCOL", "not set")
-    )
-    telemetry.logger.info(
-        "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: "
-        + os.getenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "not set")
-    )
-    telemetry.logger.info(
-        "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: "
-        + os.getenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "not set")
-    )
-    telemetry.logger.info(
-        "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT: "
-        + os.getenv("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT", "not set")
-    )
-    telemetry.logger.info(
-        "OTEL_PYTHON_LOG_LEVEL: " + os.getenv("OTEL_PYTHON_LOG_LEVEL", "not set")
-    )
-    telemetry.logger.info(
-        "OTEL_RESOURCE_ATTRIBUTES: " + os.getenv("OTEL_RESOURCE_ATTRIBUTES", "not set")
-    )
-    telemetry.logger.info(
-        "PREFECT_CLOUD_ENABLE_ORCHESTRATION_TELEMETRY: "
-        + os.getenv("PREFECT_CLOUD_ENABLE_ORCHESTRATION_TELEMETRY", "not set")
-    )
-    telemetry.logger.info(
-        "PREFECT_LOGGING_LEVEL: " + os.getenv("PREFECT_LOGGING_LEVEL", "not set")
-    )
-    telemetry.logger.info(
-        "PREFECT_LOGGING_EXTRA_LOGGERS: "
-        + os.getenv("PREFECT_LOGGING_EXTRA_LOGGERS", "not set")
-    )
-    telemetry.logger.info(
-        "OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED: "
-        + os.getenv("OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED", "not set")
-    )
+_logger = get_logger()
+_logger.info(
+    "Telemetry bootstrap complete | service=%s env=%s version=%s endpoint=%s",
+    _config.service_name,
+    _ENV,
+    _SERVICE_VERSION,
+    os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "not set"),
+)
 
 
 __all__ = ["telemetry", "get_logger", "metrics_service", "pipeline_metrics"]

--- a/data-in-pipeline/app/deploy.py
+++ b/data-in-pipeline/app/deploy.py
@@ -34,7 +34,7 @@ REQUIRED_RUNTIME_ENVIRONMENT_VARIABLES = (
     (
         # https://docs.prefect.io/v3/api-ref/settings-ref#enabled-2
         "PREFECT_LOGGING_TO_API_ENABLED",
-        False,
+        True,
     ),
     (
         # https://docs.prefect.io/v3/api-ref/settings-ref#extra-loggers

--- a/data-in-pipeline/app/navigator_document_etl_pipeline.py
+++ b/data-in-pipeline/app/navigator_document_etl_pipeline.py
@@ -110,7 +110,10 @@ def etl_pipeline(
 @flow
 def process_updates(ids: list[str] = []):
     _LOGGER = get_logger()
-    _LOGGER.info("Processing document updates started")
+    _LOGGER.info(
+        "Processing document updates started | documents=%d",
+        len(ids),
+    )
 
     results = etl_pipeline.map(ids)
 

--- a/data-in-pipeline/app/prefect_logging.yaml
+++ b/data-in-pipeline/app/prefect_logging.yaml
@@ -35,16 +35,33 @@ handlers:
       log.flow_run_name: magenta
       log.flow_name: bold magenta
 
+  otel:
+    # OTEL handler that forwards logs to OpenTelemetry
+    class: api.prefect_telemetry.OTELLoggingHandler
+    level: 0
+    formatter: standard
+
+  api:
+    # Prefect API handler - sends logs to Prefect Cloud/Server UI
+    class: prefect.logging.handlers.APILogHandler
+    level: 0
+
 loggers:
   prefect:
     level: NOTSET
+    propagate: true
+  prefect.flow_runs:
+    level: NOTSET
     handlers:
-      - console
+      - api
+    propagate: true
+  prefect.task_runs:
+    level: NOTSET
+    handlers:
+      - api
     propagate: true
   app:
     level: NOTSET
-    handlers:
-      - console
     propagate: true
   # Suppress verbose HTTP client logs to prevent OTEL export feedback loop
   urllib3:
@@ -55,6 +72,7 @@ loggers:
     propagate: false
 
 root:
-  level: DEBUG
+  level: INFO
   handlers:
     - console
+    - otel


### PR DESCRIPTION
…licable)

# Description

The prefect logging wasn't working properly with otel. It's because prefect (1) wasn't loading our custom YML properly, and (2) when it did was over-riding any customisation we'd made. Now everything goes to prefect AND otel. It's pretty lush. 

## Type of change

Please select the option(s) below that are most relevant:

- [x] Bug fix

## How Has This Been Tested?

I can see the logs in all the places, whether I run locally or from prefect. 

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
