### PR TITLE
fix(families-api): add autoscaling to apprunner

### DIFF
--- a/families-api/infra/__main__.py
+++ b/families-api/infra/__main__.py
@@ -133,10 +133,18 @@ families_api_ecr_repository = aws.ecr.Repository(
     opts=pulumi.ResourceOptions(protect=True),
 )
 
+families_api_apprunner_autoscaling_configuration = aws.apprunner.AutoScalingConfigurationVersion(
+    # len(name) < 32
+    "families-api-autoscaling-config",
+    auto_scaling_configuration_name="families-api-autoscaling-config",
+    max_concurrency=10,
+    max_size=10,
+    min_size=2 if stack == "production" else 1,
+)
 
 families_api_apprunner_service = aws.apprunner.Service(
     "families-api-apprunner-service",
-    auto_scaling_configuration_arn=f"arn:aws:apprunner:eu-west-1:{account_id}:autoscalingconfiguration/DefaultConfiguration/1/00000000000000000000000000000001",
+    auto_scaling_configuration_arn=families_api_apprunner_autoscaling_configuration.arn,
     health_check_configuration=aws.apprunner.ServiceHealthCheckConfigurationArgs(
         interval=10,
         protocol="TCP",


### PR DESCRIPTION
# Description

- we see spikes in requests
- we see spikes in latency
- the service autoscales
- the latency drops

This is also affecting downstream services like the `ccc-frontend` app.