### PR TITLE
App 1809 fix aurora iam for load-api

### DIFF
--- a/data-in-pipeline-load-api/app/main.py
+++ b/data-in-pipeline-load-api/app/main.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import sys
-from contextlib import asynccontextmanager
 from pathlib import Path
 
 from api import FastAPITelemetry, ServiceManifest, SQLAlchemyTelemetry, TelemetryConfig
@@ -44,14 +43,7 @@ except Exception as _:
 telemetry = FastAPITelemetry(otel_config)
 tracer = telemetry.get_tracer()
 sqlalchemy_telemetry = SQLAlchemyTelemetry(tracer)
-
-
-@asynccontextmanager
-async def lifespan(app: FastAPI):
-    # Runs once when the server starts — not at import time
-    _LOGGER.info("⚙️ Instrumenting SQLAlchemy telemetry")
-    sqlalchemy_telemetry.instrument(get_engine())
-    yield
+sqlalchemy_telemetry.instrument(get_engine())
 
 
 # Create the FastAPI app
@@ -59,7 +51,6 @@ app = FastAPI(
     docs_url="/load/docs",
     redoc_url="/load/redoc",
     openapi_url="/load/openapi.json",
-    lifespan=lifespan,
 )
 
 # Include router in app

--- a/data-in-pipeline-load-api/app/session.py
+++ b/data-in-pipeline-load-api/app/session.py
@@ -8,7 +8,6 @@ sessions. Use get_db_context() for all database operations.
 import logging
 from collections.abc import Generator
 from contextlib import contextmanager
-from urllib.parse import quote_plus
 
 from sqlalchemy import Engine, event
 from sqlmodel import Session, create_engine
@@ -102,7 +101,7 @@ def _generate_token() -> str:
 @event.listens_for(_engine, "do_connect")
 def provide_token(dialect, conn_rec, cargs, cparams):
     _LOGGER.info("Generating fresh IAM auth token for new connection")
-    cparams["password"] = quote_plus(_generate_token())
+    cparams["password"] = _generate_token()
 
 
 def get_engine() -> Engine:

--- a/data-in-pipeline-load-api/app/session.py
+++ b/data-in-pipeline-load-api/app/session.py
@@ -10,13 +10,43 @@ from collections.abc import Generator
 from contextlib import contextmanager
 from urllib.parse import quote_plus
 
-from sqlalchemy.engine import Engine
+from sqlalchemy import Engine, event
 from sqlmodel import Session, create_engine
 
-from app.aws import get_aws_session, get_ssm_parameter
+from app.aws import get_aws_session
 from app.settings import settings
 
 _LOGGER = logging.getLogger(__name__)
+
+endpoint = settings.load_database_url.get_secret_value()
+port = settings.db_port
+region = settings.aws_region
+username = settings.db_username.get_secret_value()
+
+SQLALCHEMY_DATABASE_URI = (
+    f"postgresql://{username}@{endpoint}:{port}/{settings.db_name}"
+    f"?sslmode={settings.db_sslmode}"
+)
+
+_LOGGER.info(
+    f"🔌 Initialising database engine for "
+    f"{settings.load_database_url.get_secret_value()}:"
+    f"{settings.db_port}/{settings.db_name}"
+)
+
+# Engine with connection pooling to prevent connection leaks
+# Lazy initialisation - created once per worker
+_engine = create_engine(
+    SQLALCHEMY_DATABASE_URI,
+    pool_pre_ping=True,  # Verify connections before use
+    pool_size=10,  # Base connection pool size
+    max_overflow=100,  # Additional connections when pool exhausted
+    pool_recycle=840,  # Recycle every 14 min to avoid expired IAM auth tokens (15 min lifetime). https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/UsingWithRDS.IAMDBAuth.html
+    pool_timeout=30,  # Wait up to 30s for a connection before error
+    isolation_level="READ COMMITTED",  # PostgreSQL default, explicit
+    connect_args={"options": f"-c statement_timeout={settings.statement_timeout}"},
+    echo=False,  # Set to True for SQL query logging in debug
+)
 
 
 @contextmanager
@@ -30,7 +60,7 @@ def get_db_context() -> Generator[Session, None, None]:
     :yields: Database session
     :rtype: Generator[Session, None, None]
     """
-    db = Session(get_engine())
+    db = Session(_engine)
     try:
         _LOGGER.debug("Database session created (context manager)")
         yield db
@@ -58,58 +88,26 @@ def get_db() -> Generator[Session, None, None]:
         yield db
 
 
-def _build_database_uri() -> str:
-    """Fetch the IAM auth token and build the SQLAlchemy URI."""
-    username = get_ssm_parameter("/data-in-pipeline/aurora/write-replica-db-username")
-
+def _generate_token() -> str:
     aws_session = get_aws_session()
     rds_client = aws_session.client("rds")
-
-    endpoint = settings.load_database_url.get_secret_value()
-    port = settings.db_port
-    region = settings.aws_region
-
-    _LOGGER.info("Generating IAM auth token")
-
-    token = rds_client.generate_db_auth_token(
-        DBHostname=endpoint, Port=port, DBUsername=username, Region=region
+    return rds_client.generate_db_auth_token(
+        DBHostname=endpoint,
+        Port=port,
+        DBUsername=username,
+        Region=region,
     )
 
-    return (
-        f"postgresql://{username}:{quote_plus(token)}@"
-        f"{endpoint}:{port}/{settings.db_name}"
-        f"?sslmode={settings.db_sslmode}"
-    )
+
+@event.listens_for(_engine, "do_connect")
+def provide_token(dialect, conn_rec, cargs, cparams):
+    _LOGGER.info("Generating fresh IAM auth token for new connection")
+    cparams["password"] = quote_plus(_generate_token())
 
 
 def get_engine() -> Engine:
     """Get the database engine instance.
-
-    Exposed for testing and advanced use cases. Generally prefer
-    get_db_context() for normal operations.
-
     :return: SQLModel engine instance
     :rtype: Engine
     """
-
-    _LOGGER.info(
-        f"🔌 Initialising database engine for "
-        f"{settings.load_database_url.get_secret_value()}:"
-        f"{settings.db_port}/{settings.db_name}"
-    )
-
-    # Engine with connection pooling to prevent connection leaks
-    # Lazy initialisation - created once per worker
-    _engine = create_engine(
-        _build_database_uri(),
-        pool_pre_ping=True,  # Verify connections before use
-        pool_size=10,  # Base connection pool size
-        max_overflow=100,  # Additional connections when pool exhausted
-        pool_recycle=840,  # Recycle every 14 min to avoid expired IAM auth tokens (15 min lifetime). https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/UsingWithRDS.IAMDBAuth.html
-        pool_timeout=30,  # Wait up to 30s for a connection before error
-        isolation_level="READ COMMITTED",  # PostgreSQL default, explicit
-        connect_args={"options": f"-c statement_timeout={settings.statement_timeout}"},
-        echo=False,  # Set to True for SQL query logging in debug
-    )
-
     return _engine

--- a/data-in-pipeline-load-api/app/session.py
+++ b/data-in-pipeline-load-api/app/session.py
@@ -9,7 +9,8 @@ import logging
 from collections.abc import Generator
 from contextlib import contextmanager
 
-from sqlalchemy import Engine, event
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
 from sqlmodel import Session, create_engine
 
 from app.aws import get_aws_session

--- a/data-in-pipeline-load-api/app/session.py
+++ b/data-in-pipeline-load-api/app/session.py
@@ -59,7 +59,7 @@ def get_db() -> Generator[Session, None, None]:
 
 def _build_database_uri() -> str:
     """Fetch the IAM auth token and build the SQLAlchemy URI."""
-    username = get_ssm_parameter("data-in-pipeline-aurora-write-replica-db-username")
+    username = get_ssm_parameter("/data-in-pipeline/aurora/write-replica-db-username")
 
     aws_session = get_aws_session()
     rds_client = aws_session.client("rds")

--- a/data-in-pipeline-load-api/app/session.py
+++ b/data-in-pipeline-load-api/app/session.py
@@ -8,6 +8,7 @@ sessions. Use get_db_context() for all database operations.
 import logging
 from collections.abc import Generator
 from contextlib import contextmanager
+from urllib.parse import quote_plus
 
 from sqlalchemy.engine import Engine
 from sqlmodel import Session, create_engine
@@ -75,7 +76,7 @@ def _build_database_uri() -> str:
     )
 
     return (
-        f"postgresql://{username}:{token}@"
+        f"postgresql://{username}:{quote_plus(token)}@"
         f"{endpoint}:{port}/{settings.db_name}"
         f"?sslmode={settings.db_sslmode}"
     )

--- a/data-in-pipeline-load-api/app/settings.py
+++ b/data-in-pipeline-load-api/app/settings.py
@@ -27,6 +27,7 @@ class Settings(BaseSettings):
     load_database_url: SecretStr
     db_port: str
     db_name: str
+    db_username: SecretStr
     aws_region: str
 
     # Connection pool parameters


### PR DESCRIPTION
# What does this do?

- move engine creation back to module level so that it's created once
- add event listener to the engine so that it fetches the IAM token on connection   

## Why is it needed?

- in the previous implementation we were creating a new engine per request which is incorrect
- also the tokens were not managed correctly 

## How was it tested?

Integration tests