### PR TITLE
feat(DIP): add related document with entity_type for litigations docs

### DIFF
--- a/data-in-pipeline/app/extract/connectors.py
+++ b/data-in-pipeline/app/extract/connectors.py
@@ -13,9 +13,15 @@ from app.pipeline_metrics import ErrorType, Operation
 from app.util import generate_envelope_uuid
 
 
+class NavigatorEvent(BaseModel):
+    import_id: str
+    event_type: str
+
+
 class NavigatorDocument(BaseModel):
     import_id: str
     title: str
+    events: list[NavigatorEvent]
     valid_metadata: dict[str, list[str]] = {}
 
 

--- a/data-in-pipeline/app/scripts/transform_all_families.py
+++ b/data-in-pipeline/app/scripts/transform_all_families.py
@@ -36,6 +36,7 @@ if __name__ == "__main__":
                             import_id=doc["import_id"],
                             title=doc["title"],
                             valid_metadata=doc["valid_metadata"],
+                            events=[],
                         )
                         for doc in family["documents"]
                     ],

--- a/data-in-pipeline/app/transform/navigator_family.py
+++ b/data-in-pipeline/app/transform/navigator_family.py
@@ -214,10 +214,52 @@ def transform_navigator_family_never(
     )
 
 
+def transform_navigator_family_with_litigation_corpus_type_document(
+    document: NavigatorDocument,
+) -> Document:
+    """
+    Values are controlled
+    @see: https://github.com/climatepolicyradar/data-migrations/blob/main/taxonomies/Litigation.json#L11-L113
+    """
+
+    labels: list[DocumentLabelRelationship] = []
+
+    if document.events:
+        event_type = document.events[0].event_type
+
+        labels.append(
+            DocumentLabelRelationship(
+                type="entity_type",
+                label=Label(
+                    id=event_type,
+                    title=event_type,
+                    type="entity_type",
+                ),
+            )
+        )
+
+    labels.append(
+        DocumentLabelRelationship(
+            type="transformer",
+            label=TransformerLabel(
+                id="transform_navigator_family_with_litigation_corpus_type",
+                title="transform_navigator_family_with_litigation_corpus_type",
+                type="transformer",
+            ),
+        )
+    )
+
+    return Document(id=document.import_id, title=document.title, labels=labels)
+
+
 def transform_navigator_family_with_litigation_corpus_type(
     input: Identified[NavigatorFamily],
 ) -> Result[list[Document], CouldNotTransform]:
     if input.data.corpus.import_id == "Academic.corpus.Litigation.n0000":
+        related_documents = [
+            transform_navigator_family_with_litigation_corpus_type_document(document)
+            for document in input.data.documents
+        ]
         case_label = DocumentLabelRelationship(
             type="entity_type",
             label=Label(
@@ -239,7 +281,7 @@ def transform_navigator_family_with_litigation_corpus_type(
             title=input.data.title,
             labels=[case_label, transformer_label],
         )
-        return Success([document_from_family])
+        return Success([document_from_family, *related_documents])
 
     return Failure(
         CouldNotTransform(

--- a/data-in-pipeline/tests/test_integration.py
+++ b/data-in-pipeline/tests/test_integration.py
@@ -49,7 +49,9 @@ def test_process_family_updates_flow_multiple_families(
             corpus=NavigatorCorpus(import_id="UNFCCC"),
             documents=[
                 NavigatorDocument(
-                    import_id="i00000315", title="Belgium UNCBD National Targets"
+                    import_id="i00000315",
+                    title="Belgium UNCBD National Targets",
+                    events=[],
                 )
             ],
         )
@@ -62,7 +64,9 @@ def test_process_family_updates_flow_multiple_families(
             corpus=NavigatorCorpus(import_id="UNFCCC"),
             documents=[
                 NavigatorDocument(
-                    import_id="i00000316", title="France UNCBD National Targets"
+                    import_id="i00000316",
+                    title="France UNCBD National Targets",
+                    events=[],
                 )
             ],
         )

--- a/data-in-pipeline/tests/test_unit.py
+++ b/data-in-pipeline/tests/test_unit.py
@@ -76,7 +76,7 @@ def test_fetch_document_success(base_config):
 
     mock_response = {
         "data": NavigatorDocument(
-            import_id=import_id, title="Test Document"
+            import_id=import_id, title="Test Document", events=[]
         ).model_dump()
     }
 
@@ -142,8 +142,10 @@ def test_fetch_family_success(base_config):
             import_id=import_id,
             title="Test Family",
             corpus=NavigatorCorpus(import_id="COR-111"),
-            documents=[NavigatorDocument(import_id=import_id, title="Test Document")],
-        ).model_dump()
+            documents=[
+                NavigatorDocument(import_id=import_id, title="Test Document", events=[])
+            ],
+        ).model_dump(),
     }
 
     with (
@@ -217,6 +219,7 @@ def test_extract_document_handles_valid_id_success():
                 data=NavigatorDocument(
                     import_id=valid_id,
                     title="A Valid Document",
+                    events=[],
                 ),
                 metadata=ExtractedMetadata(
                     endpoint="www.capsule-corp.com", http_status=HTTPStatus.OK

--- a/data-in-pipeline/tests/transform/test_navigator_family.py
+++ b/data-in-pipeline/tests/transform/test_navigator_family.py
@@ -1,7 +1,12 @@
 import pytest
 from returns.result import Success
 
-from app.extract.connectors import NavigatorCorpus, NavigatorDocument, NavigatorFamily
+from app.extract.connectors import (
+    NavigatorCorpus,
+    NavigatorDocument,
+    NavigatorEvent,
+    NavigatorFamily,
+)
 from app.models import Document, DocumentLabelRelationship, Identified, Label
 from app.transform.models import NoMatchingTransformations
 from app.transform.navigator_family import TransformerLabel, transform_navigator_family
@@ -22,6 +27,7 @@ def navigator_family_with_single_matching_title_document() -> (
                 NavigatorDocument(
                     import_id="456",
                     title="Matching title on family and document",
+                    events=[],
                 ),
             ],
         ),
@@ -38,10 +44,7 @@ def navigator_family_with_no_matching_transformations() -> Identified[NavigatorF
             title="No matches for this family or documents",
             corpus=NavigatorCorpus(import_id="123"),
             documents=[
-                NavigatorDocument(
-                    import_id="456",
-                    title="Test document 1",
-                ),
+                NavigatorDocument(import_id="456", title="Test document 1", events=[]),
             ],
         ),
     )
@@ -58,8 +61,9 @@ def navigator_family_with_litigation_corpus_type() -> Identified[NavigatorFamily
             corpus=NavigatorCorpus(import_id="Academic.corpus.Litigation.n0000"),
             documents=[
                 NavigatorDocument(
-                    import_id="456",
-                    title="Litigation case",
+                    import_id="Litigation family document",
+                    title="Litigation family document",
+                    events=[NavigatorEvent(import_id="123", event_type="Decision")],
                 ),
             ],
         ),
@@ -141,6 +145,31 @@ def test_transform_navigator_family_with_litigation_corpus_type(
                     ),
                 ],
                 relationships=[],
-            )
-        ]
+            ),
+            Document(
+                id="Litigation family document",
+                title="Litigation family document",
+                labels=[
+                    DocumentLabelRelationship(
+                        type="entity_type",
+                        label=Label(
+                            id="Decision",
+                            title="Decision",
+                            type="entity_type",
+                        ),
+                    ),
+                    DocumentLabelRelationship(
+                        type="transformer",
+                        label=TransformerLabel(
+                            id="transform_navigator_family_with_litigation_corpus_type",
+                            title="transform_navigator_family_with_litigation_corpus_type",
+                            type="transformer",
+                        ),
+                    ),
+                ],
+                relationships=[],
+            ),
+        ],
     )
+
+    def test_transform_navigator_family_with_litigation_corpus_type_document(): ...


### PR DESCRIPTION
# Description
- few refactors adding events to `NavigatorDocument`
- generates a new document for each event with `entity_type` = `event_type` for litigation docs

part of https://linear.app/climate-policy-radar/issue/APP-1457/dip-transformer-family-=-document-transformations