### PR TITLE
Update CICD permissions

### DIFF
--- a/api/infra/__main__.py
+++ b/api/infra/__main__.py
@@ -392,11 +392,19 @@ navigator_backend_github_actions_deploy = aws.iam.Role(
                         resources=["*"],
                     ),
                     aws.iam.GetPolicyDocumentStatementArgs(
-                        actions=["iam:PassRole"],
+                        actions=[
+                            "iam:PassRole",
+                            "iam:DeleteRolePolicy",
+                            "iam:GetRole",
+                            "iam:ListRolePolicies",
+                            "iam:GetRolePolicy",
+                            "iam:PutRolePolicy",
+                            "iam:ListAttachedRolePolicies",
+                        ],
                         effect="Allow",
                         resources=[
-                            f"arn:aws:iam::{account_id}:role/data-in-pipeline-*"
-                            f"arn:aws:iam::{account_id}:role/data-in-api-*"
+                            f"arn:aws:iam::{account_id}:role/data-in-pipeline-*",
+                            f"arn:aws:iam::{account_id}:role/data-in-api-*",
                         ],
                     ),
                     aws.iam.GetPolicyDocumentStatementArgs(

--- a/data-in-api/infra/__main__.py
+++ b/data-in-api/infra/__main__.py
@@ -325,6 +325,7 @@ data_in_pipeline_load_api_github_actions_role = aws.iam.Role(
                                 "iam:GetRole",
                                 "acm:DescribeCertificate",
                                 "iam:PutRolePolicy",
+                                "iam:DeleteRolePolicy",
                             ],
                             "Effect": "Allow",
                             "Resource": "*",


### PR DESCRIPTION
# What does this do?

- Adds necessary permissions for the `data_in_pipeline_load_api_github_actions_role` and `navigator_backend_github_actions_deploy` to modify IAM policies for `data-in-api`

## Why is it needed?

- We needed to revert some IAM policy changes to get back to a fixed state with the `data-in-api` and the deployments were failing due to GA not having the right permissions to deploy them.

