### PR TITLE
fix(data-in-api): add empty infra

### DIFF
--- a/data-in-api/infra/Pulumi.production.yaml
+++ b/data-in-api/infra/Pulumi.production.yaml
@@ -1,0 +1,2 @@
+config:
+  aws:region: eu-west-1

--- a/data-in-api/infra/Pulumi.staging.yaml
+++ b/data-in-api/infra/Pulumi.staging.yaml
@@ -1,0 +1,2 @@
+config:
+  aws:region: eu-west-1

--- a/data-in-api/infra/Pulumi.yaml
+++ b/data-in-api/infra/Pulumi.yaml
@@ -1,0 +1,10 @@
+name: data-in-api
+description: Data in API
+runtime:
+  name: python
+  options:
+    toolchain: uv
+config:
+  pulumi:tags:
+    value:
+      pulumi:template: aws-python

--- a/data-in-api/infra/__main__.py
+++ b/data-in-api/infra/__main__.py
@@ -1,0 +1,3 @@
+"""
+Infarstructure for this service is currently provisioned in ../../data-in-pipeline/infra/__main__.py
+"""


### PR DESCRIPTION
# Description

- adds empty `infra` for `data-in-api`

This allows us to [run a deploy on all services](https://github.com/climatepolicyradar/navigator-backend/pull/989) without edge-cases whilst we whittle away at the architecture / folder structure for the services.

Towards: https://linear.app/climate-policy-radar/issue/APP-1574/deployment-of-infrastructure