### PR TITLE
Downgrade postgres version for aurora

### DIFF
--- a/data-in-pipeline/infra/__main__.py
+++ b/data-in-pipeline/infra/__main__.py
@@ -162,7 +162,7 @@ aurora_subnet_group = aws.rds.SubnetGroup(
 aurora_cluster = aws.rds.Cluster(
     f"{name}-aurora-cluster",
     engine="aurora-postgresql",
-    engine_version="18.1",
+    engine_version="17.6",
     master_username=credentials.apply(lambda creds: creds["username"]),
     master_password=credentials.apply(lambda creds: creds["password"]),
     db_subnet_group_name=aurora_subnet_group.name,


### PR DESCRIPTION
# Description

Downgrade postgres version from 18.1 -> 17.6 for aurora as latest is not yet fully supported in AWS.

## Type of change

Please select the option(s) below that are most relevant:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Refactor legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
