### PR TITLE
Disable tls

### DIFF
--- a/data-in-pipeline/app/load/load.py
+++ b/data-in-pipeline/app/load/load.py
@@ -19,9 +19,8 @@ def load_to_db(documents: list[Document]) -> list[str] | Exception:
             load_api_base_url = f"http://{load_api_base_url}"
         response = requests.post(
             url=f"{load_api_base_url}/load/",
-            data=TypeAdapter(list[Document]).dump_json(documents),
+            json=TypeAdapter(list[Document]).dump_json(documents),
             timeout=10,
-            verify=False,  # nosec
         )
         response.raise_for_status()
     except Exception as e:


### PR DESCRIPTION
# Description

- fix post request to load-API - changing `data` => `json` in the request also sets the `Content-Type` header to be `application/json`

NOTE: We were seeing 405 Method Not Allowed after switching to http which meant we were no longer hitting the AppRunner LB which was resolving that for us before. We have to be more explicit now.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand
      areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
