### PR TITLE
Make the aurora cluster identifier more meaningful

### DIFF
--- a/data-in-pipeline/infra/__main__.py
+++ b/data-in-pipeline/infra/__main__.py
@@ -160,7 +160,8 @@ aurora_subnet_group = aws.rds.SubnetGroup(
 
 
 aurora_cluster = aws.rds.Cluster(
-    f"{name}-aurora-cluster",
+    f"{name}-{environment}-aurora-cluster",
+    cluster_identifier=f"{name}-{environment}-aurora-cluster",
     engine="aurora-postgresql",
     engine_version="17.6",
     master_username=credentials.apply(lambda creds: creds["username"]),


### PR DESCRIPTION
# Description
Set `cluster_identifier` when creating the Aurora cluster so that it has a more meaningful name and reflects the AWS environment.

## Type of change

Please select the option(s) below that are most relevant:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Refactor legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
