### PR TITLE
fix: remove recently added iam policies related to iam auth on rds

### DIFF
--- a/api/infra/__main__.py
+++ b/api/infra/__main__.py
@@ -374,31 +374,6 @@ navigator_backend_github_actions_deploy = aws.iam.Role(
                             f"arn:aws:s3:::cpr-{stack}-document-cache/concepts/*"
                         ],
                     ),
-                    aws.iam.GetPolicyDocumentStatementArgs(
-                        actions=["rds:ModifyDBCluster"],
-                        effect="Allow",
-                        resources=[
-                            f"arn:aws:rds:*:{account_id}:cluster:data-in-pipeline-*",
-                        ],
-                    ),
-                    aws.iam.GetPolicyDocumentStatementArgs(
-                        actions=["rds:DescribeDBClusters"],
-                        effect="Allow",
-                        resources=["*"],
-                    ),
-                    aws.iam.GetPolicyDocumentStatementArgs(
-                        actions=[
-                            "iam:PutRolePolicy",
-                            "iam:DeleteRolePolicy",
-                            "iam:GetRolePolicy",
-                            "iam:GetRole",
-                            "iam:ListRolePolicies",
-                        ],
-                        effect="Allow",
-                        resources=[
-                            f"arn:aws:iam::{account_id}:role/prefect-data-in-pipeline-load-aurora-role",
-                        ],
-                    ),
                 ]
             ).json,
         )


### PR DESCRIPTION
- we are in a weird muddle state, where the github role permissions required to deploy the recentyly added policies to data in pipeline is out of sync and is erroring when trying to run a pulumi up despite having the requisite roles/permission


