### PR TITLE
fix(families-api): tie breaker on order for families-api

### DIFF
--- a/families-api/app/router.py
+++ b/families-api/app/router.py
@@ -75,7 +75,7 @@ def read_families(
 
     families = session.exec(
         Family.eager_loaded_select()
-        .order_by(desc(Family.last_modified))
+        .order_by(desc(Family.last_modified), desc(Family.import_id))
         .offset(offset)
         .limit(limit)
         .where(*filters)


### PR DESCRIPTION
# Description

- we need a tie breaker for when last_modified is matching, which seems odd to be able to happen, but apparently it can