### PR TITLE
fix: remove workflow on pr edit

### DIFF
--- a/.github/workflows/ci-backend-api.yml
+++ b/.github/workflows/ci-backend-api.yml
@@ -2,14 +2,13 @@ name: CI for backend-api
 
 on:
   push:
-    tags: [v*]
     branches:
       - main
 
   pull_request:
     # By default, a workflow only runs when a pull_request event's activity type is opened,
     # synchronize, or reopened.
-    types: [opened, synchronize, reopened, edited]
+    types: [opened, synchronize, reopened]
     branches:
       - main
 


### PR DESCRIPTION
# Description

- removes the `backend-api` tests running on PR edit, which we used to have because the PR description controlled the versioning of the repo, which is no longer needed.

This gets frustrating when having to wait for builds because there was an edit to the description etc