### PR TITLE
fix(dip): add published activity_status transformation

### DIFF
--- a/data-in-pipeline/app/transform/navigator_family.py
+++ b/data-in-pipeline/app/transform/navigator_family.py
@@ -356,9 +356,18 @@ def _transform_navigator_family(navigator_family: NavigatorFamily) -> Document:
             "Updated": "Updated",
         }
 
+        """
+        Values from Navigator are controlled
+        @see: https://github.com/climatepolicyradar/data-migrations/blob/main/taxonomies/Reports.json#L6
+        """
+        reports_event_type_to_activity_status_map = {
+            "Published": "Published",
+        }
+
         event_type_to_activity_status_map = (
             mcf_project_event_type_to_activity_status_map
             | laws_and_policies_event_type_to_activity_status_map
+            | reports_event_type_to_activity_status_map
         )
 
         for event in navigator_family.events:

--- a/data-in-pipeline/tests/transform/test_navigator_family.py
+++ b/data-in-pipeline/tests/transform/test_navigator_family.py
@@ -140,6 +140,11 @@ def navigator_family_with_single_matching_document() -> Identified[NavigatorFami
                     event_type="Updated",
                     date=datetime.datetime(2020, 1, 1),
                 ),
+                NavigatorEvent(
+                    import_id="Published",
+                    event_type="Published",
+                    date=datetime.datetime(2020, 1, 1),
+                ),
             ],
             collections=[
                 NavigatorCollection(
@@ -427,6 +432,11 @@ def test_transform_navigator_family_with_single_matching_document(
                 type="activity_status",
                 timestamp=datetime.datetime(2020, 1, 1),
                 label=Label(type="activity_status", id="Updated", title="Updated"),
+            ),
+            DocumentLabelRelationship(
+                type="activity_status",
+                timestamp=datetime.datetime(2020, 1, 1),
+                label=Label(type="activity_status", id="Published", title="Published"),
             ),
             DocumentLabelRelationship(
                 type="provider",


### PR DESCRIPTION
# Description
- adds the [`Reports` `Published`](https://github.com/climatepolicyradar/data-migrations/blob/main/taxonomies/Reports.json#L6) `activity_status` as a label

This was was an oversight on my side and picked up by the policy team 🙇 