### PR TITLE
Remove commit() from context manager

### DIFF
--- a/data-in-pipeline-load-api/app/session.py
+++ b/data-in-pipeline-load-api/app/session.py
@@ -63,9 +63,10 @@ def get_db_context() -> Generator[Session, None, None]:
     try:
         _LOGGER.debug("Database session created (context manager)")
         yield db
+        _LOGGER.debug("Safely exiting database session (context manager)")
     except Exception:
         db.rollback()
-        _LOGGER.exception("Database session rolled back")
+        _LOGGER.exception("Database session rolled back (context manager)")
         raise
     finally:
         db.close()


### PR DESCRIPTION
# Description

Remove commit() from context manager so that the onus is moved back to the developer, making commits explicit and atomic. We keep auto rollbacks and closes for transaction safety.

## Type of change

Please select the option(s) below that are most relevant:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Refactor legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
