### PR TITLE
Switch over user credentials on data in load api

### DIFF
--- a/data-in-pipeline-load-api/app/main.py
+++ b/data-in-pipeline-load-api/app/main.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import sys
+from contextlib import asynccontextmanager
 from pathlib import Path
 
 from api import FastAPITelemetry, ServiceManifest, SQLAlchemyTelemetry, TelemetryConfig
@@ -43,7 +44,14 @@ except Exception as _:
 telemetry = FastAPITelemetry(otel_config)
 tracer = telemetry.get_tracer()
 sqlalchemy_telemetry = SQLAlchemyTelemetry(tracer)
-sqlalchemy_telemetry.instrument(get_engine())
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    # Runs once when the server starts — not at import time
+    _LOGGER.info("⚙️ Instrumenting SQLAlchemy telemetry")
+    sqlalchemy_telemetry.instrument(get_engine())
+    yield
 
 
 # Create the FastAPI app
@@ -51,6 +59,7 @@ app = FastAPI(
     docs_url="/load/docs",
     redoc_url="/load/redoc",
     openapi_url="/load/openapi.json",
+    lifespan=lifespan,
 )
 
 # Include router in app

--- a/data-in-pipeline-load-api/app/session.py
+++ b/data-in-pipeline-load-api/app/session.py
@@ -18,48 +18,6 @@ from app.settings import settings
 _LOGGER = logging.getLogger(__name__)
 
 
-username = get_ssm_parameter("data-in-pipeline-aurora-write-replica-db-username")
-
-session = get_aws_session()
-client = session.client("rds")
-
-ENDPOINT = settings.load_database_url.get_secret_value()
-PORT = settings.db_port
-REGION = settings.aws_region
-
-token = client.generate_db_auth_token(
-    DBHostname=ENDPOINT, Port=PORT, DBUsername=username, Region=REGION
-)
-
-
-SQLALCHEMY_DATABASE_URI = (
-    f"postgresql://{username}:"
-    f"{token}@"
-    f"{ENDPOINT}:"
-    f"{PORT}/{settings.db_name}?sslmode={settings.db_sslmode}"
-)
-
-_LOGGER.info(
-    f"🔌 Initialising database engine for "
-    f"{settings.load_database_url.get_secret_value()}:"
-    f"{settings.db_port}/{settings.db_name}"
-)
-
-# Engine with connection pooling to prevent connection leaks
-# Lazy initialisation - created once per worker
-_engine = create_engine(
-    SQLALCHEMY_DATABASE_URI,
-    pool_pre_ping=True,  # Verify connections before use
-    pool_size=10,  # Base connection pool size
-    max_overflow=100,  # Additional connections when pool exhausted
-    pool_recycle=840,  # Recycle every 14 min to avoid expired IAM auth tokens (15 min lifetime). https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/UsingWithRDS.IAMDBAuth.html
-    pool_timeout=30,  # Wait up to 30s for a connection before error
-    isolation_level="READ COMMITTED",  # PostgreSQL default, explicit
-    connect_args={"options": f"-c statement_timeout={settings.statement_timeout}"},
-    echo=False,  # Set to True for SQL query logging in debug
-)
-
-
 @contextmanager
 def get_db_context() -> Generator[Session, None, None]:
     """Context manager for database session lifecycle.
@@ -71,7 +29,7 @@ def get_db_context() -> Generator[Session, None, None]:
     :yields: Database session
     :rtype: Generator[Session, None, None]
     """
-    db = Session(_engine)
+    db = Session(get_engine())
     try:
         _LOGGER.debug("Database session created (context manager)")
         yield db
@@ -99,6 +57,28 @@ def get_db() -> Generator[Session, None, None]:
         yield db
 
 
+def _build_database_uri() -> str:
+    """Fetch the IAM auth token and build the SQLAlchemy URI."""
+    username = get_ssm_parameter("data-in-pipeline-aurora-write-replica-db-username")
+
+    aws_session = get_aws_session()
+    rds_client = aws_session.client("rds")
+
+    endpoint = settings.load_database_url.get_secret_value()
+    port = settings.db_port
+    region = settings.aws_region
+
+    token = rds_client.generate_db_auth_token(
+        DBHostname=endpoint, Port=port, DBUsername=username, Region=region
+    )
+
+    return (
+        f"postgresql://{username}:{token}@"
+        f"{endpoint}:{port}/{settings.db_name}"
+        f"?sslmode={settings.db_sslmode}"
+    )
+
+
 def get_engine() -> Engine:
     """Get the database engine instance.
 
@@ -108,4 +88,25 @@ def get_engine() -> Engine:
     :return: SQLModel engine instance
     :rtype: Engine
     """
+
+    _LOGGER.info(
+        f"🔌 Initialising database engine for "
+        f"{settings.load_database_url.get_secret_value()}:"
+        f"{settings.db_port}/{settings.db_name}"
+    )
+
+    # Engine with connection pooling to prevent connection leaks
+    # Lazy initialisation - created once per worker
+    _engine = create_engine(
+        _build_database_uri(),
+        pool_pre_ping=True,  # Verify connections before use
+        pool_size=10,  # Base connection pool size
+        max_overflow=100,  # Additional connections when pool exhausted
+        pool_recycle=840,  # Recycle every 14 min to avoid expired IAM auth tokens (15 min lifetime). https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/UsingWithRDS.IAMDBAuth.html
+        pool_timeout=30,  # Wait up to 30s for a connection before error
+        isolation_level="READ COMMITTED",  # PostgreSQL default, explicit
+        connect_args={"options": f"-c statement_timeout={settings.statement_timeout}"},
+        echo=False,  # Set to True for SQL query logging in debug
+    )
+
     return _engine

--- a/data-in-pipeline-load-api/app/session.py
+++ b/data-in-pipeline-load-api/app/session.py
@@ -9,30 +9,34 @@ import logging
 from collections.abc import Generator
 from contextlib import contextmanager
 
-from pydantic import BaseModel
 from sqlalchemy.engine import Engine
 from sqlmodel import Session, create_engine
 
+from app.aws import get_aws_session, get_ssm_parameter
 from app.settings import settings
 
 _LOGGER = logging.getLogger(__name__)
 
 
-# Connection parameters from pydantic settings (validated on import)
-class ManagedDBPassword(BaseModel):
-    username: str
-    password: str
+username = get_ssm_parameter("data-in-pipeline-aurora-write-replica-db-username")
 
+session = get_aws_session()
+client = session.client("rds")
 
-username_password = ManagedDBPassword.model_validate_json(
-    settings.managed_db_password.get_secret_value()
+ENDPOINT = settings.load_database_url.get_secret_value()
+PORT = settings.db_port
+REGION = settings.aws_region
+
+token = client.generate_db_auth_token(
+    DBHostname=ENDPOINT, Port=PORT, DBUsername=username, Region=REGION
 )
 
+
 SQLALCHEMY_DATABASE_URI = (
-    f"postgresql://{settings.db_master_username}:"
-    f"{username_password.password}@"
-    f"{settings.load_database_url.get_secret_value()}:"
-    f"{settings.db_port}/{settings.db_name}?sslmode={settings.db_sslmode}"
+    f"postgresql://{username}:"
+    f"{token}@"
+    f"{ENDPOINT}:"
+    f"{PORT}/{settings.db_name}?sslmode={settings.db_sslmode}"
 )
 
 _LOGGER.info(
@@ -48,7 +52,7 @@ _engine = create_engine(
     pool_pre_ping=True,  # Verify connections before use
     pool_size=10,  # Base connection pool size
     max_overflow=100,  # Additional connections when pool exhausted
-    pool_recycle=1800,  # Recycle connections after 30 minutes
+    pool_recycle=840,  # Recycle every 14 min to avoid expired IAM auth tokens (15 min lifetime). https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/UsingWithRDS.IAMDBAuth.html
     pool_timeout=30,  # Wait up to 30s for a connection before error
     isolation_level="READ COMMITTED",  # PostgreSQL default, explicit
     connect_args={"options": f"-c statement_timeout={settings.statement_timeout}"},

--- a/data-in-pipeline-load-api/app/settings.py
+++ b/data-in-pipeline-load-api/app/settings.py
@@ -24,11 +24,10 @@ class Settings(BaseSettings):
     github_sha: str = "unknown"
 
     # DB connection parameters
-    db_master_username: str
-    managed_db_password: SecretStr
     load_database_url: SecretStr
     db_port: str
     db_name: str
+    aws_region: str
 
     # Connection pool parameters
     statement_timeout: str = "10000"

--- a/data-in-pipeline-load-api/docker-compose.yml
+++ b/data-in-pipeline-load-api/docker-compose.yml
@@ -33,14 +33,17 @@ services:
     working_dir: /app
     environment:
       db_master_username: data-in-pipeline-load-api
-      managed_db_password: '{"password": "data-in-pipeline-load-api", "username": "data-in-pipeline-load-api"}'
+      managed_db_password: '{"password": "data-in-pipeline-load-api",
+        "username": "data-in-pipeline-load-api"}'
       load_database_url: db
       db_port: 5432
       db_name: data-in-pipeline-load-api
       DB_URL: db
       DB_NAME: data-in-pipeline-load-api
       DB_USERNAME: data-in-pipeline-load-api
-      DB_SECRETS: '{"password": "data-in-pipeline-load-api", "username": "data-in-pipeline-load-api"}'
+      DB_SECRETS: '{"password": "data-in-pipeline-load-api", "username":
+        "data-in-pipeline-load-api"}'
+      AWS_REGION: eu-west-1
     command:
       [
         uv,
@@ -65,6 +68,7 @@ services:
       POSTGRES_USER: data-in-pipeline-load-api
       POSTGRES_PASSWORD: data-in-pipeline-load-api
       POSTGRES_DB: data-in-pipeline-load-api
+      AWS_REGION: eu-west-1
     ports:
       - 5432:5432
     healthcheck:
@@ -89,14 +93,17 @@ services:
     working_dir: /app
     environment:
       db_master_username: data-in-pipeline-load-api
-      managed_db_password: '{"password": "data-in-pipeline-load-api", "username": "data-in-pipeline-load-api"}'
+      managed_db_password: '{"password": "data-in-pipeline-load-api",
+        "username": "data-in-pipeline-load-api"}'
       load_database_url: test-db
       db_port: 5432
       db_name: data-in-pipeline-load-api
       DB_URL: test-db
       DB_NAME: data-in-pipeline-load-api
       DB_USERNAME: data-in-pipeline-load-api
-      DB_SECRETS: '{"password": "data-in-pipeline-load-api", "username": "data-in-pipeline-load-api"}'
+      DB_SECRETS: '{"password": "data-in-pipeline-load-api", "username":
+        "data-in-pipeline-load-api"}'
+      AWS_REGION: eu-west-1
     command:
       [
         uv,

--- a/data-in-pipeline/infra/__main__.py
+++ b/data-in-pipeline/infra/__main__.py
@@ -734,8 +734,6 @@ data_in_pipeline_load_api_apprunner_service = aws.apprunner.Service(
                 runtime_environment_secrets={
                     "LOAD_DATABASE_URL": data_in_pipeline_load_api_load_database_url.arn,
                     "CDN_URL": data_in_pipeline_load_api_cdn_url.arn,
-                    "MANAGED_DB_PASSWORD": data_in_pipeline_load_api_cluster_password_secret.secret_arn,
-                    # TODO: ^ to be removed in a later PR in favour of 👇
                     "DB_URL": data_in_pipeline_aurora_write_replica_db_url.arn,
                     "DB_NAME": data_in_pipeline_aurora_write_replica_db_name.arn,
                     "DB_USERNAME": data_in_pipeline_aurora_write_replica_db_username.arn,
@@ -743,7 +741,6 @@ data_in_pipeline_load_api_apprunner_service = aws.apprunner.Service(
                     "DB_SECRETS": data_in_pipeline_aurora_write_replica_db_secrets.secret_arn,
                 },
                 runtime_environment_variables={
-                    "DB_MASTER_USERNAME": config.require("aurora_master_username"),
                     "DB_PORT": "5432",
                     "AWS_REGION": "eu-west-1",
                 },

--- a/data-in-pipeline/infra/__main__.py
+++ b/data-in-pipeline/infra/__main__.py
@@ -495,7 +495,7 @@ data_in_pipeline_aurora_write_replica_db_username = aws.ssm.Parameter(
     ),
     description="Username for the load database",
     type=aws.ssm.ParameterType.STRING,
-    value=config.require("aurora_master_username"),
+    value=config.require("api_load_writer_db_user"),
 )
 # Get the ARN of the secret holding the master password
 # When manage_master_user_password=True, master_user_secrets contains exactly one secret

--- a/data-in-pipeline/infra/__main__.py
+++ b/data-in-pipeline/infra/__main__.py
@@ -736,7 +736,6 @@ data_in_pipeline_load_api_apprunner_service = aws.apprunner.Service(
                     "CDN_URL": data_in_pipeline_load_api_cdn_url.arn,
                     "DB_URL": data_in_pipeline_aurora_write_replica_db_url.arn,
                     "DB_NAME": data_in_pipeline_aurora_write_replica_db_name.arn,
-                    "DB_USERNAME": data_in_pipeline_aurora_write_replica_db_username.arn,
                     # This is in the format `{"password": "xxx", "username": "xxx"}`
                     "DB_SECRETS": data_in_pipeline_aurora_write_replica_db_secrets.secret_arn,
                 },


### PR DESCRIPTION

---

## 🚀 Switch database authentication to IAM

### Summary

This PR replaces static database credentials with IAM-based authentication for connecting to our Aurora PostgreSQL instance.

Instead of retrieving a long-lived password from configuration, we now generate a short-lived authentication token using AWS IAM. This improves security posture and aligns with AWS best practices for database access.

---

### 🔄 What changed

#### Authentication method

* ❌ Removed usage of:

  * Static username/password from `managed_db_password`
* ✅ Introduced:

  * IAM authentication via `rds.generate_db_auth_token`
  * Username retrieved from SSM Parameter Store
  * Temporary auth token used as the database password

#### AWS integration

* Added AWS session + RDS client usage to generate auth tokens
* Introduced dependency on:

  * SSM Parameter Store (for DB username)
  * IAM permissions for token generation

#### Connection string

* Updated `SQLALCHEMY_DATABASE_URI` to use:

  * IAM auth token instead of static password
  * Same PostgreSQL connection format with SSL enforced

---

### ⚙️ Connection pooling changes

* Updated `pool_recycle`:

  * From **1800s (30 min)** → **840s (14 min)**

This ensures connections are recycled before IAM tokens expire (15 min lifetime), preventing authentication failures from stale connections.

---

### 🧠 Why this matters

* Eliminates long-lived database credentials
* Reduces risk of credential leakage
* Enables fine-grained access control via IAM
* Aligns with AWS-recommended security practices

---

### ⚠️ Operational considerations

* Services must have IAM permissions to call:

  * `rds:GenerateDBAuthToken`
* Database must have IAM authentication enabled
* Connection recycling is critical due to token expiry
* Slight increase in connection overhead due to token generation

