### PR TITLE
Fix incorrect field name

### DIFF
--- a/data-in-pipeline/app/extract/connectors.py
+++ b/data-in-pipeline/app/extract/connectors.py
@@ -17,7 +17,7 @@ class NavigatorEvent(BaseModel):
     import_id: str
     event_type: str
     date: datetime.datetime
-    valid_metadata: dict[str, list[str]] = {}
+    metadata: dict[str, list[str]] = {}
 
 
 class NavigatorDocument(BaseModel):

--- a/data-in-pipeline/app/transform/navigator_family.py
+++ b/data-in-pipeline/app/transform/navigator_family.py
@@ -1043,7 +1043,7 @@ def _transform_navigator_document(
     if navigator_family.corpus.import_id == "Academic.corpus.Litigation.n0000":
         if navigator_document.events:
             document_event = navigator_document.events[0]
-            description = document_event.valid_metadata.get("description")
+            description = document_event.metadata.get("description")
             event_type = document_event.event_type
             labels.append(
                 LabelRelationship(
@@ -1066,7 +1066,7 @@ def _transform_navigator_document(
                     ),
                 )
             )
-            action_taken = document_event.valid_metadata.get("action_taken")
+            action_taken = document_event.metadata.get("action_taken")
             if action_taken:
                 attributes["action_taken"] = action_taken[0]
 

--- a/data-in-pipeline/tests/transform/test_navigator_family_litigation.py
+++ b/data-in-pipeline/tests/transform/test_navigator_family_litigation.py
@@ -59,7 +59,7 @@ def navigator_family_with_litigation_corpus_type() -> Identified[NavigatorFamily
                             import_id="123",
                             event_type="Decision",
                             date=decision_date,
-                            valid_metadata={
+                            metadata={
                                 "event_type": ["Decision"],
                                 "datetime_event_name": ["Decision"],
                                 "action_taken": ["Answer filed by federal defendants"],
@@ -90,7 +90,7 @@ def navigator_family_with_litigation_corpus_type() -> Identified[NavigatorFamily
                     import_id="123",
                     event_type="Decision",
                     date=decision_date,
-                    valid_metadata={
+                    metadata={
                         "event_type": ["Decision"],
                         "datetime_event_name": ["Decision"],
                     },
@@ -99,7 +99,7 @@ def navigator_family_with_litigation_corpus_type() -> Identified[NavigatorFamily
                     import_id="456",
                     event_type="Filing Year For Action",
                     date=decision_date,
-                    valid_metadata={
+                    metadata={
                         "event_type": ["Filing Year For Action"],
                         "datetime_event_name": ["Filing Year For Action"],
                     },
@@ -153,7 +153,7 @@ def navigator_family_with_litigation_concepts() -> Identified[NavigatorFamily]:
                             import_id="123",
                             event_type="Decision",
                             date=decision_date,
-                            valid_metadata={
+                            metadata={
                                 "event_type": ["Decision"],
                                 "datetime_event_name": ["Decision"],
                             },
@@ -170,7 +170,7 @@ def navigator_family_with_litigation_concepts() -> Identified[NavigatorFamily]:
                     import_id="123",
                     event_type="Decision",
                     date=decision_date,
-                    valid_metadata={
+                    metadata={
                         "event_type": ["Decision"],
                         "datetime_event_name": ["Decision"],
                     },


### PR DESCRIPTION
# What does this do?

- Fixes an incorrect field name `NavigatorEvent.valid_metadata` => `NavigatorEvent.metadata`

## Why is it needed?

- The document metadata was not getting populated during the `extract` step which led to attributes not being transformed as expected.

## How was it tested?

Unit tests