### PR TITLE
feat(dip): add provider to documents from family

### DIFF
--- a/data-in-pipeline/app/extract/connectors.py
+++ b/data-in-pipeline/app/extract/connectors.py
@@ -30,9 +30,16 @@ class NavigatorCorpusType(BaseModel):
     name: str
 
 
+class NavigatorOrganisation(BaseModel):
+    id: int
+    name: str
+    attribution_url: str | None = None
+
+
 class NavigatorCorpus(BaseModel):
     import_id: str
     corpus_type: NavigatorCorpusType
+    organisation: NavigatorOrganisation
 
 
 class NavigatorFamily(BaseModel):

--- a/data-in-pipeline/app/transform/navigator_family.py
+++ b/data-in-pipeline/app/transform/navigator_family.py
@@ -161,20 +161,44 @@ def transform(
             ),
         )
         documents.append(document_from_document)
-    else:
-        # this is for debugging
-        document_from_family.labels.append(
-            DocumentLabelRelationship(
-                type="debug",
-                label=Label(
-                    id="no_versions",
-                    title="no_versions",
-                    type="debug",
-                ),
-            )
-        )
 
     return Success(documents)
+
+
+def _transform_family_corpus_organisation(
+    navigator_family: NavigatorFamily,
+) -> list[DocumentLabelRelationship]:
+    """
+    Related ontologies
+    @see: https://schema.org/provider
+    """
+    labels: list[DocumentLabelRelationship] = []
+    organisation_to_agent_map = {
+        "AF": "Adapation Fund",
+        "CCLW": "Grantham Research Institute",
+        "CIF": "The Climate Investment Funds",
+        "CPR": "Policy Radar",
+        "GCF": "Green Climate Fund",
+        "GEF": "Global Environment Facility",
+        "Ocean Energy Pathways": "Ocean Energy Pathway",
+        "Sabin": "Sabin Center for Climate Change Law",
+        "UNFCCC": "UNFCCC",
+    }
+
+    organisation_name = organisation_to_agent_map.get(
+        navigator_family.corpus.organisation.name, "Unknown"
+    )
+    labels.append(
+        DocumentLabelRelationship(
+            type="provider",
+            label=Label(
+                type="agent",
+                id=organisation_name,
+                title=organisation_name,
+            ),
+        )
+    )
+    return labels
 
 
 def _transform_navigator_family(navigator_family: NavigatorFamily) -> Document:
@@ -284,18 +308,10 @@ def _transform_navigator_family(navigator_family: NavigatorFamily) -> Document:
                 )
             )
 
-    # this is for debugging
-    if not labels:
-        labels.append(
-            DocumentLabelRelationship(
-                type="debug",
-                label=Label(
-                    id="no_family_labels",
-                    title="no_family_labels",
-                    type="debug",
-                ),
-            )
-        )
+    """
+    Provider labels
+    """
+    labels.extend(_transform_family_corpus_organisation(navigator_family))
 
     return Document(
         id=navigator_family.import_id,
@@ -371,18 +387,10 @@ def _transform_navigator_document(
             )
         )
 
-    # this is for debugging
-    if not labels:
-        labels.append(
-            DocumentLabelRelationship(
-                type="debug",
-                label=Label(
-                    id="no_document_labels",
-                    title="no_document_labels",
-                    type="debug",
-                ),
-            )
-        )
+    """
+    Provider labels
+    """
+    labels.extend(_transform_family_corpus_organisation(navigator_family))
 
     return Document(
         id=navigator_document.import_id,

--- a/data-in-pipeline/tests/test_integration.py
+++ b/data-in-pipeline/tests/test_integration.py
@@ -8,6 +8,7 @@ from app.extract.connectors import (
     NavigatorCorpusType,
     NavigatorDocument,
     NavigatorFamily,
+    NavigatorOrganisation,
     PageFetchFailure,
 )
 from app.models import Document, ExtractedEnvelope, ExtractedMetadata
@@ -46,7 +47,9 @@ def test_process_family_updates_flow_multiple_families(
             import_id="i00000315",
             title="Belgium UNCBD National Targets",
             corpus=NavigatorCorpus(
-                import_id="UNFCCC", corpus_type=NavigatorCorpusType(name="corpus_type")
+                import_id="UNFCCC",
+                corpus_type=NavigatorCorpusType(name="corpus_type"),
+                organisation=NavigatorOrganisation(id=1, name="UNFCCC"),
             ),
             documents=[
                 NavigatorDocument(
@@ -64,7 +67,9 @@ def test_process_family_updates_flow_multiple_families(
             import_id="i00000316",
             title="France UNCBD National Targets",
             corpus=NavigatorCorpus(
-                import_id="UNFCCC", corpus_type=NavigatorCorpusType(name="corpus_type")
+                import_id="UNFCCC",
+                corpus_type=NavigatorCorpusType(name="corpus_type"),
+                organisation=NavigatorOrganisation(id=1, name="UNFCCC"),
             ),
             documents=[
                 NavigatorDocument(

--- a/data-in-pipeline/tests/test_unit.py
+++ b/data-in-pipeline/tests/test_unit.py
@@ -14,6 +14,7 @@ from app.extract.connectors import (
     NavigatorCorpusType,
     NavigatorDocument,
     NavigatorFamily,
+    NavigatorOrganisation,
     PageFetchFailure,
 )
 from app.extract.enums import CheckPointStorageType
@@ -147,7 +148,9 @@ def test_fetch_family_success(base_config):
             import_id=import_id,
             title="Test Family",
             corpus=NavigatorCorpus(
-                import_id="COR-111", corpus_type=NavigatorCorpusType(name="corpus_type")
+                import_id="COR-111",
+                corpus_type=NavigatorCorpusType(name="corpus_type"),
+                organisation=NavigatorOrganisation(id=1, name="UNFCCC"),
             ),
             documents=[
                 NavigatorDocument(import_id=import_id, title="Test Document", events=[])
@@ -309,6 +312,7 @@ def test_fetch_all_families_successfully(base_config):
                 corpus=NavigatorCorpus(
                     import_id="COR-001",
                     corpus_type=NavigatorCorpusType(name="corpus_type"),
+                    organisation=NavigatorOrganisation(id=1, name="UNFCCC"),
                 ),
                 documents=[],
                 events=[],
@@ -319,6 +323,7 @@ def test_fetch_all_families_successfully(base_config):
                 corpus=NavigatorCorpus(
                     import_id="COR-001",
                     corpus_type=NavigatorCorpusType(name="corpus_type"),
+                    organisation=NavigatorOrganisation(id=1, name="UNFCCC"),
                 ),
                 documents=[],
                 events=[],
@@ -333,6 +338,7 @@ def test_fetch_all_families_successfully(base_config):
                 corpus=NavigatorCorpus(
                     import_id="COR-002",
                     corpus_type=NavigatorCorpusType(name="corpus_type"),
+                    organisation=NavigatorOrganisation(id=1, name="UNFCCC"),
                 ),
                 documents=[],
                 events=[],
@@ -394,6 +400,7 @@ def test_fetch_all_families_handles_successful_retrievals_and_errors(base_config
                 corpus=NavigatorCorpus(
                     import_id="COR-001",
                     corpus_type=NavigatorCorpusType(name="corpus_type"),
+                    organisation=NavigatorOrganisation(id=1, name="UNFCCC"),
                 ),
                 documents=[],
                 events=[],

--- a/data-in-pipeline/tests/transform/test_navigator_family.py
+++ b/data-in-pipeline/tests/transform/test_navigator_family.py
@@ -9,6 +9,7 @@ from app.extract.connectors import (
     NavigatorDocument,
     NavigatorEvent,
     NavigatorFamily,
+    NavigatorOrganisation,
 )
 from app.models import (
     Document,
@@ -30,7 +31,9 @@ def navigator_family_with_single_matching_document() -> Identified[NavigatorFami
             import_id="family",
             title="Matching title on family and document",
             corpus=NavigatorCorpus(
-                import_id="corpus", corpus_type=NavigatorCorpusType(name="corpus_type")
+                import_id="corpus",
+                corpus_type=NavigatorCorpusType(name="corpus_type"),
+                organisation=NavigatorOrganisation(id=1, name="CCLW"),
             ),
             documents=[
                 NavigatorDocument(
@@ -143,7 +146,9 @@ def navigator_family_with_no_matching_transformations() -> Identified[NavigatorF
             import_id="123",
             title="No matches for this family or documents",
             corpus=NavigatorCorpus(
-                import_id="123", corpus_type=NavigatorCorpusType(name="corpus_type")
+                import_id="123",
+                corpus_type=NavigatorCorpusType(name="corpus_type"),
+                organisation=NavigatorOrganisation(id=1, name="CCLW"),
             ),
             documents=[
                 NavigatorDocument(import_id="456", title="Test document 1", events=[]),
@@ -164,6 +169,7 @@ def navigator_family_with_litigation_corpus_type() -> Identified[NavigatorFamily
             corpus=NavigatorCorpus(
                 import_id="Academic.corpus.Litigation.n0000",
                 corpus_type=NavigatorCorpusType(name="Litigation"),
+                organisation=NavigatorOrganisation(id=1, name="CCLW"),
             ),
             documents=[
                 NavigatorDocument(
@@ -205,6 +211,7 @@ def navigator_family_multilateral_climate_fund_project() -> Identified[Navigator
             corpus=NavigatorCorpus(
                 import_id="MCF.corpus.AF.n0000",
                 corpus_type=NavigatorCorpusType(name="AF"),
+                organisation=NavigatorOrganisation(id=1, name="CCLW"),
             ),
             documents=[
                 NavigatorDocument(
@@ -394,6 +401,14 @@ def test_transform_navigator_family_with_single_matching_document(
                             type="activity_status", id="Updated", title="Updated"
                         ),
                     ),
+                    DocumentLabelRelationship(
+                        type="provider",
+                        label=Label(
+                            type="agent",
+                            id="Grantham Research Institute",
+                            title="Grantham Research Institute",
+                        ),
+                    ),
                 ],
                 relationships=[
                     DocumentDocumentRelationship(
@@ -416,6 +431,14 @@ def test_transform_navigator_family_with_single_matching_document(
                                         type="entity_type",
                                         id="National drought plan (ndp)",
                                         title="National drought plan (ndp)",
+                                    ),
+                                ),
+                                DocumentLabelRelationship(
+                                    type="provider",
+                                    label=Label(
+                                        type="agent",
+                                        id="Grantham Research Institute",
+                                        title="Grantham Research Institute",
                                     ),
                                 ),
                             ],
@@ -441,6 +464,14 @@ def test_transform_navigator_family_with_single_matching_document(
                             type="entity_type",
                             id="National drought plan (ndp)",
                             title="National drought plan (ndp)",
+                        ),
+                    ),
+                    DocumentLabelRelationship(
+                        type="provider",
+                        label=Label(
+                            type="agent",
+                            id="Grantham Research Institute",
+                            title="Grantham Research Institute",
                         ),
                     ),
                 ],
@@ -602,6 +633,14 @@ def test_transform_navigator_family_with_single_matching_document(
                                         title="Updated",
                                     ),
                                 ),
+                                DocumentLabelRelationship(
+                                    type="provider",
+                                    label=Label(
+                                        type="agent",
+                                        id="Grantham Research Institute",
+                                        title="Grantham Research Institute",
+                                    ),
+                                ),
                             ],
                         ),
                     ),
@@ -630,11 +669,11 @@ def test_transform_navigator_family_with_litigation_corpus_type(
                         ),
                     ),
                     DocumentLabelRelationship(
-                        type="debug",
+                        type="provider",
                         label=Label(
-                            id="no_versions",
-                            title="no_versions",
-                            type="debug",
+                            type="agent",
+                            id="Grantham Research Institute",
+                            title="Grantham Research Institute",
                         ),
                     ),
                 ],
@@ -651,6 +690,14 @@ def test_transform_navigator_family_with_litigation_corpus_type(
                                         id="Decision",
                                         title="Decision",
                                         type="entity_type",
+                                    ),
+                                ),
+                                DocumentLabelRelationship(
+                                    type="provider",
+                                    label=Label(
+                                        type="agent",
+                                        id="Grantham Research Institute",
+                                        title="Grantham Research Institute",
                                     ),
                                 ),
                             ],
@@ -670,6 +717,14 @@ def test_transform_navigator_family_with_litigation_corpus_type(
                                         type="status",
                                     ),
                                 ),
+                                DocumentLabelRelationship(
+                                    type="provider",
+                                    label=Label(
+                                        type="agent",
+                                        id="Grantham Research Institute",
+                                        title="Grantham Research Institute",
+                                    ),
+                                ),
                             ],
                         ),
                     ),
@@ -687,6 +742,14 @@ def test_transform_navigator_family_with_litigation_corpus_type(
                             type="entity_type",
                         ),
                     ),
+                    DocumentLabelRelationship(
+                        type="provider",
+                        label=Label(
+                            type="agent",
+                            id="Grantham Research Institute",
+                            title="Grantham Research Institute",
+                        ),
+                    ),
                 ],
                 relationships=[
                     DocumentDocumentRelationship(
@@ -701,6 +764,14 @@ def test_transform_navigator_family_with_litigation_corpus_type(
                                         id="Legal case",
                                         title="Legal case",
                                         type="entity_type",
+                                    ),
+                                ),
+                                DocumentLabelRelationship(
+                                    type="provider",
+                                    label=Label(
+                                        type="agent",
+                                        id="Grantham Research Institute",
+                                        title="Grantham Research Institute",
                                     ),
                                 ),
                             ],
@@ -720,6 +791,14 @@ def test_transform_navigator_family_with_litigation_corpus_type(
                             type="status",
                         ),
                     ),
+                    DocumentLabelRelationship(
+                        type="provider",
+                        label=Label(
+                            type="agent",
+                            id="Grantham Research Institute",
+                            title="Grantham Research Institute",
+                        ),
+                    ),
                 ],
                 relationships=[
                     DocumentDocumentRelationship(
@@ -734,6 +813,14 @@ def test_transform_navigator_family_with_litigation_corpus_type(
                                         id="Legal case",
                                         title="Legal case",
                                         type="entity_type",
+                                    ),
+                                ),
+                                DocumentLabelRelationship(
+                                    type="provider",
+                                    label=Label(
+                                        type="agent",
+                                        id="Grantham Research Institute",
+                                        title="Grantham Research Institute",
                                     ),
                                 ),
                             ],
@@ -810,6 +897,14 @@ def test_transform_navigator_family_with_multilateral_climate_fund_project(
                         ),
                         timestamp=datetime.datetime(2020, 1, 1),
                     ),
+                    DocumentLabelRelationship(
+                        type="provider",
+                        label=Label(
+                            type="agent",
+                            id="Grantham Research Institute",
+                            title="Grantham Research Institute",
+                        ),
+                    ),
                 ],
                 relationships=[
                     DocumentDocumentRelationship(
@@ -819,11 +914,11 @@ def test_transform_navigator_family_with_multilateral_climate_fund_project(
                             title="Multilateral climate fund project document",
                             labels=[
                                 DocumentLabelRelationship(
-                                    type="debug",
+                                    type="provider",
                                     label=Label(
-                                        type="debug",
-                                        id="no_document_labels",
-                                        title="no_document_labels",
+                                        type="agent",
+                                        id="Grantham Research Institute",
+                                        title="Grantham Research Institute",
                                     ),
                                 ),
                             ],
@@ -836,11 +931,11 @@ def test_transform_navigator_family_with_multilateral_climate_fund_project(
                             title="Project document",
                             labels=[
                                 DocumentLabelRelationship(
-                                    type="debug",
+                                    type="provider",
                                     label=Label(
-                                        type="debug",
-                                        id="no_document_labels",
-                                        title="no_document_labels",
+                                        type="agent",
+                                        id="Grantham Research Institute",
+                                        title="Grantham Research Institute",
                                     ),
                                 ),
                             ],
@@ -853,11 +948,11 @@ def test_transform_navigator_family_with_multilateral_climate_fund_project(
                 title="Multilateral climate fund project document",
                 labels=[
                     DocumentLabelRelationship(
-                        type="debug",
+                        type="provider",
                         label=Label(
-                            type="debug",
-                            id="no_document_labels",
-                            title="no_document_labels",
+                            type="agent",
+                            id="Grantham Research Institute",
+                            title="Grantham Research Institute",
                         ),
                     ),
                 ],
@@ -921,6 +1016,14 @@ def test_transform_navigator_family_with_multilateral_climate_fund_project(
                                     ),
                                     timestamp=datetime.datetime(2020, 1, 1),
                                 ),
+                                DocumentLabelRelationship(
+                                    type="provider",
+                                    label=Label(
+                                        type="agent",
+                                        id="Grantham Research Institute",
+                                        title="Grantham Research Institute",
+                                    ),
+                                ),
                             ],
                         ),
                     )
@@ -931,11 +1034,11 @@ def test_transform_navigator_family_with_multilateral_climate_fund_project(
                 title="Project document",
                 labels=[
                     DocumentLabelRelationship(
-                        type="debug",
+                        type="provider",
                         label=Label(
-                            type="debug",
-                            id="no_document_labels",
-                            title="no_document_labels",
+                            type="agent",
+                            id="Grantham Research Institute",
+                            title="Grantham Research Institute",
                         ),
                     ),
                 ],
@@ -998,6 +1101,14 @@ def test_transform_navigator_family_with_multilateral_climate_fund_project(
                                         type="activity_status",
                                     ),
                                     timestamp=datetime.datetime(2020, 1, 1),
+                                ),
+                                DocumentLabelRelationship(
+                                    type="provider",
+                                    label=Label(
+                                        type="agent",
+                                        id="Grantham Research Institute",
+                                        title="Grantham Research Institute",
+                                    ),
                                 ),
                             ],
                         ),


### PR DESCRIPTION
# Description

- transforms `family.corpus.organisation` => `provider`
- does some tidy up of the values based on talks with policy
- applies the label to both `NavigatorDocuments` and `NavigatorFamily`

Fixes: https://linear.app/climate-policy-radar/issue/APP-1514/transform-familycorpusorganisation=-label