### PR TITLE
fix: sync workspaces for trunk in backend workflow

### DIFF
--- a/.github/workflows/ci-backend-api.yml
+++ b/.github/workflows/ci-backend-api.yml
@@ -42,24 +42,10 @@ jobs:
         with:
           python-version: "3.12"
       - uses: astral-sh/setup-uv@v7
-      # Install dependencies for all Python projects in the monorepo
-      # Sync workspace members (api, families-api, concepts-api, geographies-api) from root
-      - run: uv sync --frozen --no-install-project --dev
-      # Ensure all workspace members are properly installed for pyright
-      - run: uv sync --frozen --dev
-        working-directory: families-api
-      - run: uv sync --frozen --dev
-        working-directory: concepts-api
-      - run: uv sync --frozen --dev
+      - run: uv sync --all-packages
         working-directory: backend-api
       - run: uv sync --frozen --dev
-        working-directory: geographies-api
-      - run: uv sync --frozen --dev
-        working-directory: data-in-pipeline
-      - run: uv sync --frozen --dev
-        working-directory: data-in-pipeline-load-api
-      # @related BACKEND_API_PYRIGHT_HACK
-      # This is a little hack to make sure we have pyright available by the pyright-backend-api trunk definition
+        working-directory: backend-api
       - run: pip install pyright==1.1.361
       - name: Trunk Check
         uses: trunk-io/trunk-action@v1


### PR DESCRIPTION
# Description

- uv sync --all-packages instead of doing each individually

This has come about from some issues I am seeing in [other builds](https://github.com/climatepolicyradar/navigator-backend/actions/runs/20817507278/job/59796818363?pr=911) on [PRs changing the workspaces](https://github.com/climatepolicyradar/navigator-backend/pull/911).