### PR TITLE
Fix ssm parameter name when getting Aurora username

### DIFF
--- a/data-in-pipeline-load-api/app/session.py
+++ b/data-in-pipeline-load-api/app/session.py
@@ -59,7 +59,7 @@ def get_db() -> Generator[Session, None, None]:
 
 def _build_database_uri() -> str:
     """Fetch the IAM auth token and build the SQLAlchemy URI."""
-    username = get_ssm_parameter("data-in-pipeline-aurora-write-replica-db-username")
+    username = get_ssm_parameter("/data-in-pipeline/aurora/write-replica-db-username")
 
     aws_session = get_aws_session()
     rds_client = aws_session.client("rds")

--- a/data-in-pipeline-load-api/app/session.py
+++ b/data-in-pipeline-load-api/app/session.py
@@ -8,6 +8,7 @@ sessions. Use get_db_context() for all database operations.
 import logging
 from collections.abc import Generator
 from contextlib import contextmanager
+from urllib.parse import quote_plus
 
 from sqlalchemy.engine import Engine
 from sqlmodel import Session, create_engine
@@ -75,7 +76,7 @@ def _build_database_uri() -> str:
     )
 
     return (
-        f"postgresql://{username}:{token}@"
+        f"postgresql://{username}:{quote_plus(token)}@"
         f"{endpoint}:{port}/{settings.db_name}"
         f"?sslmode={settings.db_sslmode}"
     )


### PR DESCRIPTION
Wraps the token in urllib.parse.quote_plus before interpolation so reserved characters are percent-encoded and the URI parses correctly.

The token returned by rds_client.generate_db_auth_token() is a signed URL containing reserved characters (?, &, =, /, +). Interpolating it directly into the postgresql:// URI caused the parser to terminate the password at the first '?', which both truncated the signature and discarded the trailing ?sslmode=... query parameter.

This produced two symptoms in production:
  - FATAL: PAM authentication failed (truncated token → bad signature)
  - FATAL: pg_hba.conf rejects connection ... no encryption
    (sslmode never applied → libpq connected in plaintext, which
    Aurora refuses for IAM-authenticated users)

Refs: https://repost.aws/knowledge-center/aurora-postgresql-connect-iam
