### PR TITLE
fix: use Principal instead of Canonical

### DIFF
--- a/data-in-pipeline/app/transform/navigator_family.py
+++ b/data-in-pipeline/app/transform/navigator_family.py
@@ -257,15 +257,20 @@ def _transform_family_corpus_organisation(
 
 def _transform_navigator_family(navigator_family: NavigatorFamily) -> Document:
     labels: list[DocumentLabelRelationship] = []
+    """
+    All families are currently Principal.
+    Based on the FRBR taxonomy.
 
-    # All families are currently canonical
+    @see: https://en.wikipedia.org/wiki/Functional_Requirements_for_Bibliographic_Records
+    @see: https://developers.laws.africa/get-started/works-and-expressions
+    """
     labels.append(
         DocumentLabelRelationship(
             type="status",
             label=Label(
                 type="status",
-                id="Canonical",
-                title="Canonical",
+                id="Principal",
+                title="Principal",
             ),
         )
     )

--- a/data-in-pipeline/tests/transform/test_navigator_family.py
+++ b/data-in-pipeline/tests/transform/test_navigator_family.py
@@ -289,8 +289,8 @@ def test_transform_navigator_family_with_single_matching_document(
                 type="status",
                 label=Label(
                     type="status",
-                    id="Canonical",
-                    title="Canonical",
+                    id="Principal",
+                    title="Principal",
                 ),
             ),
             DocumentLabelRelationship(
@@ -563,8 +563,8 @@ def test_transform_navigator_family_with_litigation_corpus_type(
                 type="status",
                 label=Label(
                     type="status",
-                    id="Canonical",
-                    title="Canonical",
+                    id="Principal",
+                    title="Principal",
                 ),
             ),
             DocumentLabelRelationship(
@@ -719,8 +719,8 @@ def test_transform_navigator_family_with_multilateral_climate_fund_project(
                 type="status",
                 label=Label(
                     type="status",
-                    id="Canonical",
-                    title="Canonical",
+                    id="Principal",
+                    title="Principal",
                 ),
             ),
             DocumentLabelRelationship(


### PR DESCRIPTION
# Description

[Currently we're using ](https://github.com/climatepolicyradar/navigator-backend/blob/dae554ef1321cbf26a0502d79fdfaa8bf03203bc/data-in-pipeline/app/transform/navigator_family.py#L261-L271)Canonical and, after working with policy, is not syntactically correct, as it's not what other documents should link to.

We will use Principal as per the [FRBR taxonomy like laws.africa](https://developers.laws.africa/get-started/works-and-expressions)