### PR TITLE
Increase memory and cpu for the dip flow as it was failing

### DIFF
--- a/data-in-pipeline/app/deploy.py
+++ b/data-in-pipeline/app/deploy.py
@@ -15,8 +15,8 @@ from app.navigator_family_etl_pipeline import data_in_pipeline
 
 MEGABYTES_PER_GIGABYTE = 1024
 DEFAULT_FLOW_VARIABLES = {
-    "cpu": MEGABYTES_PER_GIGABYTE * 1,
-    "memory": MEGABYTES_PER_GIGABYTE * 2,
+    "cpu": MEGABYTES_PER_GIGABYTE * 2,
+    "memory": MEGABYTES_PER_GIGABYTE * 32,
 }
 
 


### PR DESCRIPTION
# Description

Increase memory and cpu as they were too low for the prefect flow to handle the whole data import.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand
      areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
