### PR TITLE
chore: add missing policy

### DIFF
--- a/data-in-api/infra/__main__.py
+++ b/data-in-api/infra/__main__.py
@@ -304,6 +304,7 @@ data_in_pipeline_load_api_github_actions_role = aws.iam.Role(
                                 "iam:GetPolicy",
                                 "iam:GetRole",
                                 "acm:DescribeCertificate",
+                                "iam:PutRolePolicy",
                             ],
                             "Effect": "Allow",
                             "Resource": "*",


### PR DESCRIPTION

See error below.

Outputs:
    apprunner_service_url: "aa2pdfcjkk.eu-west-1.awsapprunner.com"
    role_arn             : "arn:aws:iam::***:role/data-in-api-production-github-actions"
    role_name            : "data-in-api-production-github-actions"

```
 aws:iam:RolePolicy (data-in-api-instance-role-policy):
    error:   sdk-v2/provider2.go:572: sdk.helper_schema: putting IAM Role (data-in-api-instance-role) Policy (data-in-api-instance-role-policy): operation error IAM: PutRolePolicy, https response error StatusCode: 403, RequestID: 7174b79e-2361-40a7-8c82-29495d374e8b, api error AccessDenied: User: arn:aws:sts::***:assumed-role/navigator-backend-github-actions-deploy/GitHub_to_AWS_via_FederatedOIDC_production is not authorized to perform: iam:PutRolePolicy on resource: role data-in-api-instance-role because no identity-based policy allows the iam:PutRolePolicy action: provider=aws@6.83.2
```    
```    
    error: 1 error occurred:
    	* updating urn:pulumi:production::data-in-api::aws:iam/rolePolicy:RolePolicy::data-in-api-instance-role-policy: 1 error occurred:
    	* putting IAM Role (data-in-api-instance-role) Policy (data-in-api-instance-role-policy): operation error IAM: PutRolePolicy, https response error StatusCode: 403, RequestID: 7174b79e-2361-40a7-8c82-29495d374e8b, api error AccessDenied: User: arn:aws:sts::***:assumed-role/navigator-backend-github-actions-deploy/GitHub_to_AWS_via_FederatedOIDC_production is not authorized to perform: iam:PutRolePolicy on resource: role data-in-api-instance-role because no identity-based policy allows the iam:PutRolePolicy action
   ```