### PR TITLE
Do not break on extract errors

### DIFF
--- a/data-in-pipeline/app/extract/connectors.py
+++ b/data-in-pipeline/app/extract/connectors.py
@@ -2,7 +2,7 @@ import datetime
 from http import HTTPStatus
 
 import requests
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 from requests.adapters import HTTPAdapter, Retry
 from returns.result import Failure, Result, Success
 
@@ -82,8 +82,8 @@ class NavigatorFamily(BaseModel):
     slug: str
     concepts: list[NavigatorConcept] = []
     metadata: dict[str, list[str]] = {}
-    published_date: str | None
-    last_updated_date: str | None
+    published_date: str | None = None
+    last_updated_date: str | None = None
 
 
 class PageFetchFailure(BaseModel):
@@ -92,9 +92,15 @@ class PageFetchFailure(BaseModel):
     task_run_id: str | None
 
 
+class RecordValidationFailure(BaseModel):
+    import_ids: list[str]
+    page: int
+    error: str
+
+
 class FamilyFetchResult(BaseModel):
     envelopes: list[ExtractedEnvelope]
-    failure: PageFetchFailure | None = None
+    failures: PageFetchFailure | list[RecordValidationFailure] | None = None
 
 
 class HTTPConnector:
@@ -254,7 +260,16 @@ class NavigatorConnector(HTTPConnector):
 
             if not families_data:
                 logger.info(f"No families found for import_ids: {import_ids}")
-                return FamilyFetchResult(envelopes=[])
+                return FamilyFetchResult(
+                    envelopes=[],
+                    failures=[
+                        RecordValidationFailure(
+                            import_ids=import_ids,
+                            page=0,
+                            error="No families found for import_ids",
+                        )
+                    ],
+                )
 
             validated_families = [
                 NavigatorFamily.model_validate(family) for family in families_data
@@ -280,21 +295,25 @@ class NavigatorConnector(HTTPConnector):
             logger.info(
                 f"Successfully fetched {len(validated_families)} families by import_ids"
             )
-            return FamilyFetchResult(envelopes=[envelope])
+            return FamilyFetchResult(envelopes=[envelope], failures=[])
 
         except requests.RequestException as e:
             logger.exception(f"Request failed fetching families {import_ids}")
             pipeline_metrics.record_error(Operation.EXTRACT, ErrorType.NETWORK)
             return FamilyFetchResult(
                 envelopes=[],
-                failure=PageFetchFailure(page=0, error=str(e), task_run_id=task_run_id),
+                failures=PageFetchFailure(
+                    page=0, error=str(e), task_run_id=task_run_id
+                ),
             )
         except Exception as e:
             logger.exception(f"Unexpected error fetching families {import_ids}: {e}")
             pipeline_metrics.record_error(Operation.EXTRACT, ErrorType.UNKNOWN)
             return FamilyFetchResult(
                 envelopes=[],
-                failure=PageFetchFailure(page=0, error=str(e), task_run_id=task_run_id),
+                failures=PageFetchFailure(
+                    page=0, error=str(e), task_run_id=task_run_id
+                ),
             )
 
     def fetch_all_families(
@@ -322,6 +341,9 @@ class NavigatorConnector(HTTPConnector):
 
         page = 1
         successful_envelopes: list[ExtractedEnvelope] = []
+        failures: list[RecordValidationFailure] = []
+        validated_families: list[NavigatorFamily] = []
+
         while True:
             with log_context(page_number=page):
                 try:
@@ -336,29 +358,38 @@ class NavigatorConnector(HTTPConnector):
                         )
                         break
 
-                    validated_families = [
-                        NavigatorFamily.model_validate(family)
-                        for family in families_data
-                    ]
+                    for family in families_data:
+                        try:
+                            validated_families.append(
+                                NavigatorFamily.model_validate(family)
+                            )
+                        except ValidationError as e:
+                            failures.append(
+                                RecordValidationFailure(
+                                    import_ids=[family["import_id"]],
+                                    page=page,
+                                    error=f"Error validating family: {e.json()}",
+                                )
+                            )
+                    if validated_families:
+                        envelope = ExtractedEnvelope(
+                            data=validated_families,
+                            id=generate_envelope_uuid(),
+                            source_name="navigator_family",
+                            source_record_id=f"{task_run_id}-families-endpoint-page-{page}",
+                            raw_payload=families_data,
+                            content_type="application/json",
+                            connector_version="1.0.0",
+                            extracted_at=datetime.datetime.now(datetime.UTC),
+                            task_run_id=task_run_id,
+                            flow_run_id=flow_run_id,
+                            metadata=ExtractedMetadata(
+                                endpoint=f"{self.config.base_url}/families/?page={page}",
+                                http_status=HTTPStatus.OK,
+                            ),
+                        )
 
-                    envelope = ExtractedEnvelope(
-                        data=validated_families,
-                        id=generate_envelope_uuid(),
-                        source_name="navigator_family",
-                        source_record_id=f"{task_run_id}-families-endpoint-page-{page}",
-                        raw_payload=families_data,
-                        content_type="application/json",
-                        connector_version="1.0.0",
-                        extracted_at=datetime.datetime.now(datetime.UTC),
-                        task_run_id=task_run_id,
-                        flow_run_id=flow_run_id,
-                        metadata=ExtractedMetadata(
-                            endpoint=f"{self.config.base_url}/families/?page={page}",
-                            http_status=HTTPStatus.OK,
-                        ),
-                    )
-
-                    successful_envelopes.append(envelope)
+                        successful_envelopes.append(envelope)
                     page += 1
 
                 except requests.RequestException as e:
@@ -370,7 +401,7 @@ class NavigatorConnector(HTTPConnector):
                     )
                     return FamilyFetchResult(
                         envelopes=successful_envelopes,
-                        failure=PageFetchFailure(
+                        failures=PageFetchFailure(
                             page=page, error=str(e), task_run_id=task_run_id
                         ),
                     )
@@ -384,7 +415,7 @@ class NavigatorConnector(HTTPConnector):
                     )
                     return FamilyFetchResult(
                         envelopes=successful_envelopes,
-                        failure=PageFetchFailure(
+                        failures=PageFetchFailure(
                             page=page, error=str(e), task_run_id=task_run_id
                         ),
                     )
@@ -392,4 +423,4 @@ class NavigatorConnector(HTTPConnector):
         logger.info(
             f"Fetch families completed: {len(successful_envelopes)} pages succeeded"
         )
-        return FamilyFetchResult(envelopes=successful_envelopes)
+        return FamilyFetchResult(envelopes=successful_envelopes, failures=failures)

--- a/data-in-pipeline/app/extract/connectors.py
+++ b/data-in-pipeline/app/extract/connectors.py
@@ -100,7 +100,7 @@ class RecordValidationFailure(BaseModel):
 
 class FamilyFetchResult(BaseModel):
     envelopes: list[ExtractedEnvelope]
-    failures: list[PageFetchFailure] | list[RecordValidationFailure] | None = None
+    failures: list[PageFetchFailure] | list[RecordValidationFailure]
 
 
 class HTTPConnector:

--- a/data-in-pipeline/app/extract/connectors.py
+++ b/data-in-pipeline/app/extract/connectors.py
@@ -100,7 +100,7 @@ class RecordValidationFailure(BaseModel):
 
 class FamilyFetchResult(BaseModel):
     envelopes: list[ExtractedEnvelope]
-    failures: PageFetchFailure | list[RecordValidationFailure] | None = None
+    failures: list[PageFetchFailure] | list[RecordValidationFailure] | None = None
 
 
 class HTTPConnector:
@@ -302,18 +302,18 @@ class NavigatorConnector(HTTPConnector):
             pipeline_metrics.record_error(Operation.EXTRACT, ErrorType.NETWORK)
             return FamilyFetchResult(
                 envelopes=[],
-                failures=PageFetchFailure(
-                    page=0, error=str(e), task_run_id=task_run_id
-                ),
+                failures=[
+                    PageFetchFailure(page=0, error=str(e), task_run_id=task_run_id),
+                ],
             )
         except Exception as e:
             logger.exception(f"Unexpected error fetching families {import_ids}: {e}")
             pipeline_metrics.record_error(Operation.EXTRACT, ErrorType.UNKNOWN)
             return FamilyFetchResult(
                 envelopes=[],
-                failures=PageFetchFailure(
-                    page=0, error=str(e), task_run_id=task_run_id
-                ),
+                failures=[
+                    PageFetchFailure(page=0, error=str(e), task_run_id=task_run_id)
+                ],
             )
 
     def fetch_all_families(
@@ -401,9 +401,11 @@ class NavigatorConnector(HTTPConnector):
                     )
                     return FamilyFetchResult(
                         envelopes=successful_envelopes,
-                        failures=PageFetchFailure(
-                            page=page, error=str(e), task_run_id=task_run_id
-                        ),
+                        failures=[
+                            PageFetchFailure(
+                                page=page, error=str(e), task_run_id=task_run_id
+                            ),
+                        ],
                     )
 
                 except Exception as e:
@@ -415,9 +417,11 @@ class NavigatorConnector(HTTPConnector):
                     )
                     return FamilyFetchResult(
                         envelopes=successful_envelopes,
-                        failures=PageFetchFailure(
-                            page=page, error=str(e), task_run_id=task_run_id
-                        ),
+                        failures=[
+                            PageFetchFailure(
+                                page=page, error=str(e), task_run_id=task_run_id
+                            ),
+                        ],
                     )
 
         logger.info(

--- a/data-in-pipeline/app/navigator_family_etl_pipeline.py
+++ b/data-in-pipeline/app/navigator_family_etl_pipeline.py
@@ -20,6 +20,7 @@ from app.extract.connectors import (
     FamilyFetchResult,
     NavigatorConnector,
     NavigatorFamily,
+    RecordValidationFailure,
 )
 from app.extract.enums import CheckPointStorageType
 from app.identify.navigator_family import identify_navigator_families
@@ -181,6 +182,18 @@ def cache_transform_errors(errors: list[Exception], run_id: str):
         json.dumps(error_data),
         bucket="cpr-cache",
         key=f"pipelines/data-in-pipeline/transformation_errors/{run_id}-transform-errors.json",
+    )
+
+
+@task(log_prints=True)
+def cache_extract_errors(errors: list[RecordValidationFailure], run_id: str):
+    """Cache extract errors to S3."""
+
+    error_data = [f"{e.import_ids}: {e.error}" for e in errors]
+    upload_to_s3(
+        json.dumps(error_data),
+        bucket="cpr-cache",
+        key=f"pipelines/data-in-pipeline/extract_errors/{run_id}-extract-errors.json",
     )
 
 
@@ -374,12 +387,24 @@ def data_in_pipeline(
     # EXTRACT
     # -------------------------
     extracted_result = extract(ids)
+    extract_failures = extracted_result.failures
     cache_extraction_result(extracted_result)
 
-    if extracted_result.failures is not None:
-        _LOGGER.error(f"Extraction failed: {extracted_result.failures}")
-        pipeline_metrics.record_processed(PipelineType.FAMILY, Status.FAILURE)
-        return Exception(f"Extraction failed at page {extracted_result.failures.page}")
+    if extract_failures and isinstance(extract_failures[0], RecordValidationFailure):
+        _LOGGER.error(f"Extraction failed for some families: {extract_failures}")
+        pipeline_metrics.record_processed(PipelineType.FAMILY, Status.PARTIAL)
+        cache_extract_errors(extract_failures, run_id)  # type: ignore
+        asyncio.run(
+            SlackNotify.send_custom_message(
+                message=(
+                    f"⚠️ *Partial extract failure* in `{run_id}`\n"
+                    f"*Failed:* {len(extract_failures)} families\n"
+                    f"*Succeeded:* {len(extracted_result.envelopes)}\n"
+                    f"Failed IDs cached to S3 → `s3://cpr-cache/pipelines/data-in-pipeline/extract_errors/{run_id}-extract-errors.json`"
+                )
+            )
+        )
+        pipeline_metrics.record_processed(PipelineType.FAMILY, Status.PARTIAL)
 
     envelopes = extracted_result.envelopes
 

--- a/data-in-pipeline/app/navigator_family_etl_pipeline.py
+++ b/data-in-pipeline/app/navigator_family_etl_pipeline.py
@@ -376,10 +376,10 @@ def data_in_pipeline(
     extracted_result = extract(ids)
     cache_extraction_result(extracted_result)
 
-    if extracted_result.failure is not None:
-        _LOGGER.error(f"Extraction failed: {extracted_result.failure}")
+    if extracted_result.failures is not None:
+        _LOGGER.error(f"Extraction failed: {extracted_result.failures}")
         pipeline_metrics.record_processed(PipelineType.FAMILY, Status.FAILURE)
-        return Exception(f"Extraction failed at page {extracted_result.failure.page}")
+        return Exception(f"Extraction failed at page {extracted_result.failures.page}")
 
     envelopes = extracted_result.envelopes
 

--- a/data-in-pipeline/tests/extract/test_family_extract_step.py
+++ b/data-in-pipeline/tests/extract/test_family_extract_step.py
@@ -96,12 +96,12 @@ def test_extract_families_handles_valid_ids_success():
         )
 
         mock_connector_instance.fetch_families.return_value = FamilyFetchResult(
-            envelopes=[mock_envelope], failure=None
+            envelopes=[mock_envelope], failures=None
         )
 
         result = extract(valid_ids)
 
-    assert result.failure is None
+    assert result.failures is None
     assert len(result.envelopes) == 1
     assert result.envelopes[0].source_name == "navigator_family"
     expected_family_count = 2
@@ -125,16 +125,16 @@ def test_extract_families_propagates_connector_failure():
         expected_error = "Failed to fetch families: API timeout"
         mock_connector_instance.fetch_families.return_value = FamilyFetchResult(
             envelopes=[],
-            failure=PageFetchFailureFactory.build(
+            failures=PageFetchFailureFactory.build(
                 page=0, error=expected_error, task_run_id="task-001"
             ),
         )
 
         result = extract(invalid_ids)
 
-    assert result.failure is not None
-    assert isinstance(result.failure, PageFetchFailure)
-    assert "API timeout" in result.failure.error
+    assert result.failures is not None
+    assert isinstance(result.failures, PageFetchFailure)
+    assert "API timeout" in result.failures.error
     assert len(result.envelopes) == 0
     mock_connector_instance.fetch_families.assert_called_once()
 
@@ -153,14 +153,14 @@ def test_extract_families_handles_http_error():
         expected_error = "404 Client Error: Not Found"
         mock_connector_instance.fetch_families.return_value = FamilyFetchResult(
             envelopes=[],
-            failure=PageFetchFailureFactory.build(
+            failures=PageFetchFailureFactory.build(
                 page=0, error=expected_error, task_run_id="task-001"
             ),
         )
 
         result = extract(invalid_ids)
 
-    assert result.failure is not None
-    assert isinstance(result.failure, PageFetchFailure)
-    assert "404" in result.failure.error
+    assert result.failures is not None
+    assert isinstance(result.failures, PageFetchFailure)
+    assert "404" in result.failures.error
     assert len(result.envelopes) == 0

--- a/data-in-pipeline/tests/extract/test_family_extract_step.py
+++ b/data-in-pipeline/tests/extract/test_family_extract_step.py
@@ -96,7 +96,7 @@ def test_extract_families_handles_valid_ids_success():
         )
 
         mock_connector_instance.fetch_families.return_value = FamilyFetchResult(
-            envelopes=[mock_envelope], failures=None
+            envelopes=[mock_envelope], failures=[]
         )
 
         result = extract(valid_ids)

--- a/data-in-pipeline/tests/extract/test_family_extract_step.py
+++ b/data-in-pipeline/tests/extract/test_family_extract_step.py
@@ -125,9 +125,11 @@ def test_extract_families_propagates_connector_failure():
         expected_error = "Failed to fetch families: API timeout"
         mock_connector_instance.fetch_families.return_value = FamilyFetchResult(
             envelopes=[],
-            failures=PageFetchFailureFactory.build(
-                page=0, error=expected_error, task_run_id="task-001"
-            ),
+            failures=[
+                PageFetchFailureFactory.build(
+                    page=0, error=expected_error, task_run_id="task-001"
+                )
+            ],
         )
 
         result = extract(invalid_ids)
@@ -153,9 +155,11 @@ def test_extract_families_handles_http_error():
         expected_error = "404 Client Error: Not Found"
         mock_connector_instance.fetch_families.return_value = FamilyFetchResult(
             envelopes=[],
-            failures=PageFetchFailureFactory.build(
-                page=0, error=expected_error, task_run_id="task-001"
-            ),
+            failures=[
+                PageFetchFailureFactory.build(
+                    page=0, error=expected_error, task_run_id="task-001"
+                )
+            ],
         )
 
         result = extract(invalid_ids)

--- a/data-in-pipeline/tests/extract/test_family_extract_step.py
+++ b/data-in-pipeline/tests/extract/test_family_extract_step.py
@@ -101,7 +101,7 @@ def test_extract_families_handles_valid_ids_success():
 
         result = extract(valid_ids)
 
-    assert result.failures is None
+    assert not result.failures
     assert len(result.envelopes) == 1
     assert result.envelopes[0].source_name == "navigator_family"
     expected_family_count = 2
@@ -134,9 +134,10 @@ def test_extract_families_propagates_connector_failure():
 
         result = extract(invalid_ids)
 
-    assert result.failures is not None
-    assert isinstance(result.failures, PageFetchFailure)
-    assert "API timeout" in result.failures.error
+    assert result.failures
+    failure = result.failures[0]
+    assert isinstance(failure, PageFetchFailure)
+    assert "API timeout" in failure.error
     assert len(result.envelopes) == 0
     mock_connector_instance.fetch_families.assert_called_once()
 
@@ -164,7 +165,8 @@ def test_extract_families_handles_http_error():
 
         result = extract(invalid_ids)
 
-    assert result.failures is not None
-    assert isinstance(result.failures, PageFetchFailure)
-    assert "404" in result.failures.error
+    assert result.failures
+    failure = result.failures[0]
+    assert isinstance(failure, PageFetchFailure)
+    assert "404" in failure.error
     assert len(result.envelopes) == 0

--- a/data-in-pipeline/tests/extract/test_fetch_all_families.py
+++ b/data-in-pipeline/tests/extract/test_fetch_all_families.py
@@ -72,7 +72,7 @@ def test_fetch_all_families_collects_validation_failures_and_continues():
 
     failure = result.failures[0]
     assert isinstance(failure, RecordValidationFailure)
-    assert failure.import_ids == "Invalid.family.0.0"
+    assert failure.import_ids[0] == "Invalid.family.0.0"
     assert failure.page == 1
     assert (
         failure.error

--- a/data-in-pipeline/tests/extract/test_fetch_all_families.py
+++ b/data-in-pipeline/tests/extract/test_fetch_all_families.py
@@ -1,0 +1,80 @@
+from unittest.mock import patch
+
+from pydantic import ValidationError
+
+from app.extract.connectors import (
+    NavigatorConnector,
+    NavigatorConnectorConfig,
+    NavigatorFamily,
+    RecordValidationFailure,
+)
+from app.extract.enums import CheckPointStorageType
+
+
+def test_fetch_all_families_collects_validation_failures_and_continues():
+    invalid_family = {"import_id": "Invalid.family.0.0", "other": "fields"}
+    valid_family = {
+        "import_id": "Valid.family.0.0",
+        "title": "Test title",
+        "summary": "Test summary",
+        "documents": [],
+        "corpus": {
+            "import_id": "Test.corpus.0.0",
+            "corpus_type": {"name": "Test"},
+            "organisation": {"id": 0, "name": "Test"},
+            "corpus_text": "Test",
+        },
+        "events": [],
+        "collections": [],
+        "geographies": [],
+        "category": "Test",
+        "slug": "valid-test-family",
+    }
+
+    responses = [
+        {"data": [invalid_family]},  # page 1 → ValidationError
+        {"data": [valid_family]},  # page 2 → succeeds
+        {"data": []},  # page 3 → terminates
+    ]
+
+    valid_family_instance = NavigatorFamily.model_construct()
+    validation_error = ValidationError.from_exception_data(
+        "NavigatorFamily",
+        [{"type": "missing", "loc": ("slug",), "input": {}}],
+    )
+
+    connector = NavigatorConnector(
+        NavigatorConnectorConfig(
+            source_id="navigator_family",
+            checkpoint_storage=CheckPointStorageType.S3,
+            checkpoint_key_prefix="navigator/families/",
+        )
+    )
+
+    with (
+        patch.object(connector, "get", side_effect=responses),
+        patch.object(
+            NavigatorFamily,
+            "model_validate",
+            side_effect=[validation_error, valid_family_instance],
+        ),
+    ):
+        result = connector.fetch_all_families(
+            task_run_id="task-123",
+            flow_run_id="flow-456",
+        )
+
+    assert len(result.envelopes) == 1
+    assert result.envelopes[0].source_record_id == "task-123-families-endpoint-page-2"
+
+    assert isinstance(result.failures, list)
+    assert len(result.failures) == 1
+
+    failure = result.failures[0]
+    assert isinstance(failure, RecordValidationFailure)
+    assert failure.import_ids == "Invalid.family.0.0"
+    assert failure.page == 1
+    assert (
+        failure.error
+        == 'Error validating family: [{"type":"missing","loc":["slug"],"msg":"Field required","input":{},"url":"https://errors.pydantic.dev/2.12/v/missing"}]'
+    )

--- a/data-in-pipeline/tests/identify/test_family_identify_step.py
+++ b/data-in-pipeline/tests/identify/test_family_identify_step.py
@@ -207,7 +207,7 @@ def test_fetch_all_families_no_data_returned_from_endpoint(base_config):
     with patch.object(connector, "get", return_value=mock_empty_page):
         result = connector.fetch_all_families(task_run_id, flow_run_id)
 
-    assert result.failures is None
+    assert not result.failures
     assert len(result.envelopes) == 0
     connector.close()
 

--- a/data-in-pipeline/tests/identify/test_family_identify_step.py
+++ b/data-in-pipeline/tests/identify/test_family_identify_step.py
@@ -182,7 +182,7 @@ def test_fetch_all_families_successfully(base_config):
     ):
         result = connector.fetch_all_families(task_run_id, flow_run_id)
 
-    assert result.failure is None
+    assert result.failures is None
     expected_num_families = 2
     assert len(result.envelopes) == expected_num_families
     assert (
@@ -207,7 +207,7 @@ def test_fetch_all_families_no_data_returned_from_endpoint(base_config):
     with patch.object(connector, "get", return_value=mock_empty_page):
         result = connector.fetch_all_families(task_run_id, flow_run_id)
 
-    assert result.failure is None
+    assert result.failures is None
     assert len(result.envelopes) == 0
     connector.close()
 
@@ -247,11 +247,11 @@ def test_fetch_all_families_handles_successful_retrievals_and_errors(base_config
     ):
         result = connector.fetch_all_families(task_run_id, flow_run_id)
 
-    assert result.failure is not None
-    assert isinstance(result.failure, PageFetchFailure)
+    assert result.failures is not None
+    assert isinstance(result.failures, PageFetchFailure)
     expected_page_num_to_fail = 2
-    assert result.failure.page == expected_page_num_to_fail
-    assert "500 Internal Server Error" in result.failure.error
+    assert result.failures.page == expected_page_num_to_fail
+    assert "500 Internal Server Error" in result.failures.error
     assert len(result.envelopes) == 1
     assert (
         result.envelopes[0].source_record_id
@@ -271,9 +271,9 @@ def test_fetch_all_families_handles_errors(base_config):
     with patch.object(connector, "get", side_effect=unexpected_error):
         result = connector.fetch_all_families(task_run_id, flow_run_id)
 
-    assert result.failure is not None
-    assert isinstance(result.failure, PageFetchFailure)
-    assert result.failure.page == 1
-    assert "Unexpected parsing error" in result.failure.error
+    assert result.failures is not None
+    assert isinstance(result.failures, PageFetchFailure)
+    assert result.failures.page == 1
+    assert "Unexpected parsing error" in result.failures.error
     assert len(result.envelopes) == 0
     connector.close()

--- a/data-in-pipeline/tests/identify/test_family_identify_step.py
+++ b/data-in-pipeline/tests/identify/test_family_identify_step.py
@@ -182,7 +182,7 @@ def test_fetch_all_families_successfully(base_config):
     ):
         result = connector.fetch_all_families(task_run_id, flow_run_id)
 
-    assert result.failures is None
+    assert not result.failures
     expected_num_families = 2
     assert len(result.envelopes) == expected_num_families
     assert (
@@ -247,11 +247,12 @@ def test_fetch_all_families_handles_successful_retrievals_and_errors(base_config
     ):
         result = connector.fetch_all_families(task_run_id, flow_run_id)
 
-    assert result.failures is not None
-    assert isinstance(result.failures, PageFetchFailure)
+    assert result.failures
+    failure = result.failures[0]
+    assert isinstance(failure, PageFetchFailure)
     expected_page_num_to_fail = 2
-    assert result.failures.page == expected_page_num_to_fail
-    assert "500 Internal Server Error" in result.failures.error
+    assert failure.page == expected_page_num_to_fail
+    assert "500 Internal Server Error" in failure.error
     assert len(result.envelopes) == 1
     assert (
         result.envelopes[0].source_record_id
@@ -271,9 +272,10 @@ def test_fetch_all_families_handles_errors(base_config):
     with patch.object(connector, "get", side_effect=unexpected_error):
         result = connector.fetch_all_families(task_run_id, flow_run_id)
 
-    assert result.failures is not None
-    assert isinstance(result.failures, PageFetchFailure)
-    assert result.failures.page == 1
-    assert "Unexpected parsing error" in result.failures.error
+    assert result.failures
+    failure = result.failures[0]
+    assert isinstance(failure, PageFetchFailure)
+    assert failure.page == 1
+    assert "Unexpected parsing error" in failure.error
     assert len(result.envelopes) == 0
     connector.close()

--- a/data-in-pipeline/tests/test_family_pipeline.py
+++ b/data-in-pipeline/tests/test_family_pipeline.py
@@ -169,9 +169,11 @@ def test_process_family_updates_flow_extraction_failure(
     expected_error = Exception("500 Internal Server Error")
     mock_connector_instance.fetch_all_families.return_value = FamilyFetchResult(
         envelopes=[],
-        failures=PageFetchFailureFactory.build(
-            page=1, error=str(expected_error), task_run_id="task-001"
-        ),
+        failures=[
+            PageFetchFailureFactory.build(
+                page=1, error=str(expected_error), task_run_id="task-001"
+            )
+        ],
     )
 
     result = data_in_pipeline()

--- a/data-in-pipeline/tests/test_family_pipeline.py
+++ b/data-in-pipeline/tests/test_family_pipeline.py
@@ -132,7 +132,7 @@ def test_process_family_updates_flow_multiple_families(  # noqa: PLR0913
     )
 
     mock_connector_instance.fetch_all_families.return_value = FamilyFetchResult(
-        envelopes=[envelope_1, envelope_2], failure=None
+        envelopes=[envelope_1, envelope_2], failures=None
     )
 
     result = data_in_pipeline()
@@ -169,7 +169,7 @@ def test_process_family_updates_flow_extraction_failure(
     expected_error = Exception("500 Internal Server Error")
     mock_connector_instance.fetch_all_families.return_value = FamilyFetchResult(
         envelopes=[],
-        failure=PageFetchFailureFactory.build(
+        failures=PageFetchFailureFactory.build(
             page=1, error=str(expected_error), task_run_id="task-001"
         ),
     )
@@ -251,7 +251,7 @@ def test_etl_pipeline_load_failure(  # noqa: PLR0913
 
     # Mock connector response
     mock_connector_instance.fetch_all_families.return_value = FamilyFetchResult(
-        envelopes=[test_envelope], failure=None
+        envelopes=[test_envelope], failures=None
     )
 
     mock_load_batch_task.map.return_value = [HTTPError("Server error")]
@@ -351,7 +351,7 @@ def test_etl_pipeline_partial_transformation_failure(  # noqa: PLR0913
     )
 
     mock_connector_instance.fetch_all_families.return_value = FamilyFetchResult(
-        envelopes=[envelope], failure=None
+        envelopes=[envelope], failures=None
     )
 
     mock_transformed_documents = [
@@ -427,7 +427,7 @@ def test_etl_pipeline_all_families_fail_transformation(
     )
 
     mock_connector_instance.fetch_all_families.return_value = FamilyFetchResult(
-        envelopes=[envelope], failure=None
+        envelopes=[envelope], failures=None
     )
 
     mock_transform_families.side_effect = [

--- a/data-in-pipeline/tests/test_family_pipeline.py
+++ b/data-in-pipeline/tests/test_family_pipeline.py
@@ -132,7 +132,7 @@ def test_process_family_updates_flow_multiple_families(  # noqa: PLR0913
     )
 
     mock_connector_instance.fetch_all_families.return_value = FamilyFetchResult(
-        envelopes=[envelope_1, envelope_2], failures=None
+        envelopes=[envelope_1, envelope_2], failures=[]
     )
 
     result = data_in_pipeline()
@@ -253,7 +253,7 @@ def test_etl_pipeline_load_failure(  # noqa: PLR0913
 
     # Mock connector response
     mock_connector_instance.fetch_all_families.return_value = FamilyFetchResult(
-        envelopes=[test_envelope], failures=None
+        envelopes=[test_envelope], failures=[]
     )
 
     mock_load_batch_task.map.return_value = [HTTPError("Server error")]
@@ -353,7 +353,7 @@ def test_etl_pipeline_partial_transformation_failure(  # noqa: PLR0913
     )
 
     mock_connector_instance.fetch_all_families.return_value = FamilyFetchResult(
-        envelopes=[envelope], failures=None
+        envelopes=[envelope], failures=[]
     )
 
     mock_transformed_documents = [
@@ -429,7 +429,7 @@ def test_etl_pipeline_all_families_fail_transformation(
     )
 
     mock_connector_instance.fetch_all_families.return_value = FamilyFetchResult(
-        envelopes=[envelope], failures=None
+        envelopes=[envelope], failures=[]
     )
 
     mock_transform_families.side_effect = [


### PR DESCRIPTION
# What does this do?

- Updates `NavigatorConnector` to collect extract errors and continue rather than fail the whole pipeline
- Save extract errors to S3 and send a quick summary alert to Slack

## Why is it needed?

- We came across invalid data in run after adding event metadata which broke the entire pipeline. It was also not possible to find out which family was causing the issue as we were not capturing an import-id.


