### PR TITLE
fix: serialize datetime fields in Document models when loading to S3

### DIFF
--- a/data-in-pipeline/app/navigator_family_etl_pipeline.py
+++ b/data-in-pipeline/app/navigator_family_etl_pipeline.py
@@ -91,7 +91,7 @@ def extract(ids: list[str] | None = None) -> FamilyFetchResult:
 def load_to_s3(documents: list[Document], run_id: str | None = None):
     """Upload transformed to S3 cache."""
     upload_to_s3(
-        json.dumps([doc.model_dump() for doc in documents]),
+        json.dumps([doc.model_dump(mode="json") for doc in documents]),
         bucket="cpr-cache",
         key=f"pipelines/data-in-pipeline/navigator_family/{run_id}-transformed-result.json",
     )


### PR DESCRIPTION
## Fix datetime serialization error in load_to_s3

### Problem
Pipeline was failing with `TypeError: Object of type datetime is not JSON serializable` when uploading documents to S3 cache.

### Solution
Added `mode='json'` to `model_dump()` call to properly serialize datetime fields (timestamps in DocumentLabelRelationship and DocumentDocumentRelationship) to ISO 8601 strings.

### Changes
- Updated `load_to_s3` in `navigator_family_etl_pipeline.py` to use `doc.model_dump(mode='json')`