### PR TITLE
fix: few fixes for load-api connections

### DIFF
--- a/data-in-pipeline-load-api/app/settings.py
+++ b/data-in-pipeline-load-api/app/settings.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import sys
 
 from pydantic import SecretStr
@@ -39,9 +38,7 @@ class Settings(BaseSettings):
     # 'prefer' tries SSL but falls back to non-SSL for local dev (validates
     # certs if SSL is used). For production RDS without cert validation,
     # set db_sslmode=require via environment variable.
-    db_sslmode: str = (
-        "prefer" if os.getenv("ENV", "development") != "production" else "require"
-    )
+    db_sslmode: str = "require"
 
 
 # Pydantic settings are set from the env variables passed in via

--- a/data-in-pipeline/infra/lambda_code/.gitignore
+++ b/data-in-pipeline/infra/lambda_code/.gitignore
@@ -1,0 +1,1 @@
+!requirements.txt

--- a/data-in-pipeline/infra/lambda_code/requirements.txt
+++ b/data-in-pipeline/infra/lambda_code/requirements.txt
@@ -1,0 +1,6 @@
+boto3>=1.42.0
+fastapi>=0.123.4
+httpx>=0.28.1
+mangum>=0.19.0
+pydantic>=2.12.5
+psycopg2-binary>=2.9.9


### PR DESCRIPTION
# Description
- parse username, password from password manager
- use `sslmode=require`
- add lambda `requirements.txt`

The main issue here was that the value from secret store is a JSON string `{"username": "xxx", "password": "xxx"}` - we were passing that whole string as the password.

There is a follow up infra PR coming soon.

Follow up from https://github.com/climatepolicyradar/navigator-backend/pull/910