### PR TITLE
Small QoL improvements for CSV download endpoint

### DIFF
--- a/backend-api/app/api/api_v1/routers/search.py
+++ b/backend-api/app/api/api_v1/routers/search.py
@@ -21,7 +21,6 @@ https://fastapi.tiangolo.com/async/
 """
 
 import logging
-from io import BytesIO
 from typing import Annotated, Sequence, cast
 
 from cpr_sdk.search_adaptors import VespaSearchAdapter
@@ -44,7 +43,7 @@ from app.models.search import SearchRequestBody, SearchResponse
 from app.service.custom_app import AppTokenFactory
 from app.service.download import (
     create_data_download_zip_archive,
-    process_result_into_csv,
+    stream_result_into_csv,
 )
 from app.service.search import get_s3_doc_url_from_cdn, make_search_request
 from app.service.vespa import get_vespa_search_adapter
@@ -224,13 +223,11 @@ def download_search_documents(
             detail=f"Invalid Query: {' '.join(e.args)}",
         )
 
-    content_str = process_result_into_csv(
+    content_stream = stream_result_into_csv(
         db, search_response.families, token.aud, is_browse=is_browse, theme=token.sub
     )
-
-    _LOGGER.debug(f"Downloading search results as CSV: {content_str}")
     return StreamingResponse(
-        content=BytesIO(content_str.encode("utf-8")),
+        content=content_stream,
         headers={
             "Content-Type": "text/csv",
             "Content-Disposition": "attachment; filename=results.csv",

--- a/backend-api/app/service/download.py
+++ b/backend-api/app/service/download.py
@@ -5,7 +5,7 @@ import zipfile
 from collections import defaultdict
 from io import BytesIO, StringIO
 from logging import getLogger
-from typing import Any, Mapping, Optional, Sequence, cast
+from typing import Any, Iterator, Mapping, Optional, Sequence, cast
 
 import pandas as pd
 from db_client.models.dfce import (
@@ -185,13 +185,14 @@ def _get_document_events(
 
 
 @observe("process_result_into_csv")
-def process_result_into_csv(
+def stream_result_into_csv(  # noqa: PLR0913
     db: Session,
     search_response_families: Sequence[SearchResponseFamily],
     base_url: Optional[str],
     is_browse: bool,
     theme: Optional[str] = None,
-) -> str:
+    chunk_size: int = 128,
+) -> Iterator[bytes]:
     """
     Process a search/browse result into a CSV file for download.
 
@@ -199,7 +200,8 @@ def process_result_into_csv(
     :param Sequence[SearchResponseFamily] search_response_families: the families search result to process
     :param bool is_browse: a flag indicating whether this is a search/browse result
     :param Optional[str] theme: the theme to determine CSV column format
-    :return str: the search result represented as CSV
+    :param int chunk_size: number of rows per yielded CSV chunk
+    :return Iterator[bytes]: UTF-8 encoded CSV chunks
     """
     # Check if theme is CCC (case insensitive)
     is_ccc_theme = theme and theme.upper() == "CCC"
@@ -214,10 +216,25 @@ def process_result_into_csv(
 
     if base_url is None:
         raise ValidationError("Error creating CSV")
+    if chunk_size < 1:
+        raise ValidationError("CSV chunk size must be at least 1")
 
     scheme = "http" if "localhost" in base_url else "https"
     url_base = f"{scheme}://{base_url}"
-    rows = []
+    csv_buffer = StringIO("")
+    csv_fieldnames = (
+        _CCC_CSV_SEARCH_RESPONSE_COLUMNS
+        if is_ccc_theme
+        else _CSV_SEARCH_RESPONSE_COLUMNS
+    )
+    writer = csv.DictWriter(
+        csv_buffer, fieldnames=csv_fieldnames, extrasaction="ignore"
+    )
+    writer.writeheader()
+    yield csv_buffer.getvalue().encode("utf-8")
+    csv_buffer.seek(0)
+    csv_buffer.truncate(0)
+    rows_in_chunk = 0
 
     for family in search_response_families:
         _LOGGER.debug(f"Family: {family}")
@@ -299,7 +316,13 @@ def process_result_into_csv(
                         document_languages,
                     )
 
-                rows.append(row)
+                writer.writerow(row)
+                rows_in_chunk += 1
+                if rows_in_chunk >= chunk_size:
+                    yield csv_buffer.getvalue().encode("utf-8")
+                    csv_buffer.seek(0)
+                    csv_buffer.truncate(0)
+                    rows_in_chunk = 0
         else:
             # Always write a row, even if the Family contains no documents
             if is_ccc_theme:
@@ -329,24 +352,36 @@ def process_result_into_csv(
                     "",  # Document languages
                 )
 
-            rows.append(row)
+            writer.writerow(row)
+            rows_in_chunk += 1
+            if rows_in_chunk >= chunk_size:
+                yield csv_buffer.getvalue().encode("utf-8")
+                csv_buffer.seek(0)
+                csv_buffer.truncate(0)
+                rows_in_chunk = 0
 
-    csv_result_io = StringIO("")
+    if rows_in_chunk > 0:
+        yield csv_buffer.getvalue().encode("utf-8")
 
-    if is_ccc_theme:
-        csv_fieldnames = _CCC_CSV_SEARCH_RESPONSE_COLUMNS
-    else:
-        csv_fieldnames = _CSV_SEARCH_RESPONSE_COLUMNS
 
-    writer = csv.DictWriter(
-        csv_result_io, fieldnames=csv_fieldnames, extrasaction="ignore"
-    )
-    writer.writeheader()
-    for row in rows:
-        writer.writerow(row)
-
-    csv_result_io.seek(0)
-    return csv_result_io.read()
+@observe("process_result_into_csv")
+def process_result_into_csv(
+    db: Session,
+    search_response_families: Sequence[SearchResponseFamily],
+    base_url: str | None,
+    is_browse: bool,
+    theme: str | None = None,
+) -> str:
+    """Process a search/browse result into a CSV string."""
+    return b"".join(
+        stream_result_into_csv(
+            db=db,
+            search_response_families=search_response_families,
+            base_url=base_url,
+            is_browse=is_browse,
+            theme=theme,
+        )
+    ).decode("utf-8")
 
 
 def _create_ccc_csv_row(

--- a/backend-api/app/service/download.py
+++ b/backend-api/app/service/download.py
@@ -155,7 +155,15 @@ def _get_matching_document_import_ids(
     search_response_families: Sequence[SearchResponseFamily],
     documents_by_family_slug: Mapping[str, Sequence[FamilyDocument]],
 ) -> set[str]:
-    """Return document import IDs that match search passage hits."""
+    """Return document import IDs that match search passage hits.
+
+    :param Sequence[SearchResponseFamily] search_response_families:
+        Families returned by search, including matched document slugs.
+    :param Mapping[str, Sequence[FamilyDocument]] documents_by_family_slug:
+        Mapping of family slug to persisted family documents.
+    :return: Set of matching document import IDs represented as strings.
+    :rtype: set[str]
+    """
     all_matching_document_slugs = {
         d.document_slug
         for f in search_response_families
@@ -219,8 +227,7 @@ def stream_result_into_csv(  # noqa: PLR0913
     theme: Optional[str] = None,
     chunk_size: int = 128,
 ) -> Iterator[bytes]:
-    """
-    Process a search/browse result into a CSV file for download.
+    """Process a search/browse result into a CSV file for download.
 
     :param Session db: database session for supplementary queries
     :param Sequence[SearchResponseFamily] search_response_families: the families search result to process
@@ -391,7 +398,21 @@ def process_result_into_csv(
     is_browse: bool,
     theme: str | None = None,
 ) -> str:
-    """Process a search/browse result into a CSV string."""
+    """
+    Process search or browse results into a CSV string.
+
+    :param Session db: Database session for supplementary CSV enrichment.
+    :param Sequence[SearchResponseFamily] search_response_families:
+        Families from the search or browse response.
+    :param str | None base_url:
+        Public application base URL used to construct links.
+    :param bool is_browse:
+        Whether the result source is browse mode instead of search mode.
+    :param str | None theme:
+        Optional theme controlling CSV schema, defaults to None.
+    :return: UTF-8 decoded CSV content.
+    :rtype: str
+    """
     return b"".join(
         stream_result_into_csv(
             db=db,

--- a/backend-api/app/service/download.py
+++ b/backend-api/app/service/download.py
@@ -235,7 +235,6 @@ def process_result_into_csv(
         ]
         if family_documents:
             for document in family_documents:
-                _LOGGER.info(f"Document: {document}")
                 physical_document = document.physical_document
 
                 if physical_document is None:

--- a/backend-api/app/service/download.py
+++ b/backend-api/app/service/download.py
@@ -151,6 +151,32 @@ def parse_concept_labels(concept_labels: Sequence[str], prefix: str) -> str:
     )
 
 
+def _get_matching_document_import_ids(
+    search_response_families: Sequence[SearchResponseFamily],
+    documents_by_family_slug: Mapping[str, Sequence[FamilyDocument]],
+) -> set[str]:
+    """Return document import IDs that match search passage hits."""
+    all_matching_document_slugs = {
+        d.document_slug
+        for f in search_response_families
+        for d in f.family_documents
+        if d.document_passage_matches
+    }
+    if not all_matching_document_slugs:
+        return set()
+
+    matching_document_import_ids: set[str] = set()
+    for family in search_response_families:
+        family_documents = documents_by_family_slug.get(family.family_slug, [])
+        for document in family_documents:
+            if not document.import_id:
+                continue
+            if any(slug.name in all_matching_document_slugs for slug in document.slugs):
+                matching_document_import_ids.add(str(document.import_id))
+
+    return matching_document_import_ids
+
+
 def _get_document_events(
     db: Session, document_import_ids: Sequence[str]
 ) -> Mapping[str, list[FamilyEvent]]:
@@ -207,17 +233,14 @@ def stream_result_into_csv(  # noqa: PLR0913
     is_ccc_theme = theme and theme.upper() == "CCC"
 
     extra_required_info = _get_extra_csv_info(db, search_response_families)
-    all_matching_document_slugs = {
-        d.document_slug
-        for f in search_response_families
-        for d in f.family_documents
-        if d.document_passage_matches
-    }
-
     if base_url is None:
         raise ValidationError("Error creating CSV")
     if chunk_size < 1:
         raise ValidationError("CSV chunk size must be at least 1")
+    matching_document_import_ids = _get_matching_document_import_ids(
+        search_response_families,
+        extra_required_info["documents"],
+    )
 
     scheme = "http" if "localhost" in base_url else "https"
     url_base = f"{scheme}://{base_url}"
@@ -237,7 +260,6 @@ def stream_result_into_csv(  # noqa: PLR0913
     rows_in_chunk = 0
 
     for family in search_response_families:
-        _LOGGER.debug(f"Family: {family}")
         family_metadata = extra_required_info["metadata"].get(family.family_slug, {})
         if not family_metadata:
             _LOGGER.error(f"Failed to find metadata for '{family.family_slug}'")
@@ -273,20 +295,17 @@ def stream_result_into_csv(  # noqa: PLR0913
                     else:
                         document_match = (
                             "Yes"
-                            if bool(
-                                {slug.name for slug in document.slugs}
-                                & all_matching_document_slugs
-                            )
+                            if str(document.import_id) in matching_document_import_ids
                             else "No"
                         )
 
-                document_languages = ";".join(
-                    [
+                document_languages = (
+                    ";".join(
                         cast(str, language.name)
                         for language in physical_document.languages
-                    ]
+                    )
                     if physical_document is not None
-                    else []
+                    else ""
                 )
 
                 if is_ccc_theme:

--- a/backend-api/tests/non_search/service/download/test_download_search.py
+++ b/backend-api/tests/non_search/service/download/test_download_search.py
@@ -26,6 +26,7 @@ def test_process_result_into_csv_returns_correct_data_for_CPR_search_in_csv_form
     mock_family_slug = "cpr-test-family"
 
     mock_document_slug = "cpr-test-document"
+    mock_document_import_id = "Test.CPR.document.0"
     mock_document_source_url = "www.cpr-test-document.pdf"
     mock_document_title = "CPR Test Document"
     mock_document_content_type = "application/pdf"
@@ -36,6 +37,7 @@ def test_process_result_into_csv_returns_correct_data_for_CPR_search_in_csv_form
         "documents": {
             mock_family_slug: [
                 FamilyDocument(
+                    import_id=mock_document_import_id,
                     slugs=[Slug(name=mock_document_slug)],
                     physical_document=PhysicalDocument(
                         source_url=mock_document_source_url,
@@ -391,6 +393,7 @@ def test_stream_result_into_csv_returns_same_data_as_string_version(
 ):
     mock_family_slug = "cpr-test-family"
     mock_document_slug = "cpr-test-document"
+    mock_document_import_id = "Test.CPR.document.0"
     mock_document_source_url = "www.cpr-test-document.pdf"
     mock_document_title = "CPR Test Document"
 
@@ -400,6 +403,7 @@ def test_stream_result_into_csv_returns_same_data_as_string_version(
         "documents": {
             mock_family_slug: [
                 FamilyDocument(
+                    import_id=mock_document_import_id,
                     slugs=[Slug(name=mock_document_slug)],
                     physical_document=PhysicalDocument(
                         source_url=mock_document_source_url,

--- a/backend-api/tests/non_search/service/download/test_download_search.py
+++ b/backend-api/tests/non_search/service/download/test_download_search.py
@@ -10,7 +10,11 @@ from app.models.search import (
     SearchResponseFamily,
     SearchResponseFamilyDocument,
 )
-from app.service.download import process_result_into_csv, stream_result_into_csv
+from app.service.download import (
+    _get_matching_document_import_ids,
+    process_result_into_csv,
+    stream_result_into_csv,
+)
 
 
 @patch("app.service.download._get_extra_csv_info")
@@ -463,3 +467,72 @@ def test_stream_result_into_csv_returns_same_data_as_string_version(
     ).decode("utf-8")
 
     assert streamed_csv == expected_csv
+
+
+def test_get_matching_document_import_ids_matches_any_document_slug():
+    matching_slug = "matching-slug"
+    family_slug = "family-1"
+    matching_doc_import_id = "doc-1"
+
+    search_response_families = [
+        SearchResponseFamily(
+            family_slug=family_slug,
+            family_name="Test Family",
+            family_description="Test Family Description",
+            family_category="Legislative",
+            family_date="2025-01-01",
+            family_source="CPR",
+            corpus_import_id="Test.CPR.corpus.0",
+            corpus_type_name="Laws and Policies",
+            family_geographies=["BRA"],
+            family_metadata={},
+            family_title_match=True,
+            family_description_match=False,
+            total_passage_hits=1,
+            family_documents=[
+                SearchResponseFamilyDocument(
+                    document_title="doc",
+                    document_slug=matching_slug,
+                    document_type="Test",
+                    document_source_url="https://example.com/doc.pdf",
+                    document_url=f"https://example.com/documents/{matching_slug}",
+                    document_content_type="application/pdf",
+                    document_passage_matches=[
+                        SearchResponseDocumentPassage(text="match", text_block_id="0")
+                    ],
+                )
+            ],
+            continuation_token=None,
+            prev_continuation_token=None,
+            metadata=None,
+        )
+    ]
+
+    documents_by_family_slug = {
+        family_slug: [
+            FamilyDocument(
+                import_id=matching_doc_import_id,
+                slugs=[Slug(name="non-matching"), Slug(name=matching_slug)],
+                physical_document=PhysicalDocument(
+                    source_url="https://example.com/doc.pdf",
+                    title="Test Document",
+                ),
+                valid_metadata={},
+            ),
+            FamilyDocument(
+                import_id=None,
+                slugs=[Slug(name=matching_slug)],
+                physical_document=PhysicalDocument(
+                    source_url="https://example.com/doc2.pdf",
+                    title="Test Document 2",
+                ),
+                valid_metadata={},
+            ),
+        ]
+    }
+
+    matching_document_import_ids = _get_matching_document_import_ids(
+        search_response_families, documents_by_family_slug
+    )
+
+    assert matching_document_import_ids == {matching_doc_import_id}

--- a/backend-api/tests/non_search/service/download/test_download_search.py
+++ b/backend-api/tests/non_search/service/download/test_download_search.py
@@ -10,7 +10,7 @@ from app.models.search import (
     SearchResponseFamily,
     SearchResponseFamilyDocument,
 )
-from app.service.download import process_result_into_csv
+from app.service.download import process_result_into_csv, stream_result_into_csv
 
 
 @patch("app.service.download._get_extra_csv_info")
@@ -379,3 +379,87 @@ def test_process_result_into_csv_returns_correct_data_for_CCC_search_in_csv_form
         )
         == expected_search_csv
     )
+
+
+@patch("app.service.download._get_extra_csv_info")
+def test_stream_result_into_csv_returns_same_data_as_string_version(
+    mock_get_extra_csv_info,
+):
+    mock_family_slug = "cpr-test-family"
+    mock_document_slug = "cpr-test-document"
+    mock_document_source_url = "www.cpr-test-document.pdf"
+    mock_document_title = "CPR Test Document"
+
+    mock_get_extra_csv_info.return_value = {
+        "metadata": {mock_family_slug: {}},
+        "source": {mock_family_slug: "CPR"},
+        "documents": {
+            mock_family_slug: [
+                FamilyDocument(
+                    slugs=[Slug(name=mock_document_slug)],
+                    physical_document=PhysicalDocument(
+                        source_url=mock_document_source_url,
+                        title=mock_document_title,
+                    ),
+                    valid_metadata={},
+                )
+            ]
+        },
+        "collection": {mock_family_slug: {}},
+        "document_events": {},
+    }
+
+    families = [
+        SearchResponseFamily(
+            family_slug=mock_family_slug,
+            family_name="CPR Test Family",
+            family_description="CPR Test Family Description",
+            family_category="Legislative",
+            family_date="2025-01-01",
+            family_source="CPR",
+            corpus_import_id="Test.CPR.corpus.0",
+            corpus_type_name="Laws and Policies",
+            family_geographies=["BRA"],
+            family_metadata={},
+            family_title_match=True,
+            family_description_match=False,
+            total_passage_hits=1,
+            family_documents=[
+                SearchResponseFamilyDocument(
+                    document_title=mock_document_title,
+                    document_slug=mock_document_slug,
+                    document_type="Test",
+                    document_source_url=mock_document_source_url,
+                    document_url=f"https://test.com/documents/{mock_document_slug}",
+                    document_content_type="application/pdf",
+                    document_passage_matches=[
+                        SearchResponseDocumentPassage(text="test", text_block_id="0")
+                    ],
+                )
+            ],
+            continuation_token=None,
+            prev_continuation_token=None,
+            metadata=None,
+        )
+    ]
+
+    expected_csv = process_result_into_csv(
+        db=None,  # type: ignore
+        search_response_families=families,
+        base_url="test.com",
+        is_browse=False,
+        theme="CPR",
+    )
+
+    streamed_csv = b"".join(
+        stream_result_into_csv(
+            db=None,  # type: ignore
+            search_response_families=families,
+            base_url="test.com",
+            is_browse=False,
+            theme="CPR",
+            chunk_size=1,
+        )
+    ).decode("utf-8")
+
+    assert streamed_csv == expected_csv


### PR DESCRIPTION
# What does this do?

- Remove exploding info/debug logs in loop
- Avoid repeated expensive set/list building in inner loops
- Stop materialising giant CSV strings in memory first only

## Why is it needed?

Hopefully reduce latency & CPU utilisation (even if only briefly)

## How was it tested?

New tests