### PR TITLE
fix(dip): add document.type as entity_type to transformer

### DIFF
--- a/data-in-pipeline/app/transform/navigator_family.py
+++ b/data-in-pipeline/app/transform/navigator_family.py
@@ -326,15 +326,36 @@ def _transform_navigator_document(
     """
     These values are controlled
     @see: https://github.com/climatepolicyradar/data-migrations/blob/main/taxonomies/Intl.%20agreements.json#L42-L51
+    @see: https://github.com/climatepolicyradar/data-migrations/blob/main/taxonomies/Laws%20and%20Policies.json#L381-L396
     """
-    role = navigator_document.valid_metadata.get("role")
-    if role is not None and len(role) > 0:
-        normalised_role = role[0].capitalize()
+    metadata_role = navigator_document.valid_metadata.get("role")
+    if metadata_role is not None and len(metadata_role) > 0:
+        normalised_role = metadata_role[0].capitalize()
         labels.append(
             DocumentLabelRelationship(
                 type="entity_type",
                 label=Label(
                     id=normalised_role, title=normalised_role, type="entity_type"
+                ),
+            )
+        )
+
+    """
+    These values are controlled
+    @see: https://github.com/climatepolicyradar/data-migrations/blob/main/taxonomies/Reports.json#L16-L26
+    @see: https://github.com/climatepolicyradar/data-migrations/blob/main/taxonomies/GCF.json#L52-L67
+    @see: https://github.com/climatepolicyradar/data-migrations/blob/main/taxonomies/Intl.%20agreements.json#L54-L144
+    """
+    metadata_type = navigator_document.valid_metadata.get("type")
+    if metadata_type is not None and len(metadata_type) > 0:
+        normalised_metadata_type = metadata_type[0].capitalize()
+        labels.append(
+            DocumentLabelRelationship(
+                type="entity_type",
+                label=Label(
+                    id=normalised_metadata_type,
+                    title=normalised_metadata_type,
+                    type="entity_type",
                 ),
             )
         )

--- a/data-in-pipeline/tests/transform/test_navigator_family.py
+++ b/data-in-pipeline/tests/transform/test_navigator_family.py
@@ -37,6 +37,10 @@ def navigator_family_with_single_matching_document() -> Identified[NavigatorFami
                     import_id="document",
                     title="Matching title on family and document",
                     events=[],
+                    valid_metadata={
+                        "role": ["SUPPORTING LEGISLATION"],
+                        "type": ["National Drought Plan (NDP)"],
+                    },
                 ),
             ],
             events=[
@@ -253,7 +257,7 @@ def test_transform_navigator_family_with_single_matching_document(
         [
             Document(
                 id="family",
-                title=navigator_family_with_single_matching_document.data.title,
+                title="Matching title on family and document",
                 labels=[
                     DocumentLabelRelationship(
                         type="activity_status",
@@ -396,14 +400,22 @@ def test_transform_navigator_family_with_single_matching_document(
                         type="has_version",
                         document=DocumentWithoutRelationships(
                             id="document",
-                            title=navigator_family_with_single_matching_document.data.title,
+                            title="Matching title on family and document",
                             labels=[
                                 DocumentLabelRelationship(
-                                    type="debug",
+                                    type="entity_type",
                                     label=Label(
-                                        type="debug",
-                                        id="no_document_labels",
-                                        title="no_document_labels",
+                                        type="entity_type",
+                                        id="Supporting legislation",
+                                        title="Supporting legislation",
+                                    ),
+                                ),
+                                DocumentLabelRelationship(
+                                    type="entity_type",
+                                    label=Label(
+                                        type="entity_type",
+                                        id="National drought plan (ndp)",
+                                        title="National drought plan (ndp)",
                                     ),
                                 ),
                             ],
@@ -413,14 +425,22 @@ def test_transform_navigator_family_with_single_matching_document(
             ),
             Document(
                 id="document",
-                title=navigator_family_with_single_matching_document.data.title,
+                title="Matching title on family and document",
                 labels=[
                     DocumentLabelRelationship(
-                        type="debug",
+                        type="entity_type",
                         label=Label(
-                            type="debug",
-                            id="no_document_labels",
-                            title="no_document_labels",
+                            type="entity_type",
+                            id="Supporting legislation",
+                            title="Supporting legislation",
+                        ),
+                    ),
+                    DocumentLabelRelationship(
+                        type="entity_type",
+                        label=Label(
+                            type="entity_type",
+                            id="National drought plan (ndp)",
+                            title="National drought plan (ndp)",
                         ),
                     ),
                 ],
@@ -429,7 +449,7 @@ def test_transform_navigator_family_with_single_matching_document(
                         type="is_version_of",
                         document=DocumentWithoutRelationships(
                             id="family",
-                            title=navigator_family_with_single_matching_document.data.title,
+                            title="Matching title on family and document",
                             labels=[
                                 DocumentLabelRelationship(
                                     type="activity_status",


### PR DESCRIPTION
# Description

- adds `document.type` as `entity_type` label

Fixes https://linear.app/climate-policy-radar/issue/APP-1517/documenttype-=-label-transformation