### PR TITLE
fix(dip): add Item.source

### DIFF
--- a/data-in-models/src/data_in_models/models.py
+++ b/data-in-models/src/data_in_models/models.py
@@ -16,6 +16,7 @@ class DocumentLabelRelationship(BaseModel):
 
 
 class Item(BaseModel):
+    type: str
     url: str | None = None
 
 

--- a/data-in-pipeline/app/transform/navigator_family.py
+++ b/data-in-pipeline/app/transform/navigator_family.py
@@ -540,12 +540,14 @@ def _transform_navigator_document(
     if navigator_document.cdn_object is not None:
         items.append(
             Item(
+                type="cdn",
                 url=navigator_document.cdn_object,
             )
         )
     if navigator_document.source_url is not None:
         items.append(
             Item(
+                type="source",
                 url=navigator_document.source_url,
             )
         )

--- a/data-in-pipeline/tests/transform/test_navigator_family.py
+++ b/data-in-pipeline/tests/transform/test_navigator_family.py
@@ -558,9 +558,11 @@ def test_transform_navigator_family_with_single_matching_document(
                     ],
                     items=[
                         Item(
+                            type="cdn",
                             url="https://cdn.climatepolicyradar.org/path/to/file.pdf",
                         ),
                         Item(
+                            type="source",
                             url="https://source.climatepolicyradar.org/path/to/file.pdf",
                         ),
                     ],
@@ -629,9 +631,11 @@ def test_transform_navigator_family_with_single_matching_document(
                 ],
                 items=[
                     Item(
+                        type="cdn",
                         url="https://cdn.climatepolicyradar.org/path/to/file.pdf",
                     ),
                     Item(
+                        type="source",
                         url="https://source.climatepolicyradar.org/path/to/file.pdf",
                     ),
                 ],


### PR DESCRIPTION
# Description

- adds `source` as a required field for `Item`

This is to allow us to differentiate between where an `Item` has come from.