### PR TITLE
Transform navigator document events to activity_status label

### DIFF
--- a/data-in-pipeline/app/transform/navigator_family.py
+++ b/data-in-pipeline/app/transform/navigator_family.py
@@ -960,7 +960,8 @@ def _transform_navigator_document(
 
     if navigator_family.corpus.import_id == "Academic.corpus.Litigation.n0000":
         if navigator_document.events:
-            event_type = navigator_document.events[0].event_type
+            document_event = navigator_document.events[0]
+            event_type = document_event.event_type
             labels.append(
                 LabelRelationship(
                     type="entity_type",
@@ -968,6 +969,17 @@ def _transform_navigator_document(
                         id=f"entity_type::{event_type}",
                         value=event_type,
                         type="entity_type",
+                    ),
+                )
+            )
+            labels.append(
+                LabelRelationship(
+                    type="activity_status",
+                    timestamp=document_event.date,
+                    value=Label(
+                        id="activity_status::Filed",
+                        value="Filed",
+                        type="activity_status",
                     ),
                 )
             )

--- a/data-in-pipeline/tests/transform/test_navigator_family.py
+++ b/data-in-pipeline/tests/transform/test_navigator_family.py
@@ -1394,6 +1394,18 @@ def test_transform_navigator_family_with_litigation_corpus_type(
                             ),
                         ),
                         LabelRelationship(
+                            timestamp=datetime.datetime(2020, 1, 1, 0, 0),
+                            type="activity_status",
+                            value=Label(
+                                attributes={},
+                                documents=[],
+                                id="activity_status::Filed",
+                                labels=[],
+                                type="activity_status",
+                                value="Filed",
+                            ),
+                        ),
+                        LabelRelationship(
                             type="provider",
                             value=Label(
                                 type="agent",
@@ -1473,6 +1485,18 @@ def test_transform_navigator_family_with_litigation_corpus_type(
                             id="entity_type::Decision",
                             value="Decision",
                             type="entity_type",
+                        ),
+                    ),
+                    LabelRelationship(
+                        timestamp=datetime.datetime(2020, 1, 1, 0, 0),
+                        type="activity_status",
+                        value=Label(
+                            attributes={},
+                            documents=[],
+                            id="activity_status::Filed",
+                            labels=[],
+                            type="activity_status",
+                            value="Filed",
                         ),
                     ),
                     LabelRelationship(
@@ -1650,6 +1674,18 @@ def test_transform_navigator_family_with_litigation_corpus_type_and_litigation_c
                             ),
                         ),
                         LabelRelationship(
+                            timestamp=datetime.datetime(2020, 1, 1, 0, 0),
+                            type="activity_status",
+                            value=Label(
+                                attributes={},
+                                documents=[],
+                                id="activity_status::Filed",
+                                labels=[],
+                                type="activity_status",
+                                value="Filed",
+                            ),
+                        ),
+                        LabelRelationship(
                             type="provider",
                             value=Label(
                                 type="agent",
@@ -1693,6 +1729,18 @@ def test_transform_navigator_family_with_litigation_corpus_type_and_litigation_c
                             id="entity_type::Decision",
                             value="Decision",
                             type="entity_type",
+                        ),
+                    ),
+                    LabelRelationship(
+                        timestamp=datetime.datetime(2020, 1, 1, 0, 0),
+                        type="activity_status",
+                        value=Label(
+                            attributes={},
+                            documents=[],
+                            id="activity_status::Filed",
+                            labels=[],
+                            type="activity_status",
+                            value="Filed",
                         ),
                     ),
                     LabelRelationship(


### PR DESCRIPTION
# What does this do?

- Transforms litigation document events to `activity_status` labels of type `Filed`

## Why is it needed?

- We need to capture the dates each litigation document was filed on.

## How was it tested?

- Unit tests
