### PR TITLE
bugfix/app 1585 fix DIP override commands not pushing image to ECR

### DIFF
--- a/data-in-pipeline/justfile
+++ b/data-in-pipeline/justfile
@@ -44,7 +44,7 @@ build service environment tag:
         --tag {{service}}:${GITHUB_SHA} \
         --file Dockerfile ..
 
-deploy-override service environment tag:
+deploy-override service environment tag: 
     #!/usr/bin/env bash
     # this is run from the root justfile in CI
     # TODO: deploy to staging and production
@@ -57,11 +57,8 @@ deploy-override service environment tag:
     # Build the image
     just build {{service}} {{environment}} {{tag}}
     
-    # Tag and push to ECR
     docker tag {{service}}:{{tag}} ${DOCKER_REGISTRY}/{{service}}:{{tag}}
-    docker tag {{service}}:${GITHUB_SHA} ${DOCKER_REGISTRY}/{{service}}:${GITHUB_SHA}
     docker push ${DOCKER_REGISTRY}/{{service}}:{{tag}}
-    docker push ${DOCKER_REGISTRY}/{{service}}:${GITHUB_SHA}
     
     # Deploy to Prefect
     DOCKER_REGISTRY=${DOCKER_REGISTRY} just deploy-to-prefect


### PR DESCRIPTION
# Description

The changes introduces in #891 broke the deploy for the DIP, as it didn't allow for pushing the image to ECR before deploying to prefect.

This PR adds a build step to our deploy override so we don't skip this step.

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand
      areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
