### PR TITLE
feat(dip): MCF activity status labels

### DIFF
--- a/data-in-pipeline/app/extract/connectors.py
+++ b/data-in-pipeline/app/extract/connectors.py
@@ -16,6 +16,7 @@ from app.util import generate_envelope_uuid
 class NavigatorEvent(BaseModel):
     import_id: str
     event_type: str
+    date: datetime.datetime
 
 
 class NavigatorDocument(BaseModel):
@@ -38,6 +39,7 @@ class NavigatorFamily(BaseModel):
     title: str
     documents: list[NavigatorDocument]
     corpus: NavigatorCorpus
+    events: list[NavigatorEvent]
 
 
 class PageFetchFailure(BaseModel):

--- a/data-in-pipeline/app/models.py
+++ b/data-in-pipeline/app/models.py
@@ -44,6 +44,7 @@ class Label(BaseModel):
 class DocumentLabelRelationship(BaseModel):
     type: str
     label: Label
+    timestamp: datetime | None = None
 
 
 class BaseDocument(BaseModel):
@@ -55,6 +56,7 @@ class BaseDocument(BaseModel):
 class DocumentDocumentRelationship(BaseModel):
     type: str
     document: "DocumentWithoutRelationships"
+    timestamp: datetime | None = None
 
 
 class Document(BaseDocument):

--- a/data-in-pipeline/app/scripts/build_duckdb.py
+++ b/data-in-pipeline/app/scripts/build_duckdb.py
@@ -4,7 +4,7 @@ import duckdb
 DB_PATH = ".data_cache/documents.duckdb"
 DATA_GLOB = ".data_cache/transformed_navigator_families/*.json"
 
-con = duckdb.connect(DB_PATH)
+con = duckdb.connect(DB_PATH, config={"memory_limit": "100GB"})
 
 con.execute(
     """

--- a/data-in-pipeline/app/scripts/serve_duckdb.py
+++ b/data-in-pipeline/app/scripts/serve_duckdb.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 import duckdb
 from fastapi import Depends, FastAPI, Query
 from fastapi.middleware.cors import CORSMiddleware
@@ -8,6 +10,7 @@ class Label(BaseModel):
     id: str
     title: str
     type: str
+    timestamp: datetime | None = None
 
 
 class DocumentLabelRelationship(BaseModel):
@@ -214,6 +217,7 @@ def list_labels(
         FROM documents
         CROSS JOIN UNNEST(labels) AS t(l)
         GROUP BY l.label.id, l.label.type
+        ORDER BY l.label.type, l.label.id
         """
     )
     labels_colnames = [c[0] for c in labels_result.description]
@@ -243,6 +247,7 @@ def list_relationships(
         FROM documents
         CROSS JOIN UNNEST(relationships) AS t(r)
         GROUP BY r.type, r.type
+        ORDER BY r.type
         """
     )
     relationships_colnames = [c[0] for c in relationships_result.description]

--- a/data-in-pipeline/app/scripts/transform_all_families.py
+++ b/data-in-pipeline/app/scripts/transform_all_families.py
@@ -3,7 +3,12 @@ import os
 
 from returns.result import Failure, Success
 
-from app.extract.connectors import NavigatorCorpus, NavigatorDocument, NavigatorFamily
+from app.extract.connectors import (
+    NavigatorCorpus,
+    NavigatorDocument,
+    NavigatorEvent,
+    NavigatorFamily,
+)
 from app.models import Identified
 from app.transform.navigator_family import transform_navigator_family
 
@@ -40,6 +45,14 @@ if __name__ == "__main__":
                         )
                         for doc in family["documents"]
                     ],
+                    events=[
+                        NavigatorEvent(
+                            import_id=event["import_id"],
+                            event_type=event["event_type"],
+                            date=event["date"],
+                        )
+                        for event in family["events"]
+                    ],
                 ),
                 id=family["import_id"],
                 source="navigator_family",
@@ -56,11 +69,11 @@ if __name__ == "__main__":
         os.remove(f".data_cache/transformed_navigator_families/{file}")
 
     for document in successes:
-        model_dump = document.model_dump()
+        model_dump = document.model_dump_json(indent=4)
         with open(
             f".data_cache/transformed_navigator_families/{document.id}.json", "w"
         ) as f:
-            json.dump(model_dump, f, indent=4)
+            f.write(model_dump)
 
     print(f"Successes: {len(successes)}")
     print(f"Failures: {len(failures)}")

--- a/data-in-pipeline/app/transform/navigator_family.py
+++ b/data-in-pipeline/app/transform/navigator_family.py
@@ -196,6 +196,53 @@ def _transform_navigator_family(navigator_family: NavigatorFamily) -> Document:
             )
         )
 
+    # We skip litigation as we hijacked the event_type for document type
+    if navigator_family.corpus.import_id != "Academic.corpus.Litigation.n0000":
+        """
+        Activity status
+
+        This is loosely inspired by the IATI ontology
+        @see: https://iatistandard.org/en/iati-standard/203/activity-standard/iati-activities/iati-activity/activity-status/
+        @see: https://iatistandard.org/en/iati-standard/203/codelists/activitystatus/
+
+        e.g.
+        Project Approved => Pipeline/identification
+        Under Implementation => Implementation
+        Project Completed => Closed
+        """
+
+        """
+        Values from Navigator are controlled
+        @see: https://github.com/climatepolicyradar/data-migrations/blob/main/taxonomies/AF.json#L7C9-L9C28
+        @see: https://github.com/climatepolicyradar/data-migrations/blob/main/taxonomies/CIF.json#L7-L10
+        @see: https://github.com/climatepolicyradar/data-migrations/blob/main/taxonomies/CIF.json#L7-L10
+        @see: https://github.com/climatepolicyradar/data-migrations/blob/main/taxonomies/GEF.json#L7-L11
+        """
+        mcf_project_status_value_map = {
+            "Concept Approved": "Concept approved",
+            "Project Approved": "Approved",
+            "Under Implementation": "Under implementation",
+            "Project Completed": "Completed",
+            "Cancelled": "Cancelled",
+        }
+
+        for event in navigator_family.events:
+            label_id = mcf_project_status_value_map.get(
+                event.event_type,
+                "Unknown",
+            )
+            labels.append(
+                DocumentLabelRelationship(
+                    type="activity_status",
+                    timestamp=event.date,
+                    label=Label(
+                        id=label_id,
+                        title=label_id,
+                        type="activity_status",
+                    ),
+                )
+            )
+
     # this is for debugging
     if not labels:
         labels.append(
@@ -258,7 +305,7 @@ def _transform_navigator_document(
         labels.append(
             DocumentLabelRelationship(
                 type="status",
-                label=Label(id="obsolete", title="obsolete", type="status"),
+                label=Label(id="Obsolete", title="Obsolete", type="status"),
             )
         )
 

--- a/data-in-pipeline/tests/test_integration.py
+++ b/data-in-pipeline/tests/test_integration.py
@@ -54,6 +54,7 @@ def test_process_family_updates_flow_multiple_families(
                     events=[],
                 )
             ],
+            events=[],
         )
     ]
 
@@ -69,6 +70,7 @@ def test_process_family_updates_flow_multiple_families(
                     events=[],
                 )
             ],
+            events=[],
         )
     ]
 

--- a/data-in-pipeline/tests/test_unit.py
+++ b/data-in-pipeline/tests/test_unit.py
@@ -145,6 +145,7 @@ def test_fetch_family_success(base_config):
             documents=[
                 NavigatorDocument(import_id=import_id, title="Test Document", events=[])
             ],
+            events=[],
         ).model_dump(),
     }
 
@@ -300,12 +301,14 @@ def test_fetch_all_families_successfully(base_config):
                 title="Family 1",
                 corpus=NavigatorCorpus(import_id="COR-001"),
                 documents=[],
+                events=[],
             ).model_dump(),
             NavigatorFamily(
                 import_id="FAM-002",
                 title="Family 2",
                 corpus=NavigatorCorpus(import_id="COR-001"),
                 documents=[],
+                events=[],
             ).model_dump(),
         ]
     }
@@ -316,6 +319,7 @@ def test_fetch_all_families_successfully(base_config):
                 title="Family 3",
                 corpus=NavigatorCorpus(import_id="COR-002"),
                 documents=[],
+                events=[],
             ).model_dump()
         ]
     }
@@ -373,6 +377,7 @@ def test_fetch_all_families_handles_successful_retrievals_and_errors(base_config
                 title="Family 1",
                 corpus=NavigatorCorpus(import_id="COR-001"),
                 documents=[],
+                events=[],
             ).model_dump()
         ]
     }

--- a/data-in-pipeline/tests/transform/test_navigator_family.py
+++ b/data-in-pipeline/tests/transform/test_navigator_family.py
@@ -1,3 +1,5 @@
+import datetime
+
 import pytest
 from returns.result import Success
 
@@ -34,6 +36,7 @@ def navigator_family_with_single_matching_document() -> Identified[NavigatorFami
                     events=[],
                 ),
             ],
+            events=[],
         ),
     )
 
@@ -50,6 +53,7 @@ def navigator_family_with_no_matching_transformations() -> Identified[NavigatorF
             documents=[
                 NavigatorDocument(import_id="456", title="Test document 1", events=[]),
             ],
+            events=[],
         ),
     )
 
@@ -67,12 +71,25 @@ def navigator_family_with_litigation_corpus_type() -> Identified[NavigatorFamily
                 NavigatorDocument(
                     import_id="document",
                     title="Litigation family document",
-                    events=[NavigatorEvent(import_id="123", event_type="Decision")],
+                    events=[
+                        NavigatorEvent(
+                            import_id="123",
+                            event_type="Decision",
+                            date=datetime.datetime(2020, 1, 1),
+                        )
+                    ],
                 ),
                 NavigatorDocument(
                     import_id="1.2.3.placeholder",
                     title="Placeholder litigation family document",
                     events=[],
+                ),
+            ],
+            events=[
+                NavigatorEvent(
+                    import_id="123",
+                    event_type="Decision",
+                    date=datetime.datetime(2020, 1, 1),
                 ),
             ],
         ),
@@ -98,6 +115,33 @@ def navigator_family_multilateral_climate_fund_project() -> Identified[Navigator
                     import_id="document_2",
                     title="Project document",
                     events=[],
+                ),
+            ],
+            events=[
+                NavigatorEvent(
+                    import_id="concept_approved",
+                    event_type="Concept Approved",
+                    date=datetime.datetime(2020, 1, 1),
+                ),
+                NavigatorEvent(
+                    import_id="project_approved",
+                    event_type="Project Approved",
+                    date=datetime.datetime(2020, 1, 1),
+                ),
+                NavigatorEvent(
+                    import_id="under_implementation",
+                    event_type="Under Implementation",
+                    date=datetime.datetime(2020, 1, 1),
+                ),
+                NavigatorEvent(
+                    import_id="project_completed",
+                    event_type="Project Completed",
+                    date=datetime.datetime(2020, 1, 1),
+                ),
+                NavigatorEvent(
+                    import_id="cancelled",
+                    event_type="Cancelled",
+                    date=datetime.datetime(2020, 1, 1),
                 ),
             ],
         ),
@@ -234,8 +278,8 @@ def test_transform_navigator_family_with_litigation_corpus_type(
                                 DocumentLabelRelationship(
                                     type="status",
                                     label=Label(
-                                        id="obsolete",
-                                        title="obsolete",
+                                        id="Obsolete",
+                                        title="Obsolete",
                                         type="status",
                                     ),
                                 ),
@@ -284,8 +328,8 @@ def test_transform_navigator_family_with_litigation_corpus_type(
                     DocumentLabelRelationship(
                         type="status",
                         label=Label(
-                            id="obsolete",
-                            title="obsolete",
+                            id="Obsolete",
+                            title="Obsolete",
                             type="status",
                         ),
                     ),
@@ -333,6 +377,51 @@ def test_transform_navigator_family_with_multilateral_climate_fund_project(
                             title="Multilateral climate fund project",
                             type="entity_type",
                         ),
+                    ),
+                    DocumentLabelRelationship(
+                        type="activity_status",
+                        label=Label(
+                            id="Concept approved",
+                            title="Concept approved",
+                            type="activity_status",
+                        ),
+                        timestamp=datetime.datetime(2020, 1, 1),
+                    ),
+                    DocumentLabelRelationship(
+                        type="activity_status",
+                        label=Label(
+                            id="Approved",
+                            title="Approved",
+                            type="activity_status",
+                        ),
+                        timestamp=datetime.datetime(2020, 1, 1),
+                    ),
+                    DocumentLabelRelationship(
+                        type="activity_status",
+                        label=Label(
+                            id="Under implementation",
+                            title="Under implementation",
+                            type="activity_status",
+                        ),
+                        timestamp=datetime.datetime(2020, 1, 1),
+                    ),
+                    DocumentLabelRelationship(
+                        type="activity_status",
+                        label=Label(
+                            id="Completed",
+                            title="Completed",
+                            type="activity_status",
+                        ),
+                        timestamp=datetime.datetime(2020, 1, 1),
+                    ),
+                    DocumentLabelRelationship(
+                        type="activity_status",
+                        label=Label(
+                            id="Cancelled",
+                            title="Cancelled",
+                            type="activity_status",
+                        ),
+                        timestamp=datetime.datetime(2020, 1, 1),
                     ),
                 ],
                 relationships=[
@@ -400,6 +489,51 @@ def test_transform_navigator_family_with_multilateral_climate_fund_project(
                                         type="entity_type",
                                     ),
                                 ),
+                                DocumentLabelRelationship(
+                                    type="activity_status",
+                                    label=Label(
+                                        id="Concept approved",
+                                        title="Concept approved",
+                                        type="activity_status",
+                                    ),
+                                    timestamp=datetime.datetime(2020, 1, 1),
+                                ),
+                                DocumentLabelRelationship(
+                                    type="activity_status",
+                                    label=Label(
+                                        id="Approved",
+                                        title="Approved",
+                                        type="activity_status",
+                                    ),
+                                    timestamp=datetime.datetime(2020, 1, 1),
+                                ),
+                                DocumentLabelRelationship(
+                                    type="activity_status",
+                                    label=Label(
+                                        id="Under implementation",
+                                        title="Under implementation",
+                                        type="activity_status",
+                                    ),
+                                    timestamp=datetime.datetime(2020, 1, 1),
+                                ),
+                                DocumentLabelRelationship(
+                                    type="activity_status",
+                                    label=Label(
+                                        id="Completed",
+                                        title="Completed",
+                                        type="activity_status",
+                                    ),
+                                    timestamp=datetime.datetime(2020, 1, 1),
+                                ),
+                                DocumentLabelRelationship(
+                                    type="activity_status",
+                                    label=Label(
+                                        id="Cancelled",
+                                        title="Cancelled",
+                                        type="activity_status",
+                                    ),
+                                    timestamp=datetime.datetime(2020, 1, 1),
+                                ),
                             ],
                         ),
                     )
@@ -432,6 +566,51 @@ def test_transform_navigator_family_with_multilateral_climate_fund_project(
                                         title="Multilateral climate fund project",
                                         type="entity_type",
                                     ),
+                                ),
+                                DocumentLabelRelationship(
+                                    type="activity_status",
+                                    label=Label(
+                                        id="Concept approved",
+                                        title="Concept approved",
+                                        type="activity_status",
+                                    ),
+                                    timestamp=datetime.datetime(2020, 1, 1),
+                                ),
+                                DocumentLabelRelationship(
+                                    type="activity_status",
+                                    label=Label(
+                                        id="Approved",
+                                        title="Approved",
+                                        type="activity_status",
+                                    ),
+                                    timestamp=datetime.datetime(2020, 1, 1),
+                                ),
+                                DocumentLabelRelationship(
+                                    type="activity_status",
+                                    label=Label(
+                                        id="Under implementation",
+                                        title="Under implementation",
+                                        type="activity_status",
+                                    ),
+                                    timestamp=datetime.datetime(2020, 1, 1),
+                                ),
+                                DocumentLabelRelationship(
+                                    type="activity_status",
+                                    label=Label(
+                                        id="Completed",
+                                        title="Completed",
+                                        type="activity_status",
+                                    ),
+                                    timestamp=datetime.datetime(2020, 1, 1),
+                                ),
+                                DocumentLabelRelationship(
+                                    type="activity_status",
+                                    label=Label(
+                                        id="Cancelled",
+                                        title="Cancelled",
+                                        type="activity_status",
+                                    ),
+                                    timestamp=datetime.datetime(2020, 1, 1),
                                 ),
                             ],
                         ),

--- a/data-in-pipeline/ui/src/App.tsx
+++ b/data-in-pipeline/ui/src/App.tsx
@@ -17,9 +17,7 @@ import { Navigation } from "./components/navigation";
 import Labels from "./Labels";
 import Relationships from "./Relationships";
 
-const baseProvider = dataProvider(
-  "https://skillful-analysis-production.up.railway.app",
-);
+const baseProvider = dataProvider("http://localhost:8000");
 
 const documentsDataProvider: DataProvider = {
   ...baseProvider,
@@ -30,9 +28,7 @@ const documentsDataProvider: DataProvider = {
     const offset = (currentPage - 1) * pageSize;
     const limit = pageSize;
 
-    const url = new URL(
-      `https://skillful-analysis-production.up.railway.app/${resource}`,
-    );
+    const url = new URL(`http://localhost:8000/${resource}`);
     url.searchParams.set("offset", offset.toString());
     url.searchParams.set("limit", limit.toString());
 


### PR DESCRIPTION
# Description

Fixes: https://linear.app/climate-policy-radar/issue/APP-1498/transform-event-type-for-mcfs

We're adding the events that [we can see here](https://github.com/climatepolicyradar/data-migrations/tree/main/taxonomies) for MCF projects.

We are loosely being inspired by [this taxonomy](https://iatistandard.org/en/iati-standard/203/codelists/activitystatus/) which is widely used.

Adds a `timestamp` to a label. This might be overloading the Label, but I would like to push this further as we start to dip into [things like](https://github.com/climatepolicyradar/data-migrations/blob/main/taxonomies/Intl.%20agreements.json#L7-L23) [the Laws & Policies `event_type`](https://github.com/climatepolicyradar/data-migrations/blob/main/taxonomies/Laws%20and%20Policies.json#L17-L33) ([Linear ticket](https://linear.app/climate-policy-radar/issue/APP-1500/transform-event-type-for-laws-policies-and-intl-agreements))

Todo:
- [x] add tests