### PR TITLE
fix(dip): update docker.sock in docker-compose

### DIFF
--- a/data-in-pipeline/docker-compose.yml
+++ b/data-in-pipeline/docker-compose.yml
@@ -7,15 +7,22 @@ services:
       dockerfile: data-in-pipeline/Dockerfile
     volumes:
       - ..:/app
-      # testcontainer
+      # <testcontainers>
       # We need these lines to support running testcontainers in the container
       # Which needs access to the host docker
-      - ${DOCKER_SOCKET_PATH:-/var/run/docker.sock}:/var/run/docker.sock
+      - /var/run/docker.sock:/var/run/docker.sock
+    # this is needed as we use `USER prefect_user` in the Dockerfile
     user: root
+    extra_hosts:
+      # @see: https://docs.docker.com/docker-for-mac/networking/#use-cases-and-workarounds
+      - host.docker.internal:host-gateway
     environment:
       # We use testcontainers to test postgres so this is needed
       - TESTCONTAINERS_HOST_OVERRIDE=host.docker.internal
-    # /testcontainers
+      - OTEL_TRACES_EXPORTER=none
+      - OTEL_METRICS_EXPORTER=none
+      - OTEL_LOGS_EXPORTER=none
+    # </testcontainers>
     working_dir: /app
     command:
       [

--- a/data-in-pipeline/justfile
+++ b/data-in-pipeline/justfile
@@ -1,19 +1,8 @@
 dev: 
     uv run python -m app.dev
 
-test: 
+test-local: 
     uv run pytest -vv
-
-test-ci:
-    #!/usr/bin/env bash
-    # Build and test against the Docker image
-    set -euxo pipefail
-    docker build -t data-in-pipeline:test -f Dockerfile ..
-    docker run --rm data-in-pipeline:test uv run pytest -vv
-
-test-override:
-    # this is run from the root justfile in CI
-    just test-ci
 
 deploy-to-prefect-from-local:
     #!/usr/bin/env bash


### PR DESCRIPTION
# Description

- removes the `test-override` and uses the standard `docker-compose` test
  - this speeds up the local build significantly as it uses caching and the mount to the filesystem
- grants access to the docker.sock from the host machine to support [testcontainers](https://testcontainers.com/)
- disables otel as it was throwing up some nasties