### PR TITLE
Fix: Adjust Fargate CPU configuration to match memory requirements

### DIFF
--- a/data-in-pipeline/app/deploy.py
+++ b/data-in-pipeline/app/deploy.py
@@ -13,9 +13,12 @@ from pydantic import BaseModel, model_validator
 from app.bootstrap_telemetry import get_logger
 from app.navigator_family_etl_pipeline import data_in_pipeline
 
+# Fargate requires proportional CPU/Memory ratios
+# 16384 MB (16GB) memory requires minimum 4096 CPU (4 vCPU)
+# See: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html
 MEGABYTES_PER_GIGABYTE = 1024
 DEFAULT_FLOW_VARIABLES = {
-    "cpu": MEGABYTES_PER_GIGABYTE * 1,
+    "cpu": MEGABYTES_PER_GIGABYTE * 4,
     "memory": MEGABYTES_PER_GIGABYTE * 16,
 }
 


### PR DESCRIPTION
AWS Fargate requires specific CPU/Memory combinations. The configuration had 1024 CPU (1 vCPU) with 16384 memory (16GB), which is invalid. The maximum memory for 1 vCPU is 8GB.

**Solution**
Increased CPU from 1024 (1 vCPU) to 4096 (4 vCPU) to support the 16GB memory requirement.


**Changes**
Prefect worker configuration: Updated cpu from 1024 to 4096
Added comment documenting Fargate CPU/Memory ratio requirements

Valid Fargate combinations reference - https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html

1 vCPU (1024): 2-8GB
2 vCPU (2048): 4-16GB
4 vCPU (4096): 8-30GB ← Current config
8 vCPU (8192): 16-60GB
16 vCPU (16384): 32-120GB