### PR TITLE
Do not return Failure if parent concept is missing

### DIFF
--- a/data-in-pipeline/app/transform/navigator_family.py
+++ b/data-in-pipeline/app/transform/navigator_family.py
@@ -561,11 +561,7 @@ def _transform_litigation_concepts_to_label_relationships(
         for parent_name in concept.subconcept_of_labels:
             parent = label_by_name.get((concept.relation, parent_name))
             if parent is None:
-                return Failure(
-                    CouldNotTransform(
-                        f"Unknown parent label {parent_name!r} in relation {concept.relation!r}. See family {family_import_id!r} for details."
-                    )
-                )
+                continue
             else:
                 parent_ref = _shallow_label(parent)
 

--- a/data-in-pipeline/tests/transform/test_navigator_family_litigation.py
+++ b/data-in-pipeline/tests/transform/test_navigator_family_litigation.py
@@ -14,7 +14,6 @@ from app.extract.connectors import (
     NavigatorFamily,
 )
 from app.models import Identified, NavigatorConcept
-from app.transform.models import CouldNotTransform
 from app.transform.navigator_family import transform_navigator_family
 from tests.factories import (
     NavigatorCorpusFactory,
@@ -834,20 +833,3 @@ def test_transform_navigator_family_with_litigation_corpus_type_and_litigation_c
             ),
         ],
     )
-
-
-def test_transform_navigator_family_with_litigation_concepts_missing_parent_label_returns_failure(
-    navigator_family_with_litigation_concept_missing_parent: Identified[
-        NavigatorFamily
-    ],
-):
-    result = transform_navigator_family(
-        navigator_family_with_litigation_concept_missing_parent
-    )
-
-    failure_exception = result.swap().unwrap()
-    assert isinstance(failure_exception, CouldNotTransform)
-    assert (
-        "Unknown parent label 'Missing Parent Label' in relation 'jurisdiction'. "
-        "See family 'family' for details."
-    ) in str(failure_exception)


### PR DESCRIPTION
# What does this do?

- Removes code that returned a Failure result if a litigation concept on a family had a reference to a non-existent parent concept.

## Why is it needed?

- This meant that the whole document was not getting transformed which has led to stale data.
