### PR TITLE
Fix Prefect task handling of mapped results by removing .result() calls

### DIFF
--- a/data-in-pipeline/app/navigator_family_etl_pipeline.py
+++ b/data-in-pipeline/app/navigator_family_etl_pipeline.py
@@ -345,7 +345,10 @@ def data_in_pipeline(
 
     document_batches = create_batches(transformed_documents, batch_size)
     load_results = load_batch.map(document_batches)
-    all_succeeded = check_load_results(load_results)
+
+    # Prefect resolves mapped task results before invoking tasks.
+    # Pyright sees PrefectFutureList here, but runtime value is list[str | Exception].
+    all_succeeded = check_load_results(load_results)  # type: ignore[reportArgumentType]
 
     if not all_succeeded:
         pipeline_metrics.record_processed(PipelineType.FAMILY, Status.FAILURE)
@@ -354,7 +357,9 @@ def data_in_pipeline(
     pipeline_metrics.record_processed(PipelineType.FAMILY, Status.SUCCESS)
     _LOGGER.info("ETL pipeline completed successfully")
 
-    upload_report(document_batches, load_results, run_id)
+    # Prefect resolves mapped task results before invoking tasks.
+    # Pyright sees PrefectFutureList here, but runtime value is list[str | Exception].
+    upload_report(document_batches, load_results, run_id)  # type: ignore[reportArgumentType]
 
     return PipelineResult(
         documents_processed=len(transformed_documents),


### PR DESCRIPTION
### PR description

**Summary**
Fixes a runtime error caused by calling `.result()` on mapped task outputs inside Prefect tasks. In Prefect 3, task inputs are already resolved values, not `PrefectFuture`s.

**What changed**

* Removed `.result()` calls from `check_load_results` and `upload_report`
* Updated logic to treat mapped task outputs as `str | Exception` values directly

**Why**

* Prefect resolves futures before invoking tasks
* Calling `.result()` inside a task causes runtime failures (`'str' object has no attribute 'result'`)
* Aligns implementation with Prefect’s execution model while keeping typing simple

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand
      areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
