### PR TITLE
Fix return transformation errors

### DIFF
--- a/data-in-pipeline/app/navigator_family_etl_pipeline.py
+++ b/data-in-pipeline/app/navigator_family_etl_pipeline.py
@@ -12,7 +12,6 @@ from prefect import flow, task
 from prefect.futures import PrefectFuture
 from prefect.runtime import flow_run, task_run
 from prefect.task_runners import TaskRunner, ThreadPoolTaskRunner
-from returns.result import Failure, Success
 
 from app.bootstrap_telemetry import get_logger, pipeline_metrics
 from app.extract.connector_config import NavigatorConnectorConfig
@@ -29,9 +28,7 @@ from app.load.load import load_to_db
 from app.models import ExtractedEnvelope, Identified, PipelineResult
 from app.pipeline_metrics import ErrorType, Operation, PipelineType, Status
 from app.run_db_migrations.run_db_migrations import run_db_migrations
-from app.transform.navigator_family import (
-    transform_navigator_family,
-)
+from app.transform.navigator_family import transform_navigator_family
 from app.util import SlackNotify, get_s3_client
 
 
@@ -217,23 +214,19 @@ def transform(
     all_documents = []
     errors = []
     for family in identified_families:
-        transformed = transform_navigator_family(family)
+        transformed_result = transform_navigator_family(family)
+        all_documents.extend(transformed_result.documents)
 
-        match transformed:
-            case Success(documents):
-                all_documents.extend(documents)
-            case Failure(error):
-                _LOGGER.warning(f"Transformation failed: {error}")
+        if transformed_result.errors:
+            for error in transformed_result.errors:
+                _LOGGER.warning(f"Partial Transformation: Non Fatal Error: {error}")
                 pipeline_metrics.record_error(Operation.TRANSFORM, ErrorType.TRANSFORM)
                 pipeline_metrics.record_processed(PipelineType.FAMILY, Status.FAILURE)
                 errors.append(error)
-            case _:
-                pipeline_metrics.record_processed(PipelineType.FAMILY, Status.FAILURE)
-                errors.append(Exception("Unexpected transformed result state"))
 
     _LOGGER.info(
         f"Transformation complete: {len(all_documents)} documents from "
-        f"{len(identified_families)} families ({len(errors)} failures)"
+        f"{len(identified_families)} families ({len(errors)} non fatal errors)"
     )
 
     return all_documents, errors

--- a/data-in-pipeline/app/navigator_family_etl_pipeline.py
+++ b/data-in-pipeline/app/navigator_family_etl_pipeline.py
@@ -29,6 +29,7 @@ from app.load.load import load_to_db
 from app.models import ExtractedEnvelope, Identified, PipelineResult
 from app.pipeline_metrics import ErrorType, Operation, PipelineType, Status
 from app.run_db_migrations.run_db_migrations import run_db_migrations
+from app.transform.models import TransformWarning
 from app.transform.navigator_family import transform_navigator_family
 from app.util import SlackNotify, get_s3_client
 
@@ -220,22 +221,42 @@ def transform_duplicate_collections(
 
 @task(log_prints=True)
 @pipeline_metrics.track(operation=Operation.TRANSFORM)
+@task(log_prints=True)
+@pipeline_metrics.track(operation=Operation.TRANSFORM)
 def transform(
     identified_families: list[Identified[NavigatorFamily]],
-) -> tuple[list[Document], list[Exception]]:
-    """Transform all families to target format, collecting successes and failures."""
+) -> tuple[list[Document], list[Exception | TransformWarning]]:
+    """Transform all families to target format, collecting successes and failures.
+
+    The errors list mixes fatal `Exception`s (transformation failed entirely, no
+    document produced) with non-fatal `TransformWarning`s (transformation
+    succeeded, but a sub-step had to skip something — the document IS in the
+    returned list). Callers that need to distinguish can match on the type.
+    """
     _LOGGER = get_logger()
 
-    all_documents = []
-    all_collections = {}
-    errors = []
+    all_documents: list[Document] = []
+    all_collections: dict = {}
+    errors: list[Exception | TransformWarning] = []
+
     for family in identified_families:
         result = transform_navigator_family(family)
 
         match result:
-            case Success((documents, collection_documents)):
-                all_documents.extend(documents)
-                transform_duplicate_collections(all_collections, collection_documents)
+            case Success(output):
+                all_documents.extend(output.documents)
+                transform_duplicate_collections(
+                    all_collections, output.collection_documents
+                )
+                for warning in output.warnings:
+                    _LOGGER.warning(
+                        "transform warning",
+                        extra={
+                            "family_id": family.id,
+                            "warning": warning.model_dump(),
+                        },
+                    )
+                errors.extend(output.warnings)
             case Failure(error):
                 _LOGGER.warning(f"Transformation failed: {error}")
                 pipeline_metrics.record_error(Operation.TRANSFORM, ErrorType.TRANSFORM)
@@ -247,7 +268,7 @@ def transform(
 
     _LOGGER.info(
         f"Transformation complete: {len(all_documents)} documents from "
-        f"{len(identified_families)} families ({len(errors)} failures)"
+        f"{len(identified_families)} families ({len(errors)} issues)"
     )
 
     all_transformed = all_documents + list(all_collections.values())

--- a/data-in-pipeline/app/navigator_family_etl_pipeline.py
+++ b/data-in-pipeline/app/navigator_family_etl_pipeline.py
@@ -12,6 +12,7 @@ from prefect import flow, task
 from prefect.futures import PrefectFuture
 from prefect.runtime import flow_run, task_run
 from prefect.task_runners import TaskRunner, ThreadPoolTaskRunner
+from returns.result import Failure, Success
 
 from app.bootstrap_telemetry import get_logger, pipeline_metrics
 from app.extract.connector_config import NavigatorConnectorConfig
@@ -203,6 +204,20 @@ def identify(
     return identify_navigator_families(extracted)
 
 
+def transform_duplicate_collections(
+    collections: dict[str, Document], documents: list[Document]
+):
+    """
+    Combines duplicate collection documents with a single link to a different related family document
+    into one collection document with links to all related family documents
+    """
+    for doc in documents:
+        if doc.id not in collections:
+            collections[doc.id] = doc
+        else:
+            collections[doc.id].documents.extend(doc.documents)
+
+
 @task(log_prints=True)
 @pipeline_metrics.track(operation=Operation.TRANSFORM)
 def transform(
@@ -212,24 +227,31 @@ def transform(
     _LOGGER = get_logger()
 
     all_documents = []
+    all_collections = {}
     errors = []
     for family in identified_families:
-        transformed_result = transform_navigator_family(family)
-        all_documents.extend(transformed_result.documents)
+        result = transform_navigator_family(family)
 
-        if transformed_result.errors:
-            for error in transformed_result.errors:
-                _LOGGER.warning(f"Partial Transformation: Non Fatal Error: {error}")
+        match result:
+            case Success((documents, collection_documents)):
+                all_documents.extend(documents)
+                transform_duplicate_collections(all_collections, collection_documents)
+            case Failure(error):
+                _LOGGER.warning(f"Transformation failed: {error}")
                 pipeline_metrics.record_error(Operation.TRANSFORM, ErrorType.TRANSFORM)
                 pipeline_metrics.record_processed(PipelineType.FAMILY, Status.FAILURE)
                 errors.append(error)
+            case _:
+                pipeline_metrics.record_processed(PipelineType.FAMILY, Status.FAILURE)
+                errors.append(Exception("Unexpected transformed result state"))
 
     _LOGGER.info(
         f"Transformation complete: {len(all_documents)} documents from "
-        f"{len(identified_families)} families ({len(errors)} non fatal errors)"
+        f"{len(identified_families)} families ({len(errors)} failures)"
     )
 
-    return all_documents, errors
+    all_transformed = all_documents + list(all_collections.values())
+    return all_transformed, errors
 
 
 @task(

--- a/data-in-pipeline/app/navigator_family_etl_pipeline.py
+++ b/data-in-pipeline/app/navigator_family_etl_pipeline.py
@@ -241,8 +241,6 @@ def transform(
 
     for family in identified_families:
         result = transform_navigator_family(family)
-        result = transform_navigator_family(family)
-
         match result:
             case Success(output):
                 all_documents.extend(output.documents)

--- a/data-in-pipeline/app/navigator_family_etl_pipeline.py
+++ b/data-in-pipeline/app/navigator_family_etl_pipeline.py
@@ -174,7 +174,7 @@ def cache_extraction_result(result: FamilyFetchResult):
 
 
 @task(log_prints=True)
-def cache_transform_errors(errors: list[Exception], run_id: str):
+def cache_transform_errors(errors: list[Exception | TransformWarning], run_id: str):
     """Cache transformation errors to S3."""
     error_data = [str(e) for e in errors]
     upload_to_s3(

--- a/data-in-pipeline/app/transform/models.py
+++ b/data-in-pipeline/app/transform/models.py
@@ -1,3 +1,8 @@
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, Field
+
+
 class CouldNotTransform(Exception):
     """Raised when a transformer function cannot be found for the given input."""
 
@@ -8,3 +13,47 @@ class NoMatchingTransformations(Exception):
     """Raised when the transformer finds no matching transformations for the given input."""
 
     pass
+
+
+# ---------------------------------------------------------------------------
+# Warnings (non-fatal)
+# ---------------------------------------------------------------------------
+# A warning means "I produced a Document, but here's something I had to skip
+# or couldn't resolve." The transform still completes; warnings are an audit
+# log so callers can observe and report what happened. Compare with
+# `CouldNotTransform`, which is used at the boundary for genuinely fatal
+# failures where no Document can be produced at all.
+
+
+class UnknownParentLabel(BaseModel):
+    """A litigation concept referenced a parent label that wasn't in the input.
+
+    The child label is still emitted; only the unresolved `subconcept_of`
+    link is dropped.
+    """
+
+    kind: Literal["unknown_parent_label"] = "unknown_parent_label"
+    family_import_id: str
+    relation: str
+    parent_name: str
+
+
+class UnknownGeography(BaseModel):
+    """A geography ID was supplied that isn't in the geographies lookup table.
+
+    The geography is silently skipped; this warning surfaces it for inspection.
+    Note: the sentinel `XAA` ("No Geography") is intentionally excluded and
+    does NOT produce a warning.
+    """
+
+    kind: Literal["unknown_geography"] = "unknown_geography"
+    family_import_id: str
+    geography_id: str
+
+
+# Discriminated union — `kind` is the discriminator field.
+# @see: https://docs.pydantic.dev/latest/concepts/unions/#discriminated-unions
+type TransformWarning = Annotated[
+    UnknownParentLabel | UnknownGeography,
+    Field(discriminator="kind"),
+]

--- a/data-in-pipeline/app/transform/navigator_family.py
+++ b/data-in-pipeline/app/transform/navigator_family.py
@@ -84,10 +84,6 @@ def transform_navigator_family(
             f"Transform completed: produced {len(result.documents)} documents, "
             f"{len(result.errors)} errors"
         )
-        if result.errors:
-            logger.warning(
-                f"Transformation produced {len(result.errors)} non-fatal errors"
-            )
         return result
 
 

--- a/data-in-pipeline/app/transform/navigator_family.py
+++ b/data-in-pipeline/app/transform/navigator_family.py
@@ -7,7 +7,7 @@ from data_in_models.models import (
     LabelRelationship,
     LabelWithoutDocumentRelationships,
 )
-from returns.result import Failure, Result, Success
+from pydantic import BaseModel, ConfigDict
 
 from app.bootstrap_telemetry import get_logger, log_context
 from app.extract.connectors import (
@@ -17,7 +17,7 @@ from app.extract.connectors import (
 )
 from app.geographies import geographies_lookup
 from app.models import Identified, NavigatorConcept
-from app.transform.models import CouldNotTransform, NoMatchingTransformations
+from app.transform.models import CouldNotTransform
 
 mcf_projects_corpus_import_ids = [
     "MCF.corpus.AF.n0000",
@@ -59,23 +59,36 @@ MCF_ATTRIBUTE_KEYS = {
 }
 
 
+class TransformResult(BaseModel):
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True
+    )  # allowing non-Pydantic types in this model
+    documents: list[Document]
+    errors: list[CouldNotTransform]
+
+
+class LitigationConceptLabelTransformResult(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+    labels: list[LabelRelationship]
+    errors: list[CouldNotTransform]
+
+
 def transform_navigator_family(
     input: Identified[NavigatorFamily],
-) -> Result[list[Document], CouldNotTransform | NoMatchingTransformations]:
+) -> TransformResult:
     logger = get_logger()
     with log_context(import_id=input.id):
         logger.info(f"Transforming family with {len(input.data.documents)} documents")
-
-        match transform(input):
-            case Success(d):
-                logger.info(f"Transform completed, produced {len(d)} documents")
-                return Success(d)
-            case Failure(error):
-                logger.warning(f"Transformation failed: {error}")
-                return Failure(error)
-
-        logger.warning("No matching transformation found")
-        return Failure(NoMatchingTransformations())
+        result = transform(input)
+        logger.info(
+            f"Transform completed: produced {len(result.documents)} documents, "
+            f"{len(result.errors)} errors"
+        )
+        if result.errors:
+            logger.warning(
+                f"Transformation produced {len(result.errors)} non-fatal errors"
+            )
+        return result
 
 
 def _documents_match(
@@ -111,17 +124,15 @@ def _family_document_merged(
 
 def transform(
     input: Identified[NavigatorFamily],
-) -> Result[list[Document], CouldNotTransform]:
+) -> TransformResult:
     documents: list[Document] = []
+    transformation_errors: list[CouldNotTransform] = []
 
     """
     Transform
     """
-    result = _transform_navigator_family(input.data)
-    if isinstance(result, Failure):
-        return result
-    else:
-        document_from_family = result.unwrap()
+    document_from_family, errors = _transform_navigator_family(input.data)
+    transformation_errors.extend(errors)
 
     documents_from_documents = [
         _transform_navigator_document(
@@ -263,7 +274,7 @@ def transform(
     documents.extend(documents_from_documents)
     documents.extend(documents_from_collections)
 
-    return Success(documents)
+    return TransformResult(documents=documents, errors=transformation_errors)
 
 
 def _transform_family_corpus_organisation(
@@ -519,7 +530,7 @@ def _shallow_label(
 def _transform_litigation_concepts_to_label_relationships(
     concepts: list[NavigatorConcept],
     family_import_id: str,
-) -> Result[list[LabelRelationship], CouldNotTransform]:
+) -> LitigationConceptLabelTransformResult:
     """
     Convert litigation concepts into label relationships with subconcept hierarchies.
 
@@ -530,6 +541,8 @@ def _transform_litigation_concepts_to_label_relationships(
         - family_import_id= the import_id of the family these concepts belong to, to debug if needed.
         - Parent references are SHALLOW (labels=[] to prevent deep nesting).
     """
+
+    errors: list[CouldNotTransform] = []
 
     # The relation values unfortunately conflict with other values in the taxonomy, so we have to map them as `legal`
     # @see: https://github.com/climatepolicyradar/litigation-data-mapper/blob/49e8da8f4449dc8e3fec5a126b9973df4efb4d26/litigation_data_mapper/extract_concepts.py#L45
@@ -561,7 +574,11 @@ def _transform_litigation_concepts_to_label_relationships(
         for parent_name in concept.subconcept_of_labels:
             parent = label_by_name.get((concept.relation, parent_name))
             if parent is None:
-                continue
+                errors.append(
+                    CouldNotTransform(
+                        f"Unknown parent label {parent_name!r} in relation {concept.relation!r}. See family {family_import_id!r} for details."
+                    )
+                )
             else:
                 parent_ref = _shallow_label(parent)
 
@@ -569,12 +586,13 @@ def _transform_litigation_concepts_to_label_relationships(
                     LabelRelationship(type="subconcept_of", value=parent_ref)
                 )
 
-    return Success(
-        [
-            # we use legal_concept over concept as `concept` is reserved for our knowledge graph labels
+    return LitigationConceptLabelTransformResult(
+        labels=[
+            # `legal_concept` rather than `concept` — `concept` is reserved for knowledge graph labels.
             LabelRelationship(type="legal_concept", value=label)
             for label in label_map.values()
-        ]
+        ],
+        errors=errors,
     )
 
 
@@ -723,21 +741,20 @@ def _transform_to_category(
 
 def _transform_litigation_data(
     navigator_family: NavigatorFamily,
-) -> Result[list[LabelRelationship], CouldNotTransform]:
+) -> tuple[list[LabelRelationship], list[CouldNotTransform]]:
     """
     Transform litigation-specific concepts and filing date into label relationships.
     Only applies to the Litigation corpus.
     """
     labels: list[LabelRelationship] = []
+    errors: list[CouldNotTransform] = []
 
     if navigator_family.concepts:
-        match _transform_litigation_concepts_to_label_relationships(
+        concept_labels = _transform_litigation_concepts_to_label_relationships(
             navigator_family.concepts, navigator_family.import_id
-        ):
-            case Success(litigation_labels):
-                labels.extend(litigation_labels)
-            case Failure(e):
-                return Failure(e)
+        )
+        labels.extend(concept_labels.labels)
+        errors.extend(concept_labels.errors)
 
     if navigator_family.events:
         filing_event = next(
@@ -761,14 +778,15 @@ def _transform_litigation_data(
                 )
             )
 
-    return Success(labels)
+    return labels, errors
 
 
 def _transform_navigator_family(
     navigator_family: NavigatorFamily,
-) -> Result[Document, CouldNotTransform]:
+) -> tuple[Document, list[CouldNotTransform]]:
     labels: list[LabelRelationship] = []
     attributes: dict[str, str | float | bool] = {}
+    transformation_errors: list[CouldNotTransform] = []
 
     """
     All families are currently Principal.
@@ -976,11 +994,11 @@ def _transform_navigator_family(
     """
 
     if navigator_family.corpus.import_id == "Academic.corpus.Litigation.n0000":
-        match _transform_litigation_data(navigator_family):
-            case Success(litigation_labels):
-                labels.extend(litigation_labels)
-            case Failure(e):
-                return Failure(e)
+        litigation_labels, litigation_errors = _transform_litigation_data(
+            navigator_family
+        )
+        labels.extend(litigation_labels)
+        transformation_errors.extend(litigation_errors)
 
     """Dates"""
     if navigator_family.published_date:
@@ -1001,15 +1019,15 @@ def _transform_navigator_family(
     if navigator_family.documents and contains_published_document:
         attributes["status"] = "published"
 
-    return Success(
-        Document(
-            id=navigator_family.import_id,
-            title=navigator_family.title,
-            description=navigator_family.summary,
-            labels=_deduplicate_labels(labels),
-            attributes=attributes,
-        )
+    document = Document(
+        id=navigator_family.import_id,
+        title=navigator_family.title,
+        description=navigator_family.summary,
+        labels=_deduplicate_labels(labels),
+        attributes=attributes,
     )
+
+    return document, transformation_errors
 
 
 def _transform_document_urls(navigator_document):

--- a/data-in-pipeline/app/transform/navigator_family.py
+++ b/data-in-pipeline/app/transform/navigator_family.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from typing import Annotated, Literal
 
 from data_in_models.models import (
     Document,
@@ -10,7 +9,7 @@ from data_in_models.models import (
     LabelRelationship,
     LabelWithoutDocumentRelationships,
 )
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict
 from returns.result import Failure, Result, Success
 
 from app.bootstrap_telemetry import get_logger, log_context
@@ -21,7 +20,12 @@ from app.extract.connectors import (
 )
 from app.geographies import geographies_lookup
 from app.models import Identified, NavigatorConcept
-from app.transform.models import CouldNotTransform
+from app.transform.models import (
+    CouldNotTransform,
+    TransformWarning,
+    UnknownGeography,
+    UnknownParentLabel,
+)
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -65,50 +69,6 @@ MCF_ATTRIBUTE_KEYS = {
     "project_value_co_financing",
     "approved_ref",
 }
-
-
-# ---------------------------------------------------------------------------
-# Warnings (non-fatal)
-# ---------------------------------------------------------------------------
-# A warning means "I produced a Document, but here's something I had to skip
-# or couldn't resolve." The transform still completes; warnings are an audit
-# log so callers can observe and report what happened. Compare with
-# `CouldNotTransform`, which is used at the boundary for genuinely fatal
-# failures where no Document can be produced at all.
-
-
-class UnknownParentLabel(BaseModel):
-    """A litigation concept referenced a parent label that wasn't in the input.
-
-    The child label is still emitted; only the unresolved `subconcept_of`
-    link is dropped.
-    """
-
-    kind: Literal["unknown_parent_label"] = "unknown_parent_label"
-    family_import_id: str
-    relation: str
-    parent_name: str
-
-
-class UnknownGeography(BaseModel):
-    """A geography ID was supplied that isn't in the geographies lookup table.
-
-    The geography is silently skipped; this warning surfaces it for inspection.
-    Note: the sentinel `XAA` ("No Geography") is intentionally excluded and
-    does NOT produce a warning.
-    """
-
-    kind: Literal["unknown_geography"] = "unknown_geography"
-    family_import_id: str
-    geography_id: str
-
-
-# Discriminated union — `kind` is the discriminator field.
-# @see: https://docs.pydantic.dev/latest/concepts/unions/#discriminated-unions
-TransformWarning = Annotated[
-    UnknownParentLabel | UnknownGeography,
-    Field(discriminator="kind"),
-]
 
 
 # ---------------------------------------------------------------------------

--- a/data-in-pipeline/app/transform/navigator_family.py
+++ b/data-in-pipeline/app/transform/navigator_family.py
@@ -1,3 +1,6 @@
+from datetime import datetime
+from typing import Annotated, Literal
+
 from data_in_models.models import (
     Document,
     DocumentRelationship,
@@ -7,7 +10,8 @@ from data_in_models.models import (
     LabelRelationship,
     LabelWithoutDocumentRelationships,
 )
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
+from returns.result import Failure, Result, Success
 
 from app.bootstrap_telemetry import get_logger, log_context
 from app.extract.connectors import (
@@ -18,6 +22,10 @@ from app.extract.connectors import (
 from app.geographies import geographies_lookup
 from app.models import Identified, NavigatorConcept
 from app.transform.models import CouldNotTransform
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
 
 mcf_projects_corpus_import_ids = [
     "MCF.corpus.AF.n0000",
@@ -59,89 +67,121 @@ MCF_ATTRIBUTE_KEYS = {
 }
 
 
-class TransformResult(BaseModel):
-    model_config = ConfigDict(
-        arbitrary_types_allowed=True
-    )  # allowing non-Pydantic types in this model
-    documents: list[Document]
-    errors: list[CouldNotTransform]
+# ---------------------------------------------------------------------------
+# Warnings (non-fatal)
+# ---------------------------------------------------------------------------
+# A warning means "I produced a Document, but here's something I had to skip
+# or couldn't resolve." The transform still completes; warnings are an audit
+# log so callers can observe and report what happened. Compare with
+# `CouldNotTransform`, which is used at the boundary for genuinely fatal
+# failures where no Document can be produced at all.
 
 
-class LitigationConceptLabelTransformResult(BaseModel):
+class UnknownParentLabel(BaseModel):
+    """A litigation concept referenced a parent label that wasn't in the input.
+
+    The child label is still emitted; only the unresolved `subconcept_of`
+    link is dropped.
+    """
+
+    kind: Literal["unknown_parent_label"] = "unknown_parent_label"
+    family_import_id: str
+    relation: str
+    parent_name: str
+
+
+class UnknownGeography(BaseModel):
+    """A geography ID was supplied that isn't in the geographies lookup table.
+
+    The geography is silently skipped; this warning surfaces it for inspection.
+    Note: the sentinel `XAA` ("No Geography") is intentionally excluded and
+    does NOT produce a warning.
+    """
+
+    kind: Literal["unknown_geography"] = "unknown_geography"
+    family_import_id: str
+    geography_id: str
+
+
+# Discriminated union — `kind` is the discriminator field.
+# @see: https://docs.pydantic.dev/latest/concepts/unions/#discriminated-unions
+TransformWarning = Annotated[
+    UnknownParentLabel | UnknownGeography,
+    Field(discriminator="kind"),
+]
+
+
+# ---------------------------------------------------------------------------
+# Output
+# ---------------------------------------------------------------------------
+
+
+class TransformOutput(BaseModel):
+    """Successful result of transforming a NavigatorFamily.
+
+    `documents` are principal documents (the family + its NavigatorDocuments).
+    `collection_documents` are emitted separately because callers persist them
+    differently. `warnings` is the audit log of non-fatal issues — the
+    documents are still complete and usable when warnings is non-empty.
+    """
+
     model_config = ConfigDict(arbitrary_types_allowed=True)
-    labels: list[LabelRelationship]
-    errors: list[CouldNotTransform]
+
+    documents: list[Document]
+    collection_documents: list[Document]
+    warnings: list[TransformWarning]
+
+
+# ---------------------------------------------------------------------------
+# Public entry points
+# ---------------------------------------------------------------------------
 
 
 def transform_navigator_family(
     input: Identified[NavigatorFamily],
-) -> TransformResult:
+) -> Result[TransformOutput, CouldNotTransform]:
     logger = get_logger()
     with log_context(import_id=input.id):
         logger.info(f"Transforming family with {len(input.data.documents)} documents")
         result = transform(input)
-        logger.info(
-            f"Transform completed: produced {len(result.documents)} documents, "
-            f"{len(result.errors)} errors"
-        )
+        match result:
+            case Success(output):
+                logger.info(
+                    f"Transform completed: produced {len(output.documents)} documents "
+                    f"and {len(output.collection_documents)} collection documents "
+                    f"with {len(output.warnings)} warnings"
+                )
+            case Failure(error):
+                logger.warning(f"Transformation failed: {error}")
         return result
-
-
-def _documents_match(
-    documentA: Document,
-    documentB: Document,
-) -> bool:
-    """
-    In the world of MCFs - we often have a "project document" that is a 1-1 mapping of the family.
-    """
-    if documentA.title.lower() == "project document":
-        return True
-
-    """
-    We have some document <=> family relationships that are essentially just a
-    repeat of each other.
-
-    We can use this 1-1 mapping and put the data from the family and store on the document.
-    """
-    return documentA.title.lower() == documentB.title.lower()
-
-
-def _family_document_merged(
-    navigator_family: NavigatorFamily, navigator_document: NavigatorDocument
-) -> bool:
-    if navigator_document.title.lower() == "project document":
-        return True
-
-    if navigator_family.title.lower() == navigator_document.title.lower():
-        return True
-
-    return False
 
 
 def transform(
     input: Identified[NavigatorFamily],
-) -> TransformResult:
-    documents: list[Document] = []
-    transformation_errors: list[CouldNotTransform] = []
+) -> Result[TransformOutput, CouldNotTransform]:
+    """Transform a NavigatorFamily into principal + collection documents.
+
+    Note: this currently has no fatal failure paths — every error case is
+    non-fatal and surfaces as a warning. The `Result` wrapping is kept so
+    callers have a stable return shape and so future fatal cases can be
+    added without changing every call site.
+    """
+    warnings: list[TransformWarning] = []
 
     """
     Transform
     """
-    document_from_family, errors = _transform_navigator_family(input.data)
-    transformation_errors.extend(errors)
+    document_from_family, family_warnings = _transform_navigator_family(input.data)
+    warnings.extend(family_warnings)
 
-    documents_from_documents = [
-        _transform_navigator_document(
-            document,
-            input.data,
-        )
-        for document in input.data.documents
-    ]
-    documents_from_collections = [
-        _transform_navigator_collection(
-            collection,
-            input.data,
-        )
+    documents_from_documents: list[Document] = []
+    for nav_doc in input.data.documents:
+        doc, doc_warnings = _transform_navigator_document(nav_doc, input.data)
+        documents_from_documents.append(doc)
+        warnings.extend(doc_warnings)
+
+    documents_from_collections: list[Document] = [
+        _transform_navigator_collection(collection, input.data)
         for collection in input.data.collections
     ]
 
@@ -263,14 +303,54 @@ def transform(
                 )
             )
 
-    """
-    Return the documents
-    """
-    documents.append(document_from_family)
-    documents.extend(documents_from_documents)
-    documents.extend(documents_from_collections)
+    return Success(
+        TransformOutput(
+            documents=[document_from_family, *documents_from_documents],
+            collection_documents=documents_from_collections,
+            warnings=warnings,
+        )
+    )
 
-    return TransformResult(documents=documents, errors=transformation_errors)
+
+# ---------------------------------------------------------------------------
+# Matching helpers
+# ---------------------------------------------------------------------------
+
+
+def _documents_match(
+    documentA: Document,
+    documentB: Document,
+) -> bool:
+    """
+    In the world of MCFs - we often have a "project document" that is a 1-1 mapping of the family.
+    """
+    if documentA.title.lower() == "project document":
+        return True
+
+    """
+    We have some document <=> family relationships that are essentially just a
+    repeat of each other.
+
+    We can use this 1-1 mapping and put the data from the family and store on the document.
+    """
+    return documentA.title.lower() == documentB.title.lower()
+
+
+def _family_document_merged(
+    navigator_family: NavigatorFamily, navigator_document: NavigatorDocument
+) -> bool:
+    if navigator_document.title.lower() == "project document":
+        return True
+
+    if navigator_family.title.lower() == navigator_document.title.lower():
+        return True
+
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Label / attribute helpers
+# ---------------------------------------------------------------------------
 
 
 def _transform_family_corpus_organisation(
@@ -481,32 +561,43 @@ def _transform_litigation_metadata_to_attributes(
 
 def _transform_geographies(
     navigator_family: NavigatorFamily,
-) -> list[LabelRelationship]:
-    logger = get_logger()
-    labels = []
-    if navigator_family.geographies:
-        geography_labels = []
-        for geograpy_id in navigator_family.geographies:
-            # We exclude No Geography (XAA) as this was used as `geography` was previously required.
-            # An empty list is a clearer depiction of a document not having a geography.
-            if geograpy_id != "XAA":
-                geography = geographies_lookup.get(geograpy_id)
-                if geography:
-                    geography_labels.append(
-                        LabelRelationship(
-                            type="geography",
-                            value=Label(
-                                id=f"geography::{geography.id}",
-                                value=geography.name,
-                                type="geography",
-                            ),
-                        )
-                    )
-            else:
-                logger.warning(f"Geography not found: {geograpy_id}")
-        labels.extend(geography_labels)
+) -> tuple[list[LabelRelationship], list[TransformWarning]]:
+    """Convert family.geographies into geography labels.
 
-    return labels
+    XAA ("No Geography") is silently skipped — it's a sentinel from when
+    `geography` was previously a required field. Genuine unknown IDs become
+    `UnknownGeography` warnings.
+    """
+    labels: list[LabelRelationship] = []
+    warnings: list[TransformWarning] = []
+
+    if not navigator_family.geographies:
+        return labels, warnings
+
+    for geography_id in navigator_family.geographies:
+        if geography_id == "XAA":
+            continue
+        geography = geographies_lookup.get(geography_id)
+        if geography is None:
+            warnings.append(
+                UnknownGeography(
+                    family_import_id=navigator_family.import_id,
+                    geography_id=geography_id,
+                )
+            )
+            continue
+        labels.append(
+            LabelRelationship(
+                type="geography",
+                value=Label(
+                    id=f"geography::{geography.id}",
+                    value=geography.name,
+                    type="geography",
+                ),
+            )
+        )
+
+    return labels, warnings
 
 
 def _shallow_label(
@@ -526,19 +617,20 @@ def _shallow_label(
 def _transform_litigation_concepts_to_label_relationships(
     concepts: list[NavigatorConcept],
     family_import_id: str,
-) -> LitigationConceptLabelTransformResult:
+) -> tuple[list[LabelRelationship], list[TransformWarning]]:
     """
     Convert litigation concepts into label relationships with subconcept hierarchies.
 
     Returns:
-        List[LabelRelationship] where each:
-        - type="concept"
-        - value=LabelWithoutRelationships (with nested .labels for hierarchies)
-        - family_import_id= the import_id of the family these concepts belong to, to debug if needed.
-        - Parent references are SHALLOW (labels=[] to prevent deep nesting).
-    """
+        - labels: one `legal_concept` LabelRelationship per concept; nested
+          `subconcept_of` links wired up where the parent label resolves.
+        - warnings: `UnknownParentLabel` for any `subconcept_of_labels` entry
+          that doesn't resolve to a known concept. The child label is still
+          emitted; only the dangling link is dropped.
 
-    errors: list[CouldNotTransform] = []
+    Parent references are SHALLOW (labels=[] to prevent deep nesting).
+    """
+    warnings: list[TransformWarning] = []
 
     # The relation values unfortunately conflict with other values in the taxonomy, so we have to map them as `legal`
     # @see: https://github.com/climatepolicyradar/litigation-data-mapper/blob/49e8da8f4449dc8e3fec5a126b9973df4efb4d26/litigation_data_mapper/extract_concepts.py#L45
@@ -570,26 +662,25 @@ def _transform_litigation_concepts_to_label_relationships(
         for parent_name in concept.subconcept_of_labels:
             parent = label_by_name.get((concept.relation, parent_name))
             if parent is None:
-                errors.append(
-                    CouldNotTransform(
-                        f"Unknown parent label {parent_name!r} in relation {concept.relation!r}. See family {family_import_id!r} for details."
+                warnings.append(
+                    UnknownParentLabel(
+                        family_import_id=family_import_id,
+                        relation=concept.relation,
+                        parent_name=parent_name,
                     )
                 )
-            else:
-                parent_ref = _shallow_label(parent)
+                continue
+            parent_ref = _shallow_label(parent)
+            child.labels.append(
+                LabelRelationship(type="subconcept_of", value=parent_ref)
+            )
 
-                child.labels.append(
-                    LabelRelationship(type="subconcept_of", value=parent_ref)
-                )
-
-    return LitigationConceptLabelTransformResult(
-        labels=[
-            # `legal_concept` rather than `concept` — `concept` is reserved for knowledge graph labels.
-            LabelRelationship(type="legal_concept", value=label)
-            for label in label_map.values()
-        ],
-        errors=errors,
-    )
+    labels = [
+        # we use legal_concept over concept as `concept` is reserved for our knowledge graph labels
+        LabelRelationship(type="legal_concept", value=label)
+        for label in label_map.values()
+    ]
+    return labels, warnings
 
 
 def _transform_to_category(
@@ -737,20 +828,22 @@ def _transform_to_category(
 
 def _transform_litigation_data(
     navigator_family: NavigatorFamily,
-) -> tuple[list[LabelRelationship], list[CouldNotTransform]]:
+) -> tuple[list[LabelRelationship], list[TransformWarning]]:
     """
     Transform litigation-specific concepts and filing date into label relationships.
     Only applies to the Litigation corpus.
     """
     labels: list[LabelRelationship] = []
-    errors: list[CouldNotTransform] = []
+    warnings: list[TransformWarning] = []
 
     if navigator_family.concepts:
-        concept_labels = _transform_litigation_concepts_to_label_relationships(
-            navigator_family.concepts, navigator_family.import_id
+        concept_labels, concept_warnings = (
+            _transform_litigation_concepts_to_label_relationships(
+                navigator_family.concepts, navigator_family.import_id
+            )
         )
-        labels.extend(concept_labels.labels)
-        errors.extend(concept_labels.errors)
+        labels.extend(concept_labels)
+        warnings.extend(concept_warnings)
 
     if navigator_family.events:
         filing_event = next(
@@ -774,15 +867,57 @@ def _transform_litigation_data(
                 )
             )
 
-    return labels, errors
+    return labels, warnings
 
 
+def _part_of_gst1(navigator_family: NavigatorFamily) -> bool:
+    """
+    Checks if a family was fart of the first Global Stocktake (GST1).
+    """
+    gst1_party_submission_date = "2023-11-30"
+
+    family_created_date_without_time = str(
+        datetime.fromisoformat(navigator_family.created.replace("Z", "+00:00")).date()
+    )
+
+    gst1_party_submission = (
+        navigator_family.corpus.import_id == "UNFCCC.corpus.i00000001.n0000"
+        and navigator_family.metadata.get("author_type") is not None
+        and navigator_family.metadata["author_type"][0] == "Party"
+        and family_created_date_without_time == gst1_party_submission_date
+    )
+
+    gst1_non_party_report_dates = [
+        "2023-11-30",
+        "2024-10-15",
+        "2024-10-17",
+        "2024-11-06",
+        "2024-11-15",
+        "2024-11-18",
+    ]
+
+    gst1_non_party_report = (
+        navigator_family.corpus.import_id == "UNFCCC.corpus.i00000001.n0000"
+        and navigator_family.metadata.get("author_type") is not None
+        and navigator_family.metadata["author_type"][0] == "Non-Party"
+        and family_created_date_without_time in gst1_non_party_report_dates
+    )
+
+    return gst1_party_submission or gst1_non_party_report
+
+
+# ---------------------------------------------------------------------------
+# Per-entity transforms
+# ---------------------------------------------------------------------------
+
+
+# trunk-ignore(ruff/PLR0912)
 def _transform_navigator_family(
     navigator_family: NavigatorFamily,
-) -> tuple[Document, list[CouldNotTransform]]:
+) -> tuple[Document, list[TransformWarning]]:
     labels: list[LabelRelationship] = []
     attributes: dict[str, str | float | bool] = {}
-    transformation_errors: list[CouldNotTransform] = []
+    warnings: list[TransformWarning] = []
 
     """
     All families are currently Principal.
@@ -825,6 +960,19 @@ def _transform_navigator_family(
                     type="entity_type",
                 ),
             )
+        )
+
+    # GST1 labels
+    if _part_of_gst1(navigator_family):
+        labels.append(
+            LabelRelationship(
+                type="process",
+                value=Label(
+                    id="process::GST1",
+                    value="GST1 Submission",
+                    type="process",
+                ),
+            ),
         )
 
     # We skip litigation as we hijacked the event_type for document type
@@ -921,7 +1069,9 @@ def _transform_navigator_family(
     """
     Geography labels
     """
-    labels.extend(_transform_geographies(navigator_family))
+    geography_labels, geography_warnings = _transform_geographies(navigator_family)
+    labels.extend(geography_labels)
+    warnings.extend(geography_warnings)
 
     """
     metadata.author and metadata.author_type
@@ -977,9 +1127,7 @@ def _transform_navigator_family(
     """
     Metadata
     """
-
     labels.extend(_transform_metadata(navigator_family))
-
     attributes.update(_transform_metadata_to_attributes(navigator_family))
 
     """
@@ -988,13 +1136,12 @@ def _transform_navigator_family(
     We are adding also adding Litigation filing date as an attribute on the family as it is a key date
     for litigation documents.
     """
-
     if navigator_family.corpus.import_id == "Academic.corpus.Litigation.n0000":
-        litigation_labels, litigation_errors = _transform_litigation_data(
+        litigation_labels, litigation_warnings = _transform_litigation_data(
             navigator_family
         )
         labels.extend(litigation_labels)
-        transformation_errors.extend(litigation_errors)
+        warnings.extend(litigation_warnings)
 
     """Dates"""
     if navigator_family.published_date:
@@ -1008,7 +1155,6 @@ def _transform_navigator_family(
     that has a 'PUBLISHED' status to keep the data-in-api clean. For simplicity, we do not
     add a status if the family cannot be considered published.
     """
-
     contains_published_document = [
         doc for doc in navigator_family.documents if doc.document_status == "published"
     ]
@@ -1022,8 +1168,7 @@ def _transform_navigator_family(
         labels=_deduplicate_labels(labels),
         attributes=attributes,
     )
-
-    return document, transformation_errors
+    return document, warnings
 
 
 def _transform_document_urls(navigator_document):
@@ -1047,11 +1192,13 @@ def _transform_document_urls(navigator_document):
     return items
 
 
+# trunk-ignore(ruff/PLR0912)
 def _transform_navigator_document(
     navigator_document: NavigatorDocument, navigator_family: NavigatorFamily
-) -> Document:
+) -> tuple[Document, list[TransformWarning]]:
     labels: list[LabelRelationship] = []
     attributes: dict[str, str | float | bool] = {}
+    warnings: list[TransformWarning] = []
     description = None
 
     if navigator_family.corpus.import_id == "Academic.corpus.Litigation.n0000":
@@ -1088,6 +1235,9 @@ def _transform_navigator_document(
     These values are controlled
     @see: https://github.com/climatepolicyradar/data-migrations/blob/main/taxonomies/Intl.%20agreements.json#L42-L51
     @see: https://github.com/climatepolicyradar/data-migrations/blob/main/taxonomies/Laws%20and%20Policies.json#L381-L396
+
+    Based on
+    @see: https://schema.org/Role
     """
     metadata_role = navigator_document.valid_metadata.get("role")
     if metadata_role is not None and len(metadata_role) > 0:
@@ -1096,9 +1246,9 @@ def _transform_navigator_document(
             LabelRelationship(
                 type="role",
                 value=Label(
-                    id=f"entity_type::{normalised_role}",
+                    id=f"role::{normalised_role}",
                     value=normalised_role,
-                    type="entity_type",
+                    type="role",
                 ),
             )
         )
@@ -1139,11 +1289,23 @@ def _transform_navigator_document(
     """
     labels.extend(_transform_family_corpus_organisation(navigator_family))
 
+    # GST1 labels
+    if _part_of_gst1(navigator_family):
+        labels.append(
+            LabelRelationship(
+                type="process",
+                value=Label(
+                    id="process::GST1",
+                    value="GST1 Submission",
+                    type="process",
+                ),
+            ),
+        )
+
     """
     Items
     """
     items: list[Item] = []
-
     items.extend(_transform_document_urls(navigator_document))
 
     """
@@ -1156,7 +1318,9 @@ def _transform_navigator_document(
     """
     Geography labels
     """
-    labels.extend(_transform_geographies(navigator_family))
+    geography_labels, geography_warnings = _transform_geographies(navigator_family)
+    labels.extend(geography_labels)
+    warnings.extend(geography_warnings)
 
     """
     Canonical category
@@ -1177,7 +1341,6 @@ def _transform_navigator_document(
     """
     Internal attributes
     """
-
     if navigator_document.variant:
         attributes["variant"] = navigator_document.variant
     if navigator_document.md5_sum:
@@ -1202,7 +1365,7 @@ def _transform_navigator_document(
             )
         )
 
-    return Document(
+    document = Document(
         id=navigator_document.import_id,
         title=navigator_document.title,
         description=description[0] if description else None,
@@ -1210,6 +1373,7 @@ def _transform_navigator_document(
         items=items,
         attributes=attributes,
     )
+    return document, warnings
 
 
 def _transform_navigator_collection(

--- a/data-in-pipeline/tests/factories.py
+++ b/data-in-pipeline/tests/factories.py
@@ -4,7 +4,7 @@ Use ModelFactory.build(...) with overrides for specific test data; factories
 fill the rest with sensible defaults.
 """
 
-from data_in_models.models import DocumentWithoutRelationships
+from data_in_models.models import Document, DocumentWithoutRelationships
 from polyfactory.factories.pydantic_factory import ModelFactory
 
 from app.extract.connectors import (
@@ -58,3 +58,7 @@ class ExtractedMetadataFactory(ModelFactory[ExtractedMetadata]):
 
 class DocumentWithoutRelationshipsFactory(ModelFactory[DocumentWithoutRelationships]):
     """Factory for DocumentWithoutRelationships. Override id, title, labels, items."""
+
+
+class DocumentFactory(ModelFactory[Document]):
+    """Factory for Document. Override id, title, labels, items."""

--- a/data-in-pipeline/tests/test_family_pipeline.py
+++ b/data-in-pipeline/tests/test_family_pipeline.py
@@ -24,8 +24,8 @@ from app.navigator_family_etl_pipeline import (
     transform,
 )
 from app.transform.models import NoMatchingTransformations
+from app.transform.navigator_family import TransformOutput
 from tests.factories import (
-    DocumentWithoutRelationshipsFactory,
     NavigatorCollectionFactory,
     NavigatorCorpusFactory,
     NavigatorCorpusTypeFactory,
@@ -371,25 +371,33 @@ def test_etl_pipeline_partial_transformation_failure(  # noqa: PLR0913
         envelopes=[envelope], failures=[]
     )
 
-    mock_transformed_documents = [
-        DocumentWithoutRelationshipsFactory.build(
-            id="test-doc",
-            title="This is the test doc",
-            description=None,
-            labels=[],
-            items=[],
-        )
-    ]
+    mock_transformed_documents = TransformOutput(
+        documents=[
+            Document(
+                id="valid-family",
+                title="Valid Family",
+                description="Will transform successfully",
+                labels=[],
+                items=[],
+                documents=[],
+            )
+        ],
+        warnings=[],
+        collection_documents=[],
+    )
 
     mock_transform_families.side_effect = [
-        Success((mock_transformed_documents, [])),
+        Success(mock_transformed_documents),
         Failure(NoMatchingTransformations()),
     ]
 
     result = data_in_pipeline()
 
     assert isinstance(result, PipelineResult)
-    assert result.documents_processed == len(mock_transformed_documents)
+    assert result.documents_processed == len(
+        mock_transformed_documents.documents
+        + mock_transformed_documents.collection_documents
+    )
     assert result.status == "success"
 
 

--- a/data-in-pipeline/tests/transform/test_navigator_family.py
+++ b/data-in-pipeline/tests/transform/test_navigator_family.py
@@ -576,7 +576,7 @@ def test_transform_navigator_family_with_single_matching_document(
         },
     )
     assert_model_list_equality(
-        result.unwrap(),
+        result.documents,
         [
             expected_document_from_family,
             Document(
@@ -925,7 +925,7 @@ def test_transform_navigator_family_with_laws_and_policies_corpus_type(
         },
     )
     assert_model_list_equality(
-        result.unwrap(),
+        result.documents,
         [expected_document_from_family],
     )
 
@@ -1193,7 +1193,7 @@ def test_transform_navigator_family_with_published_and_unpublished_documents():
         },
     )
     assert_model_list_equality(
-        result.unwrap(),
+        result.documents,
         [
             expected_document_from_family,
             Document(
@@ -1528,7 +1528,7 @@ def test_transform_navigator_family_with_no_published_documents():
         },
     )
     assert_model_list_equality(
-        result.unwrap(),
+        result.documents,
         [
             expected_document_from_family,
             Document(
@@ -1661,7 +1661,7 @@ def test_transform_to_category_corpus_ids(corpus_id: str, expected_category: str
     )
 
     result = transform_navigator_family(navigator_family)
-    documents = result.unwrap()
+    documents = result.documents
     family_doc = documents[0]
 
     category_labels = [label for label in family_doc.labels if label.type == "category"]

--- a/data-in-pipeline/tests/transform/test_navigator_family.py
+++ b/data-in-pipeline/tests/transform/test_navigator_family.py
@@ -170,9 +170,15 @@ def navigator_family_with_no_matching_transformations() -> Identified[NavigatorF
 def test_transform_navigator_family_with_single_matching_document(
     navigator_family_with_single_matching_document: Identified[NavigatorFamily],
 ):
-    family_result, collection_result = transform_navigator_family(
+    output = transform_navigator_family(
         navigator_family_with_single_matching_document
     ).unwrap()
+
+    assert output.warnings == []
+
+    family_result = output.documents
+    collection_result = output.collection_documents
+
     expected_document_from_family = Document(
         id="family",
         title="Matching title on family and document and collection",
@@ -814,9 +820,15 @@ def test_transform_navigator_family_with_laws_and_policies_corpus_type(
             },
         ),
     )
-    family_result, _ = transform_navigator_family(
+    output = transform_navigator_family(
         navigator_family_with_laws_and_policies_corpus_type
     ).unwrap()
+
+    assert output.warnings == []
+    assert output.collection_documents == []
+
+    family_result = output.documents
+
     expected_document_from_family = Document(
         id="family",
         title="Laws and policies family",
@@ -985,9 +997,15 @@ def test_transform_navigator_family_with_published_and_unpublished_documents():
             metadata={},
         ),
     )
-    result, _ = transform_navigator_family(
+    output = transform_navigator_family(
         navigator_family_with_different_document_statuses
     ).unwrap()
+
+    assert output.warnings == []
+    assert output.collection_documents == []
+
+    result = output.documents
+
     expected_document_from_family = Document(
         id="family",
         title="Family with different document statuses",
@@ -1396,9 +1414,16 @@ def test_transform_navigator_family_with_no_published_documents():
             metadata={},
         ),
     )
-    result, _ = transform_navigator_family(
+
+    output = transform_navigator_family(
         navigator_family_with_no_published_documents
     ).unwrap()
+
+    assert output.warnings == []
+    assert output.collection_documents == []
+
+    result = output.documents
+
     expected_document_from_family = Document(
         id="family",
         title="Family with no published documents",
@@ -1670,9 +1695,13 @@ def test_transform_to_category_corpus_ids(corpus_id: str, expected_category: str
         ),
     )
 
-    result, _ = transform_navigator_family(navigator_family).unwrap()
-    documents = result
-    family_doc = documents[0]
+    output = transform_navigator_family(navigator_family).unwrap()
+
+    assert output.warnings == []
+    assert output.collection_documents == []
+
+    result = output.documents
+    family_doc = result[0]
 
     category_labels = [label for label in family_doc.labels if label.type == "category"]
     assert any(

--- a/data-in-pipeline/tests/transform/test_navigator_family_GST1.py
+++ b/data-in-pipeline/tests/transform/test_navigator_family_GST1.py
@@ -150,9 +150,13 @@ def test_transform_navigator_family_UNFCCC_party_submission_to_GST1_label():
             },
         ),
     )
-    result, _ = transform_navigator_family(
-        navigator_family_with_GST1_documents
-    ).unwrap()
+    output = transform_navigator_family(navigator_family_with_GST1_documents).unwrap()
+
+    assert output.warnings == []
+    assert output.collection_documents == []
+
+    result = output.documents
+
     expected_document_from_family = Document(
         id="family",
         title="GST1 party family",
@@ -431,9 +435,13 @@ def test_transform_navigator_family_UNFCCC_non_party_submission_to_GST1_label():
             },
         ),
     )
-    result, _ = transform_navigator_family(
-        navigator_family_with_GST1_documents
-    ).unwrap()
+    output = transform_navigator_family(navigator_family_with_GST1_documents).unwrap()
+
+    assert output.warnings == []
+    assert output.collection_documents == []
+
+    result = output.documents
+
     expected_document_from_family = Document(
         id="family",
         title="GST1 party family",

--- a/data-in-pipeline/tests/transform/test_navigator_family_litigation.py
+++ b/data-in-pipeline/tests/transform/test_navigator_family_litigation.py
@@ -479,7 +479,7 @@ def test_transform_navigator_family_with_litigation_corpus_type(
         },
     )
     assert_model_list_equality(
-        result.unwrap(),
+        result.documents,
         [
             expected_document_from_family,
             Document(
@@ -764,7 +764,7 @@ def test_transform_navigator_family_with_litigation_corpus_type_and_litigation_c
         },
     )
     assert_model_list_equality(
-        result.unwrap(),
+        result.documents,
         [
             expected_document_from_family,
             Document(

--- a/data-in-pipeline/tests/transform/test_navigator_family_litigation.py
+++ b/data-in-pipeline/tests/transform/test_navigator_family_litigation.py
@@ -310,9 +310,15 @@ def navigator_family_with_duplicate_legal_case() -> Identified[NavigatorFamily]:
 def test_transform_navigator_family_with_litigation_corpus_type(
     navigator_family_with_litigation_corpus_type: Identified[NavigatorFamily],
 ):
-    result, _ = transform_navigator_family(
+    output = transform_navigator_family(
         navigator_family_with_litigation_corpus_type
     ).unwrap()
+
+    assert output.warnings == []
+    assert output.collection_documents == []
+
+    result = output.documents
+
     expected_document_from_family = Document(
         id="family",
         title="Litigation family",
@@ -610,9 +616,15 @@ def test_transform_navigator_family_with_litigation_corpus_type(
 def test_transform_navigator_family_with_litigation_corpus_type_and_litigation_concepts(
     navigator_family_with_litigation_concepts: Identified[NavigatorFamily],
 ):
-    result, _ = transform_navigator_family(
+    output = transform_navigator_family(
         navigator_family_with_litigation_concepts
     ).unwrap()
+
+    assert output.warnings == []
+    assert output.collection_documents == []
+
+    result = output.documents
+
     expected_document_from_family = Document(
         id="family",
         title="Litigation family",

--- a/data-in-pipeline/tests/transform/test_navigator_family_mcf.py
+++ b/data-in-pipeline/tests/transform/test_navigator_family_mcf.py
@@ -427,7 +427,7 @@ def test_transform_navigator_family_with_multilateral_climate_fund_project(
         },
     )
     assert_model_list_equality(
-        result.unwrap(),
+        result.documents,
         [
             expected_document_from_family,
             Document(
@@ -563,7 +563,7 @@ def test_transform_navigator_family_with_multilateral_climate_fund_guidance(
         navigator_family_multilateral_climate_fund_guidance
     )
     assert_model_list_equality(
-        result.unwrap(),
+        result.documents,
         [
             Document(
                 id="family",

--- a/data-in-pipeline/tests/transform/test_navigator_family_mcf.py
+++ b/data-in-pipeline/tests/transform/test_navigator_family_mcf.py
@@ -181,9 +181,12 @@ def navigator_family_multilateral_climate_fund_guidance() -> (
 def test_transform_navigator_family_with_multilateral_climate_fund_project(
     navigator_family_multilateral_climate_fund_project: Identified[NavigatorFamily],
 ):
-    result, _ = transform_navigator_family(
+    output = transform_navigator_family(
         navigator_family_multilateral_climate_fund_project
     ).unwrap()
+
+    assert output.warnings == []
+    assert output.collection_documents == []
     expected_document_from_family = Document(
         id="family",
         title="Multilateral climate fund project",
@@ -429,7 +432,7 @@ def test_transform_navigator_family_with_multilateral_climate_fund_project(
         },
     )
     assert_model_list_equality(
-        result,
+        output.documents,
         [
             expected_document_from_family,
             Document(
@@ -561,11 +564,14 @@ def test_transform_navigator_family_with_multilateral_climate_fund_project(
 def test_transform_navigator_family_with_multilateral_climate_fund_guidance(
     navigator_family_multilateral_climate_fund_guidance: Identified[NavigatorFamily],
 ):
-    result, _ = transform_navigator_family(
+    output = transform_navigator_family(
         navigator_family_multilateral_climate_fund_guidance
     ).unwrap()
+
+    assert output.warnings == []
+    assert output.collection_documents == []
     assert_model_list_equality(
-        result,
+        output.documents,
         [
             Document(
                 id="family",


### PR DESCRIPTION
## Summary

Refactor the family transformation pipeline to use the **Validation pattern**: `Result` is preserved at the public boundary for fatal failures, and non-fatal issues are accumulated as typed `TransformWarning`s carried inside the success value. Transforms still produce their output when sub-steps have to skip something — callers observe what happened via the warnings list rather than the whole family being dropped.

This re-rolls the earlier "drop `Result` entirely" attempt after PR feedback that it gave up too much of the `returns` library's ergonomics.

## What changed

- **New `TransformOutput`** Pydantic model with `documents`, `collection_documents`, and `warnings`. Replaces the unnamed `tuple[list[Document], list[Document]]` shape and gives warnings a place to live.
- **New discriminated-union `TransformWarning`** = `UnknownParentLabel | UnknownGeography`, keyed by a `kind` literal. Defined in `app.transform.models` alongside `CouldNotTransform` so the warning vocabulary has a single source of truth.
- **`transform()` and `transform_navigator_family()` still return `Result[TransformOutput, CouldNotTransform]`.** Callers keep `.bind`, `.map`, structural pattern matching, and a stable return shape.
- **Internal helpers drop `Result` where they have no fatal path.** `_transform_navigator_family`, `_transform_navigator_document`, `_transform_litigation_concepts_to_label_relationships`, `_transform_geographies`, and `_transform_litigation_data` now return `tuple[..., list[TransformWarning]]`. This is honest about what they actually do — accumulate skips, don't fail.
- **Litigation concepts:** missing parent labels are captured as `UnknownParentLabel` warnings instead of being silently dropped.
- **Geographies:** the previous `else` branch logged `"Geography not found"` for the `XAA` sentinel, which is the *intentional* exclusion. Now `XAA` is silently skipped (correct) and genuine unknown IDs become `UnknownGeography` warnings.
- **Wrapper cleanup.** The redundant `match Success() / Failure()` rewrap in `transform_navigator_family` is gone. The unreachable `Failure(NoMatchingTransformations())` branch and its import are removed.
- **Pipeline-level caller** (`@task transform`) widens its return to `tuple[list[Document], list[Exception | TransformWarning]]`. Warnings flow into the same bucket as errors so existing downstream handling keeps working; per-warning structured logging is added on the success branch for observability.

## Why

- **Honest types without losing `Result`.** `Result` was used everywhere — including in helpers with no genuine failure path — so readers had to scan dead `Failure` branches to find the real logic. The new shape uses `Result` only where fatal failure actually exists.
- **Observability of soft failures.** Missing parent concepts and unknown geography IDs were silently dropped or logged in ways that lost context. They're now first-class, typed data threaded through the return.
- **Partial success.** A single bad litigation concept or one unknown geography no longer needs special-case handling — the document still flows through and the issue is reported alongside it.
- **Stable boundary for callers.** Public functions return `Result` whether or not there's currently a fatal path, so adding future fatal cases is additive rather than signature-changing.