### PR TITLE
Fix job variable merge order to preserve default flow variables

### DIFF
--- a/data-in-pipeline/app/deploy.py
+++ b/data-in-pipeline/app/deploy.py
@@ -275,7 +275,10 @@ def create_deployment(flow: Flow) -> None:
     )
 
     job_variables = _merge_job_environments(
-        {**DEFAULT_FLOW_VARIABLES, **default_job_variables},
+        {
+            **default_job_variables,
+            **DEFAULT_FLOW_VARIABLES,
+        },
         runtime_environment,
         secrets_arns,
         ssm_secrets,


### PR DESCRIPTION
Default flow variables were being unintentionally overwritten during job variable construction due to dictionary merge order. Because Python dict unpacking applies a last-write-wins strategy, values from default_job_variables were overriding 

DEFAULT_FLOW_VARIABLES, even when defaults were intended to be authoritative.
This resulted in unexpected runtime configuration and made it difficult to rely on documented default behavior.

Solution

Adjusted the merge order so that DEFAULT_FLOW_VARIABLES are applied after job-level defaults, ensuring they are preserved unless explicitly overridden at runtime or via secrets.
Before
{**DEFAULT_FLOW_VARIABLES, **default_job_variables}
After
{**default_job_variables, **DEFAULT_FLOW_VARIABLES}
This makes variable precedence explicit and aligns behavior with expected configuration layering.