### PR TITLE
fix: only map label label relationships for labels with allowed types

### DIFF
--- a/data-in-api/app/repository.py
+++ b/data-in-api/app/repository.py
@@ -28,6 +28,12 @@ from sqlmodel import Session, select
 
 _LOGGER = logging.getLogger(__name__)
 
+LABEL_TYPES_WITH_RELATIONSHIPS = {
+    "case_category",
+    "principal_law",
+    "jurisdiction",
+}  # For now this is a hardcoded set of label types that we known have relationships, i.e Sabin types. Should this list be updated please be aware that different corpora may have the same labels.
+
 
 def check_db_health(db: Session) -> bool:
     """Check database connection health.
@@ -177,7 +183,11 @@ def _map_db_document_to_schema(db: Session, db_doc: DBDocument) -> DocumentOutpu
         for item in db_doc.items
     ]
 
-    label_ids: list[str] = [relationship.label_id for relationship in db_doc.labels]
+    label_ids: list[str] = [
+        relationship.label_id
+        for relationship in db_doc.labels
+        if relationship.label.type in LABEL_TYPES_WITH_RELATIONSHIPS
+    ]
 
     label_label_links: list[DBLabelLabelRelationship] = db.exec(
         select(DBLabelLabelRelationship).where(

--- a/data-in-api/tests/test_repository.py
+++ b/data-in-api/tests/test_repository.py
@@ -218,13 +218,13 @@ def test_label_with_parent_returns_nested_label(session: Session):
         session,
         "Federal Statutory Claims (US)",
         "Federal Statutory Claims (US)",
-        type_="category",
+        type_="principal_law",
     )
     create_label(
         session,
         "Endangered Species Act (US)",
         "Endangered Species Act (US)",
-        type_="category",
+        type_="principal_law",
     )
     link_label_to_parent(
         session, "Endangered Species Act (US)", "Federal Statutory Claims (US)"
@@ -240,15 +240,48 @@ def test_label_with_parent_returns_nested_label(session: Session):
 
     label_rel = doc.labels[0]
     assert label_rel.value.id == "Endangered Species Act (US)"
-    assert label_rel.value.type == "category"
+    assert label_rel.value.type == "principal_law"
     assert len(label_rel.value.labels) == 1
 
     parent = label_rel.value.labels[0]
     assert parent.type == "subconcept_of"
     assert parent.value.id == "Federal Statutory Claims (US)"
     assert parent.value.value == "Federal Statutory Claims (US)"
-    assert parent.value.type == "category"
+    assert parent.value.type == "principal_law"
     assert parent.value.labels == []
+
+
+def test_label_of_invalid_type_does_not_return_nested_labels(session: Session):
+    create_label(
+        session,
+        "Federal Statutory Claims (US)",
+        "Federal Statutory Claims (US)",
+        type_="random_type",
+    )
+    create_label(
+        session,
+        "Endangered Species Act (US)",
+        "Endangered Species Act (US)",
+        type_="random_type",
+    )
+    link_label_to_parent(
+        session, "Endangered Species Act (US)", "Federal Statutory Claims (US)"
+    )
+
+    create_document(session, "doc1", "Document 1")
+    link_document_label(session, "doc1", "Endangered Species Act (US)", type="concept")
+
+    doc = get_document_by_id(session, "doc1")
+
+    assert doc is not None
+    assert len(doc.labels) == 1
+
+    label_rel = doc.labels[0]
+    assert label_rel.value.id == "Endangered Species Act (US)"
+    assert label_rel.value.type == "random_type"
+    assert (
+        len(label_rel.value.labels) == 0
+    )  # No nested labels should be returned for invalid type
 
 
 def test_label_without_parent_has_empty_nested_labels(session: Session):
@@ -271,13 +304,13 @@ def test_mixed_labels_with_and_without_parents(session: Session):
         session,
         "Federal Statutory Claims (US)",
         "Federal Statutory Claims (US)",
-        type_="category",
+        type_="case_category",
     )
     create_label(
         session,
         "Endangered Species Act (US)",
         "Endangered Species Act (US)",
-        type_="category",
+        type_="case_category",
     )
     create_label(session, "Principal", "Principal", type_="status")
     link_label_to_parent(


### PR DESCRIPTION
# What does this do?
All labels have ids, and labels are not specifically tied to a corpus or document.

Labels can also have relationships with other labels. 

This means that if a Sabin Document and UNFCC document both have the UNFCC label, we attach all UNFCCC label relationships to the documents, even though currently only Sabin documents have that label-label relationships. 

For now we are only mapping that label label relationships to Sabin documents. I have added a note for future visitors. 


UNFCC 

```
{
"type": "deprecated_category",
"value": {
"attributes": {},
"id": "UNFCCC",
"type": "deprecated_category",
"value": "UNFCCC",
"labels": [
{
"type": "subconcept_of",
"value": {
"attributes": {},
"id": "International Law",
"type": "deprecated_category",
"value": "International Law",
"labels": []
},
"timestamp": null
}
]
},
```


Sabin 


```
"type": "legal_concept",
"value": {
"attributes": {
"attribution_url": "https://climate-laws.org/",
"corpus_text": "<p>This document was downloaded from the <a href=\"https://unfccc.int/\" target=\"_blank\"> UNFCCC website</a>. Please check <a href=\"https://unfccc.int/this-site/terms-of-use\" target=\"_blank\"> terms of use </a> for citation and licensing of third party data.</p>",
"corpus_image_url": ""
},
"id": "UNFCCC",
"type": "agent",
"value": "UNFCCC",
"labels": [
{
"type": "subconcept_of",
"value": {
"attributes": {},
"id": "International Law",
"type": "agent",
"value": "International Law",
"labels": []
},
"timestamp": null
}
]
},
"timestamp": null
}

```