### PR TITLE
Fix db instance identifiers to be more meaningful

### DIFF
--- a/data-in-pipeline/infra/__main__.py
+++ b/data-in-pipeline/infra/__main__.py
@@ -180,7 +180,8 @@ aurora_cluster = aws.rds.Cluster(
 
 aurora_instances = [
     aws.rds.ClusterInstance(
-        f"{name}-aurora-instance-{i}",
+        f"{name}-{environment}-aurora-instance-{i}",
+        identifier=f"{name}-{environment}-aurora-instance-{i}",
         cluster_identifier=aurora_cluster.id,
         instance_class="db.serverless",
         engine=aurora_cluster.engine,


### PR DESCRIPTION
# Description
- set the identifier on each Aurora instance so that they are more meaningful and not just using auto generated AWS ids

## Type of change

Please select the option(s) below that are most relevant:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Refactor legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
