### PR TITLE
fix: lowercase `published`

### DIFF
--- a/data-in-api/tests/test_repository.py
+++ b/data-in-api/tests/test_repository.py
@@ -1,6 +1,7 @@
 import logging
 
 import pytest
+from app.repository import get_all_documents, get_document_by_id, select_label
 from data_in_models.db_models import Document as DBDocument
 from data_in_models.db_models import (
     DocumentDocumentRelationship as DBDocumentDocumentLink,
@@ -11,8 +12,6 @@ from data_in_models.db_models import Label as DBLabel
 from data_in_models.db_models import LabelLabelRelationship as DBLabelLabelRelationship
 from data_in_models.models import Document as DocumentOutput
 from sqlmodel import Session
-
-from app.repository import get_all_documents, get_document_by_id, select_label
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -167,7 +166,6 @@ def test_get_document_by_id_not_found(session_with_documents: Session):
 
 
 def test_get_all_documents_filter_by_label_existing(session_with_documents: Session):
-
     documents = get_all_documents(
         session_with_documents, page=1, page_size=10, label_id="Main"
     )
@@ -179,15 +177,14 @@ def test_get_all_documents_filter_by_label_existing(session_with_documents: Sess
 
 
 def test_get_all_documents_filter_by_status(session_with_documents: Session):
-
     documents = get_all_documents(
-        session_with_documents, page=1, page_size=10, status="PUBLISHED"
+        session_with_documents, page=1, page_size=10, status="published"
     )
 
     assert len(documents) == 1
     doc = documents[0]
     assert doc.id == "doc1"
-    assert doc.attributes["status"] == "PUBLISHED"
+    assert doc.attributes["status"] == "published"
 
 
 def test_get_all_documents_filter_when_no_status(session: Session):
@@ -198,13 +195,12 @@ def test_get_all_documents_filter_when_no_status(session: Session):
         "Document from family description",
     )
 
-    documents = get_all_documents(session, page=1, page_size=10, status="PUBLISHED")
+    documents = get_all_documents(session, page=1, page_size=10, status="published")
 
     assert len(documents) == 0
 
 
 def test_get_all_documents_filter_by_label_nonexistent(session_with_documents: Session):
-
     documents = get_all_documents(
         session_with_documents, page=1, page_size=10, label_id="NonExistentLabel"
     )

--- a/data-in-pipeline/app/transform/navigator_family.py
+++ b/data-in-pipeline/app/transform/navigator_family.py
@@ -1000,10 +1000,10 @@ def _transform_navigator_family(
     """
 
     contains_published_document = [
-        doc for doc in navigator_family.documents if doc.document_status == "PUBLISHED"
+        doc for doc in navigator_family.documents if doc.document_status == "published"
     ]
     if navigator_family.documents and contains_published_document:
-        attributes["status"] = "PUBLISHED"
+        attributes["status"] = "published"
 
     return Success(
         Document(

--- a/data-in-pipeline/tests/transform/test_navigator_family.py
+++ b/data-in-pipeline/tests/transform/test_navigator_family.py
@@ -1,6 +1,11 @@
 import datetime
 
 import pytest
+from app.extract.connectors import (
+    NavigatorFamily,
+)
+from app.models import Identified
+from app.transform.navigator_family import transform_navigator_family
 from data_in_models.models import (
     Document,
     DocumentRelationship,
@@ -9,12 +14,6 @@ from data_in_models.models import (
     Label,
     LabelRelationship,
 )
-
-from app.extract.connectors import (
-    NavigatorFamily,
-)
-from app.models import Identified
-from app.transform.navigator_family import transform_navigator_family
 from tests.factories import (
     NavigatorCollectionFactory,
     NavigatorCorpusFactory,
@@ -105,7 +104,7 @@ def navigator_family_with_single_matching_document() -> Identified[NavigatorFami
                         "type": ["National Drought Plan (NDP)"],
                     },
                     slug="document-slug",
-                    document_status="PUBLISHED",
+                    document_status="published",
                 ),
             ],
             events=_standard_events(),
@@ -155,7 +154,7 @@ def navigator_family_with_no_matching_transformations() -> Identified[NavigatorF
                     import_id="456",
                     title="Test document 1",
                     events=[],
-                    document_status="PUBLISHED",
+                    document_status="published",
                 ),
             ],
             events=[],
@@ -538,7 +537,7 @@ def test_transform_navigator_family_with_single_matching_document(
                         "deprecated_slug": "document-slug",
                         "variant": "Original language",
                         "md5_sum": "aaaaa11111bbbbb",
-                        "status": "PUBLISHED",
+                        "status": "published",
                         "published_date": "2020-01-0100:00:00Z",
                         "last_updated_date": "2020-01-0100:00:00Z",
                     },
@@ -572,7 +571,7 @@ def test_transform_navigator_family_with_single_matching_document(
             "deprecated_slug": "family-slug",
             "published_date": "2020-01-0100:00:00Z",
             "last_updated_date": "2020-01-0100:00:00Z",
-            "status": "PUBLISHED",
+            "status": "published",
         },
     )
     assert_model_list_equality(
@@ -693,7 +692,7 @@ def test_transform_navigator_family_with_single_matching_document(
                     "deprecated_slug": "document-slug",
                     "variant": "Original language",
                     "md5_sum": "aaaaa11111bbbbb",
-                    "status": "PUBLISHED",
+                    "status": "published",
                     "published_date": "2020-01-0100:00:00Z",
                     "last_updated_date": "2020-01-0100:00:00Z",
                 },
@@ -969,7 +968,7 @@ def test_transform_navigator_family_with_published_and_unpublished_documents():
                     events=[],
                     valid_metadata={},
                     slug="document2-slug",
-                    document_status="PUBLISHED",
+                    document_status="published",
                 ),
             ],
             events=[],
@@ -1182,14 +1181,14 @@ def test_transform_navigator_family_with_published_and_unpublished_documents():
                         "deprecated_slug": "document2-slug",
                         "variant": "Original language",
                         "md5_sum": "aaaaa11111cccc",
-                        "status": "PUBLISHED",
+                        "status": "published",
                     },
                 ),
             ),
         ],
         attributes={
             "deprecated_slug": "family-with-different-document-statuses-slug",
-            "status": "PUBLISHED",
+            "status": "published",
         },
     )
     assert_model_list_equality(
@@ -1347,7 +1346,7 @@ def test_transform_navigator_family_with_published_and_unpublished_documents():
                     "deprecated_slug": "document2-slug",
                     "variant": "Original language",
                     "md5_sum": "aaaaa11111cccc",
-                    "status": "PUBLISHED",
+                    "status": "published",
                 },
             ),
         ],
@@ -1665,6 +1664,6 @@ def test_transform_to_category_corpus_ids(corpus_id: str, expected_category: str
     family_doc = documents[0]
 
     category_labels = [label for label in family_doc.labels if label.type == "category"]
-    assert any(
-        label.value.id == expected_category for label in category_labels
-    ), f"Expected category '{expected_category}' not found in labels for corpus '{corpus_id}'"
+    assert any(label.value.id == expected_category for label in category_labels), (
+        f"Expected category '{expected_category}' not found in labels for corpus '{corpus_id}'"
+    )

--- a/data-in-pipeline/tests/transform/test_navigator_family_litigation.py
+++ b/data-in-pipeline/tests/transform/test_navigator_family_litigation.py
@@ -71,7 +71,7 @@ def navigator_family_with_litigation_corpus_type() -> Identified[NavigatorFamily
                     variant="Original language",
                     md5_sum="aaaaa11111bbbbb",
                     languages=[],
-                    document_status="PUBLISHED",
+                    document_status="published",
                 ),
                 NavigatorDocumentFactory.build(
                     import_id="1.2.3.placeholder",
@@ -83,7 +83,7 @@ def navigator_family_with_litigation_corpus_type() -> Identified[NavigatorFamily
                     variant=None,
                     md5_sum="aaaaa11111bbbbb",
                     languages=[],
-                    document_status="PUBLISHED",
+                    document_status="published",
                 ),
             ],
             events=[
@@ -163,7 +163,7 @@ def navigator_family_with_litigation_concepts() -> Identified[NavigatorFamily]:
                     variant="Original language",
                     md5_sum="aaaaa11111bbbbb",
                     languages=[],
-                    document_status="PUBLISHED",
+                    document_status="published",
                 ),
             ],
             events=[
@@ -211,9 +211,9 @@ def navigator_family_with_litigation_concepts() -> Identified[NavigatorFamily]:
 
 
 @pytest.fixture
-def navigator_family_with_litigation_concept_missing_parent() -> (
-    Identified[NavigatorFamily]
-):
+def navigator_family_with_litigation_concept_missing_parent() -> Identified[
+    NavigatorFamily
+]:
     decision_date = datetime.datetime(2020, 1, 1)
     return Identified(
         id="family",
@@ -252,7 +252,7 @@ def navigator_family_with_litigation_concept_missing_parent() -> (
                     variant="Original language",
                     md5_sum="aaaaa11111bbbbb",
                     languages=[],
-                    document_status="PUBLISHED",
+                    document_status="published",
                 ),
             ],
             events=[],
@@ -414,7 +414,7 @@ def test_transform_navigator_family_with_litigation_corpus_type(
                         "deprecated_slug": "litigation-document-slug",
                         "md5_sum": "aaaaa11111bbbbb",
                         "variant": "Original language",
-                        "status": "PUBLISHED",
+                        "status": "published",
                         "published_date": "2020-01-0100:00:00Z",
                         "last_updated_date": "2020-01-0100:00:00Z",
                         "action_taken": "Answer filed by federal defendants",
@@ -460,7 +460,7 @@ def test_transform_navigator_family_with_litigation_corpus_type(
                     attributes={
                         "deprecated_slug": "placeholder-document-slug",
                         "md5_sum": "aaaaa11111bbbbb",
-                        "status": "PUBLISHED",
+                        "status": "published",
                         "published_date": "2020-01-0100:00:00Z",
                         "last_updated_date": "2020-01-0100:00:00Z",
                     },
@@ -473,7 +473,7 @@ def test_transform_navigator_family_with_litigation_corpus_type(
             "identifier::provider_id": "123456",
             "published_date": "2020-01-0100:00:00Z",
             "last_updated_date": "2020-01-0100:00:00Z",
-            "status": "PUBLISHED",
+            "status": "published",
             "core_object": "Core Object 123",
             "original_case_name": "Original case name",
             "case_status": "Decided",
@@ -542,7 +542,7 @@ def test_transform_navigator_family_with_litigation_corpus_type(
                     "deprecated_slug": "litigation-document-slug",
                     "md5_sum": "aaaaa11111bbbbb",
                     "variant": "Original language",
-                    "status": "PUBLISHED",
+                    "status": "published",
                     "published_date": "2020-01-0100:00:00Z",
                     "last_updated_date": "2020-01-0100:00:00Z",
                     "action_taken": "Answer filed by federal defendants",
@@ -593,7 +593,7 @@ def test_transform_navigator_family_with_litigation_corpus_type(
                 attributes={
                     "deprecated_slug": "placeholder-document-slug",
                     "md5_sum": "aaaaa11111bbbbb",
-                    "status": "PUBLISHED",
+                    "status": "published",
                     "published_date": "2020-01-0100:00:00Z",
                     "last_updated_date": "2020-01-0100:00:00Z",
                 },
@@ -750,7 +750,7 @@ def test_transform_navigator_family_with_litigation_corpus_type_and_litigation_c
                         "deprecated_slug": "litigation-document-slug",
                         "md5_sum": "aaaaa11111bbbbb",
                         "variant": "Original language",
-                        "status": "PUBLISHED",
+                        "status": "published",
                         "published_date": "2020-01-0100:00:00Z",
                         "last_updated_date": "2020-01-0100:00:00Z",
                     },
@@ -761,7 +761,7 @@ def test_transform_navigator_family_with_litigation_corpus_type_and_litigation_c
             "deprecated_slug": "litigation-family-slug",
             "published_date": "2020-01-0100:00:00Z",
             "last_updated_date": "2020-01-0100:00:00Z",
-            "status": "PUBLISHED",
+            "status": "published",
         },
     )
     assert_model_list_equality(
@@ -827,7 +827,7 @@ def test_transform_navigator_family_with_litigation_corpus_type_and_litigation_c
                     "deprecated_slug": "litigation-document-slug",
                     "md5_sum": "aaaaa11111bbbbb",
                     "variant": "Original language",
-                    "status": "PUBLISHED",
+                    "status": "published",
                     "published_date": "2020-01-0100:00:00Z",
                     "last_updated_date": "2020-01-0100:00:00Z",
                 },

--- a/data-in-pipeline/tests/transform/test_navigator_family_mcf.py
+++ b/data-in-pipeline/tests/transform/test_navigator_family_mcf.py
@@ -108,7 +108,7 @@ def navigator_family_multilateral_climate_fund_project() -> Identified[Navigator
                     md5_sum="aaaaa11111bbbbb",
                     language="eng",
                     languages=["eng"],
-                    document_status="PUBLISHED",
+                    document_status="published",
                 ),
                 NavigatorDocumentFactory.build(
                     import_id="document_2",
@@ -121,7 +121,7 @@ def navigator_family_multilateral_climate_fund_project() -> Identified[Navigator
                     md5_sum="aaaaa11111bbbbb",
                     language="eng",
                     languages=["eng"],
-                    document_status="PUBLISHED",
+                    document_status="published",
                 ),
             ],
             events=_mcf_events(),
@@ -145,9 +145,9 @@ def navigator_family_multilateral_climate_fund_project() -> Identified[Navigator
 
 
 @pytest.fixture
-def navigator_family_multilateral_climate_fund_guidance() -> (
-    Identified[NavigatorFamily]
-):
+def navigator_family_multilateral_climate_fund_guidance() -> Identified[
+    NavigatorFamily
+]:
     return Identified(
         id="family",
         source="navigator_family",
@@ -351,7 +351,7 @@ def test_transform_navigator_family_with_multilateral_climate_fund_project(
                         "deprecated_slug": "document-1-slug",
                         "variant": "Original language",
                         "md5_sum": "aaaaa11111bbbbb",
-                        "status": "PUBLISHED",
+                        "status": "published",
                     },
                 ),
             ),
@@ -411,7 +411,7 @@ def test_transform_navigator_family_with_multilateral_climate_fund_project(
                         "deprecated_slug": "document-2-slug",
                         "variant": "Original language",
                         "md5_sum": "aaaaa11111bbbbb",
-                        "status": "PUBLISHED",
+                        "status": "published",
                     },
                 ),
             ),
@@ -423,7 +423,7 @@ def test_transform_navigator_family_with_multilateral_climate_fund_project(
             "project_co_financing_usd": 100000,
             "project_fund_spend_usd": 250000,
             "project_url": "https://www.cif.org/projects",
-            "status": "PUBLISHED",
+            "status": "published",
         },
     )
     assert_model_list_equality(
@@ -484,7 +484,7 @@ def test_transform_navigator_family_with_multilateral_climate_fund_project(
                     "deprecated_slug": "document-1-slug",
                     "variant": "Original language",
                     "md5_sum": "aaaaa11111bbbbb",
-                    "status": "PUBLISHED",
+                    "status": "published",
                 },
             ),
             Document(
@@ -549,7 +549,7 @@ def test_transform_navigator_family_with_multilateral_climate_fund_project(
                     "deprecated_slug": "document-2-slug",
                     "variant": "Original language",
                     "md5_sum": "aaaaa11111bbbbb",
-                    "status": "PUBLISHED",
+                    "status": "published",
                 },
             ),
         ],


### PR DESCRIPTION
# What does this do?

- lowercases published universally

This is currently already the case in 
- [`families-api`](https://api.climatepolicyradar.org/families/CCLW.family.i00005745.n0000) (see `documents[].document_status`)
- [`data-in-api`](https://api.climatepolicyradar.org/data-in/documents/CCLW.legislative.4355.1972) (see `attributes.status`)

## Why is it needed?

- we currently aren't matching published on families

## How was it tested?

pytest
