### PR TITLE
Feature/app 1642 connect data in api to read replicate of aurora

### DIFF
--- a/data-in-pipeline/infra/__main__.py
+++ b/data-in-pipeline/infra/__main__.py
@@ -587,7 +587,7 @@ data_in_pipeline_load_api_apprunner_service = aws.apprunner.Service(
                 },
             ),
             image_identifier=data_in_pipeline_load_api_ecr_repository.repository_url.apply(
-                lambda respository_url: f"{respository_url}:latest"
+                lambda repository_url: f"{repository_url}:latest"
             ),
             image_repository_type="ECR",
         ),
@@ -737,7 +737,7 @@ data_in_api_apprunner_service = aws.apprunner.Service(
                 },
             ),
             image_identifier=data_in_api_aws_ecr_repository.aws_ecr_repository.repository_url.apply(
-                lambda respository_url: f"{respository_url}:latest"
+                lambda repository_url: f"{repository_url}:latest"
             ),
             image_repository_type="ECR",
         ),


### PR DESCRIPTION
# Description

Use read only endpoint for connecting `data-in-api` to Aurora, instead of writer.

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand
      areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
