### PR TITLE
Feature/app 1957 handle sabin documents that have missing parent concepts

### DIFF
--- a/data-in-pipeline/app/transform/navigator_family.py
+++ b/data-in-pipeline/app/transform/navigator_family.py
@@ -59,7 +59,7 @@ MCF_ATTRIBUTE_KEYS = {
 
 def transform_navigator_family(
     input: Identified[NavigatorFamily],
-) -> Result[list[Document], NoMatchingTransformations]:
+) -> Result[list[Document], CouldNotTransform | NoMatchingTransformations]:
     logger = get_logger()
     with log_context(import_id=input.id):
         logger.info(f"Transforming family with {len(input.data.documents)} documents")
@@ -68,6 +68,9 @@ def transform_navigator_family(
             case Success(d):
                 logger.info(f"Transform completed, produced {len(d)} documents")
                 return Success(d)
+            case Failure(error):
+                logger.warning(f"Transformation failed: {error}")
+                return Failure(error)
 
         logger.warning("No matching transformation found")
         return Failure(NoMatchingTransformations())
@@ -456,7 +459,6 @@ def _transform_litigation_concepts_to_label_relationships(
     concepts: list[NavigatorConcept],
     family_import_id: str,
 ) -> list[LabelRelationship]:
-    logger = get_logger()
     """
     Convert litigation concepts into label relationships with subconcept hierarchies.
 
@@ -498,11 +500,7 @@ def _transform_litigation_concepts_to_label_relationships(
         for parent_name in concept.subconcept_of_labels:
             parent = label_by_name.get((concept.relation, parent_name))
             if parent is None:
-                # TODO: we should accumulate these errors and report them somewhere.
-                # raise ValueError(
-                #     f"Unknown parent label {parent_name!r} in relation {concept.relation!r}. See family {family_import_id!r} for details."
-                # )
-                logger.error(
+                raise CouldNotTransform(
                     f"Unknown parent label {parent_name!r} in relation {concept.relation!r}. See family {family_import_id!r} for details."
                 )
             else:

--- a/data-in-pipeline/app/transform/navigator_family.py
+++ b/data-in-pipeline/app/transform/navigator_family.py
@@ -103,7 +103,11 @@ def transform(
     """
     Transform
     """
-    document_from_family = _transform_navigator_family(input.data)
+    result = _transform_navigator_family(input.data)
+    if isinstance(result, Failure):
+        return result
+    document_from_family = result
+
     documents_from_documents = [
         _transform_navigator_document(
             document,
@@ -458,7 +462,7 @@ def _shallow_label(
 def _transform_litigation_concepts_to_label_relationships(
     concepts: list[NavigatorConcept],
     family_import_id: str,
-) -> list[LabelRelationship]:
+) -> Result[list[LabelRelationship], CouldNotTransform]:
     """
     Convert litigation concepts into label relationships with subconcept hierarchies.
 
@@ -500,8 +504,10 @@ def _transform_litigation_concepts_to_label_relationships(
         for parent_name in concept.subconcept_of_labels:
             parent = label_by_name.get((concept.relation, parent_name))
             if parent is None:
-                raise CouldNotTransform(
-                    f"Unknown parent label {parent_name!r} in relation {concept.relation!r}. See family {family_import_id!r} for details."
+                return Failure(
+                    CouldNotTransform(
+                        f"Unknown parent label {parent_name!r} in relation {concept.relation!r}. See family {family_import_id!r} for details."
+                    )
                 )
             else:
                 parent_ref = _shallow_label(parent)
@@ -510,11 +516,13 @@ def _transform_litigation_concepts_to_label_relationships(
                     LabelRelationship(type="subconcept_of", value=parent_ref)
                 )
 
-    return [
-        # we use legal_concept over concept as `concept` is reserved for our knowledge graph labels
-        LabelRelationship(type="legal_concept", value=label)
-        for label in label_map.values()
-    ]
+    return Success(
+        [
+            # we use legal_concept over concept as `concept` is reserved for our knowledge graph labels
+            LabelRelationship(type="legal_concept", value=label)
+            for label in label_map.values()
+        ]
+    )
 
 
 def _transform_to_category(
@@ -645,7 +653,9 @@ def _transform_to_category(
     return labels
 
 
-def _transform_navigator_family(navigator_family: NavigatorFamily) -> Document:
+def _transform_navigator_family(
+    navigator_family: NavigatorFamily,
+) -> Result[Document, CouldNotTransform]:
     labels: list[LabelRelationship] = []
     attributes: dict[str, str | float | bool] = {}
 
@@ -856,11 +866,13 @@ def _transform_navigator_family(navigator_family: NavigatorFamily) -> Document:
         navigator_family.corpus.import_id == "Academic.corpus.Litigation.n0000"
         and navigator_family.concepts
     ):
-        labels.extend(
-            _transform_litigation_concepts_to_label_relationships(
-                navigator_family.concepts, navigator_family.import_id
-            )
-        )
+        match _transform_litigation_concepts_to_label_relationships(
+            navigator_family.concepts, navigator_family.import_id
+        ):
+            case Success(litigation_labels):
+                labels.extend(litigation_labels)
+            case Failure(e):
+                return Failure(e)
 
     """
     Dates

--- a/data-in-pipeline/app/transform/navigator_family.py
+++ b/data-in-pipeline/app/transform/navigator_family.py
@@ -106,7 +106,8 @@ def transform(
     result = _transform_navigator_family(input.data)
     if isinstance(result, Failure):
         return result
-    document_from_family = result
+    else:
+        document_from_family = result.unwrap()
 
     documents_from_documents = [
         _transform_navigator_document(
@@ -897,12 +898,14 @@ def _transform_navigator_family(
     if navigator_family.documents and contains_published_document:
         attributes["status"] = "PUBLISHED"
 
-    return Document(
-        id=navigator_family.import_id,
-        title=navigator_family.title,
-        description=navigator_family.summary,
-        labels=_deduplicate_labels(labels),
-        attributes=attributes,
+    return Success(
+        Document(
+            id=navigator_family.import_id,
+            title=navigator_family.title,
+            description=navigator_family.summary,
+            labels=_deduplicate_labels(labels),
+            attributes=attributes,
+        )
     )
 
 

--- a/data-in-pipeline/tests/transform/test_navigator_family.py
+++ b/data-in-pipeline/tests/transform/test_navigator_family.py
@@ -1,11 +1,6 @@
 import datetime
 
 import pytest
-from app.extract.connectors import (
-    NavigatorFamily,
-)
-from app.models import Identified, NavigatorConcept
-from app.transform.navigator_family import transform_navigator_family
 from data_in_models.models import (
     Document,
     DocumentRelationship,
@@ -15,6 +10,13 @@ from data_in_models.models import (
     LabelRelationship,
     LabelWithoutDocumentRelationships,
 )
+
+from app.extract.connectors import (
+    NavigatorFamily,
+)
+from app.models import Identified, NavigatorConcept
+from app.transform.models import CouldNotTransform
+from app.transform.navigator_family import transform_navigator_family
 from tests.factories import (
     NavigatorCollectionFactory,
     NavigatorCorpusFactory,
@@ -339,6 +341,69 @@ def navigator_family_with_litigation_concepts() -> Identified[NavigatorFamily]:
     )
 
 
+@pytest.fixture
+def navigator_family_with_litigation_concept_missing_parent() -> (
+    Identified[NavigatorFamily]
+):
+    decision_date = datetime.datetime(2020, 1, 1)
+    return Identified(
+        id="family",
+        source="navigator_family",
+        data=NavigatorFamilyFactory.build(
+            import_id="family",
+            title="Litigation family",
+            summary="Family summary",
+            category="LITIGATION",
+            last_updated_date="2020-01-0100:00:00Z",
+            published_date="2020-01-0100:00:00Z",
+            corpus=NavigatorCorpusFactory.build(
+                import_id="Academic.corpus.Litigation.n0000",
+                corpus_type=NavigatorCorpusTypeFactory.build(name="Litigation"),
+                organisation=NavigatorOrganisationFactory.build(id=1, name="Sabin"),
+                attribution_url="testurl.org",
+                corpus_text="Test corpus",
+                corpus_image_url=None,
+            ),
+            documents=[
+                NavigatorDocumentFactory.build(
+                    import_id="document",
+                    title="Litigation family document",
+                    slug="litigation-document-slug",
+                    events=[
+                        NavigatorEventFactory.build(
+                            import_id="123",
+                            event_type="Decision",
+                            date=decision_date,
+                            valid_metadata={
+                                "event_type": ["Decision"],
+                                "datetime_event_name": ["Decision"],
+                            },
+                        )
+                    ],
+                    variant="Original language",
+                    md5_sum="aaaaa11111bbbbb",
+                    languages=[],
+                    document_status="PUBLISHED",
+                ),
+            ],
+            events=[],
+            collections=[],
+            geographies=[],
+            slug="litigation-family-slug",
+            concepts=[
+                NavigatorConcept(
+                    id="High Court of Justice",
+                    ids=[],
+                    type="legal_entity",
+                    relation="jurisdiction",
+                    preferred_label="High Court of Justice",
+                    subconcept_of_labels=["Missing Parent Label"],
+                ),
+            ],
+        ),
+    )
+
+
 def _mcf_events():
     base_date = datetime.datetime(2020, 1, 1)
     return [
@@ -459,9 +524,9 @@ def navigator_family_multilateral_climate_fund_project() -> Identified[Navigator
 
 
 @pytest.fixture
-def navigator_family_multilateral_climate_fund_guidance() -> Identified[
-    NavigatorFamily
-]:
+def navigator_family_multilateral_climate_fund_guidance() -> (
+    Identified[NavigatorFamily]
+):
     return Identified(
         id="family",
         source="navigator_family",
@@ -1603,6 +1668,23 @@ def test_transform_navigator_family_with_litigation_corpus_type_and_litigation_c
             ),
         ],
     )
+
+
+def test_transform_navigator_family_with_litigation_concepts_missing_parent_label_returns_failure(
+    navigator_family_with_litigation_concept_missing_parent: Identified[
+        NavigatorFamily
+    ],
+):
+    result = transform_navigator_family(
+        navigator_family_with_litigation_concept_missing_parent
+    )
+
+    failure_exception = result.swap().unwrap()
+    assert isinstance(failure_exception, CouldNotTransform)
+    assert (
+        "Unknown parent label 'Missing Parent Label' in relation 'jurisdiction'. "
+        "See family 'family' for details."
+    ) in str(failure_exception)
 
 
 def test_transform_navigator_family_with_multilateral_climate_fund_project(
@@ -2771,6 +2853,6 @@ def test_transform_to_category_corpus_ids(corpus_id: str, expected_category: str
     family_doc = documents[0]
 
     category_labels = [label for label in family_doc.labels if label.type == "category"]
-    assert any(label.value.id == expected_category for label in category_labels), (
-        f"Expected category '{expected_category}' not found in labels for corpus '{corpus_id}'"
-    )
+    assert any(
+        label.value.id == expected_category for label in category_labels
+    ), f"Expected category '{expected_category}' not found in labels for corpus '{corpus_id}'"


### PR DESCRIPTION
## Fix litigation concept transform to propagate missing parent errors correctly

### Problem

When transforming litigation concepts, if a concept referenced a parent label that didn't exist, the code raised a exception directly, which was silenced so that we could get transformations in. We need a way to gather a list of these transformation errors and relay this back to the Sabin team so that can fix the erroring data.

### Changes

- Updated `_transform_litigation_concepts_to_label_relationships` to return `Result[list[LabelRelationship], CouldNotTransform]` instead of `list[LabelRelationship]`, wrapping the success path in `Success(...)` and the missing parent case in `Failure(...)`
- Updated `_transform_navigator_family` to pattern match on the result and propagate any `Failure` up the call stack
- Updated `_transform_navigator_family`'s return type annotation to the correct two-parameter form `Result[Document, CouldNotTransform]`

### Result

Missing parent labels are now handled as a `Failure` that propagates cleanly through `transform` → `transform_navigator_family` → the pipeline loop, where it is logged and recorded as a metric rather than crashing the pipeline.