### PR TITLE
Fix ssm parameter name when getting Aurora username

### DIFF
--- a/data-in-pipeline-load-api/app/session.py
+++ b/data-in-pipeline-load-api/app/session.py
@@ -59,7 +59,7 @@ def get_db() -> Generator[Session, None, None]:
 
 def _build_database_uri() -> str:
     """Fetch the IAM auth token and build the SQLAlchemy URI."""
-    username = get_ssm_parameter("data-in-pipeline-aurora-write-replica-db-username")
+    username = get_ssm_parameter("/data-in-pipeline/aurora/write-replica-db-username")
 
     aws_session = get_aws_session()
     rds_client = aws_session.client("rds")


### PR DESCRIPTION
# What does this do?

- Fixes the incorrect path to the Aurora write username in the Parameter Store

## Why is it needed?

- We are seeing errors when trying to access the username to connect to Aurora


