### PR TITLE
fix(ci): add test result accumulator on pull-request

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -85,6 +85,22 @@ jobs:
       - uses: extractions/setup-just@v3
       - run: just test ${{ matrix.service }}
 
+  # As test runs on a conditional service matrix we can not require `test ({service})`
+  # tests pass in the GitHub branch rules as they may or may not run.
+  #
+  # This acts as an accumulator of the `test` job results above.
+  tests:
+    needs: test
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      # possible values
+      # @see: https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#jobs-context
+      - run: |
+          if [[ "${{ needs.test.result }}" == "failure" || "${{ needs.test.result }}" == "cancelled" ]]; then
+            exit 1
+          fi
+
   deploy:
     needs: [changes, test]
     # a.


### PR DESCRIPTION
# Description

- adds a `tests` step that accumulates the results from the previous `test` `matrix`

This will allow us to then add this step to our [`main` branch Status checks](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/about-status-checks) - which should allow us to auto-merge and the like more confidently.