### PR TITLE
Schedule DIP to run daily at 5am

### DIFF
--- a/data-in-pipeline/app/deploy.py
+++ b/data-in-pipeline/app/deploy.py
@@ -305,6 +305,8 @@ def create_deployment(flow: Flow) -> None:
             tag="latest",
             dockerfile="Dockerfile",
         ),
+        # this is scheduled to run daily at 5am
+        cron="0 5 * * *",
         job_variables=job_variables | network,
         build=False,
         push=False,


### PR DESCRIPTION
# What does this do?

- Adds a schedule to the DIP deployment so that the flow runs every day at 5am (after the document pipeline finishes). 

## Why is it needed?

- So that the `data-in-api` has its data automatically updated


