### PR TITLE
Revert data-in-api to using master creds to connect to Aurora

### DIFF
--- a/data-in-api/app/session.py
+++ b/data-in-api/app/session.py
@@ -8,15 +8,50 @@ sessions. Use get_db_context() for all database operations.
 import logging
 from collections.abc import Generator
 from contextlib import contextmanager
-from urllib.parse import quote_plus
 
+from pydantic import BaseModel
 from sqlalchemy.engine import Engine
 from sqlmodel import Session, create_engine
 
-from app.aws import get_aws_session, get_ssm_parameter
 from app.settings import settings
 
 _LOGGER = logging.getLogger(__name__)
+
+
+# Connection parameters from pydantic settings (validated on import)
+class DBSecrets(BaseModel):
+    username: str
+    password: str
+
+
+db_secrets = DBSecrets.model_validate_json(settings.db_secrets.get_secret_value())
+
+SQLALCHEMY_DATABASE_URI = (
+    f"postgresql://{db_secrets.username}:"
+    f"{db_secrets.password}@"
+    f"{settings.db_url.get_secret_value()}:"
+    f"{settings.db_port}/{settings.db_name.get_secret_value()}?sslmode={settings.db_sslmode}"
+)
+
+_LOGGER.info(
+    f"🔌 Initialising database engine for "
+    f"{settings.db_url.get_secret_value()}:"
+    f"{settings.db_port}/{settings.db_name.get_secret_value()}"
+)
+
+# Engine with connection pooling to prevent connection leaks
+# Lazy initialisation - created once per worker
+_engine = create_engine(
+    SQLALCHEMY_DATABASE_URI,
+    pool_pre_ping=True,  # Verify connections before use
+    pool_size=10,  # Base connection pool size
+    max_overflow=100,  # Additional connections when pool exhausted
+    pool_recycle=1800,  # Recycle connections after 30 minutes
+    pool_timeout=30,  # Wait up to 30s for a connection before error
+    isolation_level="READ COMMITTED",  # PostgreSQL default, explicit
+    connect_args={"options": f"-c statement_timeout={settings.statement_timeout}"},
+    echo=False,  # Set to True for SQL query logging in debug
+)
 
 
 @contextmanager
@@ -30,7 +65,7 @@ def get_db_context() -> Generator[Session, None, None]:
     :yields: Database session
     :rtype: Generator[Session, None, None]
     """
-    db = Session(get_engine())
+    db = Session(_engine)
     try:
         _LOGGER.debug("Database session created (context manager)")
         yield db
@@ -58,31 +93,6 @@ def get_db() -> Generator[Session, None, None]:
         yield db
 
 
-def _build_database_uri() -> str:
-    """Fetch the IAM auth token and build the SQLAlchemy URI."""
-
-    username = get_ssm_parameter("/data-in-pipeline/aurora/read-replica-db-username")
-
-    aws_session = get_aws_session()
-    rds_client = aws_session.client("rds")
-
-    endpoint = settings.db_url.get_secret_value()
-    port = settings.db_port
-    region = settings.aws_region
-
-    _LOGGER.info("Generating IAM auth token")
-
-    token = rds_client.generate_db_auth_token(
-        DBHostname=endpoint, Port=port, DBUsername=username, Region=region
-    )
-
-    return (
-        f"postgresql://{username}:{quote_plus(token)}@"
-        f"{endpoint}:{port}/{settings.db_name.get_secret_value()}"
-        f"?sslmode={settings.db_sslmode}"
-    )
-
-
 def get_engine() -> Engine:
     """Get the database engine instance.
 
@@ -92,25 +102,4 @@ def get_engine() -> Engine:
     :return: SQLModel engine instance
     :rtype: Engine
     """
-
-    _LOGGER.info(
-        f"🔌 Initialising database engine for "
-        f"{settings.db_url.get_secret_value()}:"
-        f"{settings.db_port}/{settings.db_name.get_secret_value()}"
-    )
-
-    # Engine with connection pooling to prevent connection leaks
-    # Lazy initialisation - created once per worker
-    _engine = create_engine(
-        _build_database_uri(),
-        pool_pre_ping=True,  # Verify connections before use
-        pool_size=10,  # Base connection pool size
-        max_overflow=100,  # Additional connections when pool exhausted
-        pool_recycle=840,  # Recycle every 14 min to avoid expired IAM auth tokens (15 min lifetime). https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/UsingWithRDS.IAMDBAuth.html
-        pool_timeout=30,  # Wait up to 30s for a connection before error
-        isolation_level="READ COMMITTED",  # PostgreSQL default, explicit
-        connect_args={"options": f"-c statement_timeout={settings.statement_timeout}"},
-        echo=False,  # Set to True for SQL query logging in debug
-    )
-
     return _engine

--- a/data-in-api/app/settings.py
+++ b/data-in-api/app/settings.py
@@ -34,14 +34,12 @@ class Settings(BaseSettings):
     # Connection pool parameters
     statement_timeout: str = "10000"
 
-    aws_region: str
-
     # SSL mode for database connections
     # Valid values: disable, allow, prefer, require, verify-ca, verify-full
     # 'prefer' tries SSL but falls back to non-SSL for local dev (validates
     # certs if SSL is used). For production RDS without cert validation,
     # set db_sslmode=require via environment variable.
-    db_sslmode: str = "require"
+    db_sslmode: str = "prefer"
 
 
 # Pydantic settings are set from the env variables passed in via

--- a/data-in-api/infra/__main__.py
+++ b/data-in-api/infra/__main__.py
@@ -246,8 +246,13 @@ apprunner_service = aws.apprunner.Service(
             image_configuration=aws.apprunner.ServiceSourceConfigurationImageRepositoryImageConfigurationArgs(
                 runtime_environment_secrets={
                     "LOAD_DATABASE_URL": aurora_read_replica_db_url_parameter.arn,
+                    "MANAGED_DB_PASSWORD": aurora_read_replica_db_secret_arn,
+                    "DB_MASTER_USERNAME": aurora_read_replica_db_username_parameter.arn,
+                    # TODO: ^ to be removed in a later PR in favour of 👇
                     "DB_URL": aurora_read_replica_db_url_parameter.arn,
                     "DB_NAME": aurora_read_replica_db_name_parameter.arn,
+                    "DB_USERNAME": aurora_read_replica_db_username_parameter.arn,
+                    # This is in the format `{"password": "xxx", "username": "xxx"}`
                     "DB_SECRETS": aurora_read_replica_db_secret_arn,
                 },
                 runtime_environment_variables={

--- a/data-in-pipeline/infra/__main__.py
+++ b/data-in-pipeline/infra/__main__.py
@@ -545,7 +545,7 @@ data_in_pipeline_aurora_read_replica_db_username = aws.ssm.Parameter(
     ),
     description="Username for the load database",
     type=aws.ssm.ParameterType.STRING,
-    value=config.require("api_data_reader_db_user"),
+    value=config.require("aurora_master_username"),
 )
 # Get the ARN of the secret holding the master password
 # When manage_master_user_password=True, master_user_secrets contains exactly one secret


### PR DESCRIPTION
# What does this do?

Reverts IAM auth changes for `data-in-api` to use master credentials again.

## Why is it needed?

The token refresh was not working correctly and we have a user testing session so we need a quick fix to gethe api working again.


