### PR TITLE
Feature/app 1487 transform unfccc gst1

### DIFF
--- a/data-in-pipeline/app/extract/connectors.py
+++ b/data-in-pipeline/app/extract/connectors.py
@@ -89,6 +89,7 @@ class NavigatorFamily(BaseModel):
     metadata: dict[str, list[str]] = {}
     published_date: str | None = None
     last_updated_date: str | None = None
+    created: str
 
 
 class PageFetchFailure(BaseModel):

--- a/data-in-pipeline/app/transform/navigator_family.py
+++ b/data-in-pipeline/app/transform/navigator_family.py
@@ -766,9 +766,9 @@ def _transform_litigation_data(
     return Success(labels)
 
 
-def _part_of_gst1(navigator_family: NavigatorFamily) -> bool:
+def _part_of_global_stock_take_1(navigator_family: NavigatorFamily) -> bool:
     """
-    Checks if a family was fart of the first Global Stocktake.
+    Checks if a family was fart of the first Global Stocktake (GST1).
     """
     gst1_party_submission_date = "2023-11-30"
 
@@ -853,7 +853,7 @@ def _transform_navigator_family(
         )
 
     # GST1 labels
-    if _part_of_gst1(navigator_family):
+    if _part_of_global_stock_take_1(navigator_family):
         labels.append(
             LabelRelationship(
                 type="entity_type",
@@ -1179,7 +1179,7 @@ def _transform_navigator_document(
     labels.extend(_transform_family_corpus_organisation(navigator_family))
 
     # GST1 labels
-    if _part_of_gst1(navigator_family):
+    if _part_of_global_stock_take_1(navigator_family):
         labels.append(
             LabelRelationship(
                 type="entity_type",

--- a/data-in-pipeline/app/transform/navigator_family.py
+++ b/data-in-pipeline/app/transform/navigator_family.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from data_in_models.models import (
     Document,
     DocumentRelationship,
@@ -764,6 +766,41 @@ def _transform_litigation_data(
     return Success(labels)
 
 
+def _part_of_gst1(navigator_family: NavigatorFamily) -> bool:
+    """
+    Checks if a family was fart of the first Global Stocktake.
+    """
+    gst1_party_submission_date = "2023-11-30"
+
+    family_created_date_without_time = str(
+        datetime.fromisoformat(navigator_family.created.replace("Z", "+00:00")).date()
+    )
+
+    gst1_party_submission = (
+        navigator_family.corpus.import_id == "UNFCCC.corpus.i00000001.n0000"
+        and navigator_family.metadata["author_type"][0] == "Party"
+        and family_created_date_without_time == gst1_party_submission_date
+    )
+
+    gst1_non_party_report_dates = [
+        "2023-11-30",
+        "2024-10-15",
+        "2024-10-17",
+        "2024-11-06",
+        "2024-11-15",
+        "2024-11-18",
+    ]
+
+    gst1_non_party_report = (
+        navigator_family.corpus.import_id == "UNFCCC.corpus.i00000001.n0000"
+        and navigator_family.metadata["author_type"][0] == "Non-Party"
+        and family_created_date_without_time in gst1_non_party_report_dates
+    )
+
+    return gst1_party_submission or gst1_non_party_report
+
+
+# trunk-ignore(ruff/PLR0912)
 def _transform_navigator_family(
     navigator_family: NavigatorFamily,
 ) -> Result[Document, CouldNotTransform]:
@@ -809,6 +846,19 @@ def _transform_navigator_family(
                     id="entity_type::Guidance",
                     value="Guidance",
                     type="entity_type",
+                ),
+            )
+        )
+
+    # GST1 labels
+    if _part_of_gst1(navigator_family):
+        labels.append(
+            LabelRelationship(
+                type="?",
+                value=Label(
+                    id="?::GST1",
+                    value="GST1",
+                    type="?",
                 ),
             )
         )

--- a/data-in-pipeline/app/transform/navigator_family.py
+++ b/data-in-pipeline/app/transform/navigator_family.py
@@ -856,11 +856,11 @@ def _transform_navigator_family(
     if _part_of_global_stock_take_1(navigator_family):
         labels.append(
             LabelRelationship(
-                type="entity_type",
+                type="process",
                 value=Label(
-                    id="entity_type::GST1",
+                    id="process::GST1",
                     value="GST1 Submission",
-                    type="entity_type",
+                    type="process",
                 ),
             ),
         )
@@ -1182,11 +1182,11 @@ def _transform_navigator_document(
     if _part_of_global_stock_take_1(navigator_family):
         labels.append(
             LabelRelationship(
-                type="entity_type",
+                type="process",
                 value=Label(
-                    id="entity_type::GST1",
+                    id="process::GST1",
                     value="GST1 Submission",
-                    type="entity_type",
+                    type="process",
                 ),
             ),
         )

--- a/data-in-pipeline/app/transform/navigator_family.py
+++ b/data-in-pipeline/app/transform/navigator_family.py
@@ -854,13 +854,13 @@ def _transform_navigator_family(
     if _part_of_gst1(navigator_family):
         labels.append(
             LabelRelationship(
-                type="?",
+                type="entity_type",
                 value=Label(
-                    id="?::GST1",
-                    value="GST1",
-                    type="?",
+                    id="entity_type::GST1",
+                    value="GST1 Submission",
+                    type="entity_type",
                 ),
-            )
+            ),
         )
 
     # We skip litigation as we hijacked the event_type for document type

--- a/data-in-pipeline/app/transform/navigator_family.py
+++ b/data-in-pipeline/app/transform/navigator_family.py
@@ -778,6 +778,7 @@ def _part_of_gst1(navigator_family: NavigatorFamily) -> bool:
 
     gst1_party_submission = (
         navigator_family.corpus.import_id == "UNFCCC.corpus.i00000001.n0000"
+        and navigator_family.metadata.get("author_type") is not None
         and navigator_family.metadata["author_type"][0] == "Party"
         and family_created_date_without_time == gst1_party_submission_date
     )
@@ -793,6 +794,7 @@ def _part_of_gst1(navigator_family: NavigatorFamily) -> bool:
 
     gst1_non_party_report = (
         navigator_family.corpus.import_id == "UNFCCC.corpus.i00000001.n0000"
+        and navigator_family.metadata.get("author_type") is not None
         and navigator_family.metadata["author_type"][0] == "Non-Party"
         and family_created_date_without_time in gst1_non_party_report_dates
     )

--- a/data-in-pipeline/app/transform/navigator_family.py
+++ b/data-in-pipeline/app/transform/navigator_family.py
@@ -1083,6 +1083,7 @@ def _transform_document_urls(navigator_document):
     return items
 
 
+# trunk-ignore(ruff/PLR0912)
 def _transform_navigator_document(
     navigator_document: NavigatorDocument, navigator_family: NavigatorFamily
 ) -> Document:
@@ -1174,6 +1175,19 @@ def _transform_navigator_document(
     Provider labels
     """
     labels.extend(_transform_family_corpus_organisation(navigator_family))
+
+    # GST1 labels
+    if _part_of_gst1(navigator_family):
+        labels.append(
+            LabelRelationship(
+                type="entity_type",
+                value=Label(
+                    id="entity_type::GST1",
+                    value="GST1 Submission",
+                    type="entity_type",
+                ),
+            ),
+        )
 
     """
     Items

--- a/data-in-pipeline/app/transform/navigator_family.py
+++ b/data-in-pipeline/app/transform/navigator_family.py
@@ -766,7 +766,7 @@ def _transform_litigation_data(
     return Success(labels)
 
 
-def _part_of_global_stock_take_1(navigator_family: NavigatorFamily) -> bool:
+def _part_of_gst1(navigator_family: NavigatorFamily) -> bool:
     """
     Checks if a family was fart of the first Global Stocktake (GST1).
     """
@@ -853,7 +853,7 @@ def _transform_navigator_family(
         )
 
     # GST1 labels
-    if _part_of_global_stock_take_1(navigator_family):
+    if _part_of_gst1(navigator_family):
         labels.append(
             LabelRelationship(
                 type="process",
@@ -1179,7 +1179,7 @@ def _transform_navigator_document(
     labels.extend(_transform_family_corpus_organisation(navigator_family))
 
     # GST1 labels
-    if _part_of_global_stock_take_1(navigator_family):
+    if _part_of_gst1(navigator_family):
         labels.append(
             LabelRelationship(
                 type="process",

--- a/data-in-pipeline/tests/test_family_pipeline.py
+++ b/data-in-pipeline/tests/test_family_pipeline.py
@@ -67,6 +67,7 @@ def test_process_family_updates_flow_multiple_families(  # noqa: PLR0913
             title="Belgium UNCBD National Targets",
             summary="Family summary",
             category="REPORTS",
+            created="2020-01-01T00:00:00Z",
             corpus=corpus,
             documents=[
                 NavigatorDocumentFactory.build(
@@ -86,6 +87,7 @@ def test_process_family_updates_flow_multiple_families(  # noqa: PLR0913
             title="France UNCBD National Targets",
             summary="Family summary",
             category="REPORTS",
+            created="2020-01-01T00:00:00Z",
             corpus=corpus,
             documents=[
                 NavigatorDocumentFactory.build(
@@ -222,6 +224,7 @@ def test_etl_pipeline_load_failure(  # noqa: PLR0913
             title=test_family_title,
             summary="Family summary",
             category="REPORTS",
+            created="2020-01-01T00:00:00Z",
             corpus=corpus,
             documents=[
                 NavigatorDocumentFactory.build(

--- a/data-in-pipeline/tests/transform/test_navigator_family.py
+++ b/data-in-pipeline/tests/transform/test_navigator_family.py
@@ -86,8 +86,8 @@ def navigator_family_with_single_matching_document() -> Identified[NavigatorFami
             summary="Family summary",
             category="EXECUTIVE",
             corpus=_cclw_corpus(),
-            last_updated_date="2020-01-0100:00:00Z",
-            published_date="2020-01-0100:00:00Z",
+            last_updated_date="2020-01-01T00:00:00Z",
+            published_date="2020-01-01T00:00:00Z",
             created="2020-01-01T00:00:00Z",
             documents=[
                 NavigatorDocumentFactory.build(
@@ -117,7 +117,7 @@ def navigator_family_with_single_matching_document() -> Identified[NavigatorFami
                     description="Collection description",
                     slug="collection-matching-slug",
                     created="2020-01-01T00:00:00Z",
-                    last_modified="2020-01-0100:00:00Z",
+                    last_modified="2020-01-01T00:00:00Z",
                 ),
                 NavigatorCollectionFactory.build(
                     import_id="collection",
@@ -125,7 +125,7 @@ def navigator_family_with_single_matching_document() -> Identified[NavigatorFami
                     description="Collection description",
                     slug="collection-slug",
                     created="2020-01-01T00:00:00Z",
-                    last_modified="2020-01-0100:00:00Z",
+                    last_modified="2020-01-01T00:00:00Z",
                 ),
             ],
             geographies=["AU-NSW", "AUS", "XAA"],
@@ -148,8 +148,8 @@ def navigator_family_with_no_matching_transformations() -> Identified[NavigatorF
             title="No matches for this family or documents",
             summary="Family summary",
             category="UNFCCC",
-            last_updated_date="2020-01-0100:00:00Z",
-            published_date="2020-01-0100:00:00Z",
+            last_updated_date="2020-01-01T00:00:00Z",
+            published_date="2020-01-01T00:00:00Z",
             created="2020-01-01T00:00:00Z",
             corpus=_cclw_corpus(),
             documents=[
@@ -427,8 +427,8 @@ def test_transform_navigator_family_with_single_matching_document(
                     ],
                     attributes={
                         "deprecated_slug": "collection-slug",
-                        "published_date": "2020-01-0100:00:00Z",
-                        "last_updated_date": "2020-01-0100:00:00Z",
+                        "published_date": "2020-01-01T00:00:00Z",
+                        "last_updated_date": "2020-01-01T00:00:00Z",
                     },
                 ),
             ),
@@ -541,8 +541,8 @@ def test_transform_navigator_family_with_single_matching_document(
                         "variant": "Original language",
                         "md5_sum": "aaaaa11111bbbbb",
                         "status": "published",
-                        "published_date": "2020-01-0100:00:00Z",
-                        "last_updated_date": "2020-01-0100:00:00Z",
+                        "published_date": "2020-01-01T00:00:00Z",
+                        "last_updated_date": "2020-01-01T00:00:00Z",
                     },
                 ),
             ),
@@ -564,16 +564,16 @@ def test_transform_navigator_family_with_single_matching_document(
                     items=[],
                     attributes={
                         "deprecated_slug": "collection-matching-slug",
-                        "published_date": "2020-01-0100:00:00Z",
-                        "last_updated_date": "2020-01-0100:00:00Z",
+                        "published_date": "2020-01-01T00:00:00Z",
+                        "last_updated_date": "2020-01-01T00:00:00Z",
                     },
                 ),
             ),
         ],
         attributes={
             "deprecated_slug": "family-slug",
-            "published_date": "2020-01-0100:00:00Z",
-            "last_updated_date": "2020-01-0100:00:00Z",
+            "published_date": "2020-01-01T00:00:00Z",
+            "last_updated_date": "2020-01-01T00:00:00Z",
             "status": "published",
         },
     )
@@ -696,8 +696,8 @@ def test_transform_navigator_family_with_single_matching_document(
                     "variant": "Original language",
                     "md5_sum": "aaaaa11111bbbbb",
                     "status": "published",
-                    "published_date": "2020-01-0100:00:00Z",
-                    "last_updated_date": "2020-01-0100:00:00Z",
+                    "published_date": "2020-01-01T00:00:00Z",
+                    "last_updated_date": "2020-01-01T00:00:00Z",
                 },
             ),
             Document(
@@ -705,8 +705,8 @@ def test_transform_navigator_family_with_single_matching_document(
                 title="Matching title on family and document and collection",
                 attributes={
                     "deprecated_slug": "collection-matching-slug",
-                    "published_date": "2020-01-0100:00:00Z",
-                    "last_updated_date": "2020-01-0100:00:00Z",
+                    "published_date": "2020-01-01T00:00:00Z",
+                    "last_updated_date": "2020-01-01T00:00:00Z",
                 },
                 labels=[
                     LabelRelationship(
@@ -730,8 +730,8 @@ def test_transform_navigator_family_with_single_matching_document(
             Document(
                 attributes={
                     "deprecated_slug": "collection-slug",
-                    "published_date": "2020-01-0100:00:00Z",
-                    "last_updated_date": "2020-01-0100:00:00Z",
+                    "published_date": "2020-01-01T00:00:00Z",
+                    "last_updated_date": "2020-01-01T00:00:00Z",
                 },
                 id="collection",
                 title="Collection title",
@@ -1661,7 +1661,7 @@ def test_transform_to_category_corpus_ids(corpus_id: str, expected_category: str
             collections=[],
             geographies=[],
             slug="family-slug",
-            metadata={"author_type": ["Party"]},
+            metadata={},
             concepts=[],
         ),
     )

--- a/data-in-pipeline/tests/transform/test_navigator_family.py
+++ b/data-in-pipeline/tests/transform/test_navigator_family.py
@@ -88,6 +88,7 @@ def navigator_family_with_single_matching_document() -> Identified[NavigatorFami
             corpus=_cclw_corpus(),
             last_updated_date="2020-01-0100:00:00Z",
             published_date="2020-01-0100:00:00Z",
+            created="2020-01-01T00:00:00Z",
             documents=[
                 NavigatorDocumentFactory.build(
                     import_id="document",
@@ -115,7 +116,7 @@ def navigator_family_with_single_matching_document() -> Identified[NavigatorFami
                     title="Matching title on family and document and collection",
                     description="Collection description",
                     slug="collection-matching-slug",
-                    created="2020-01-0100:00:00Z",
+                    created="2020-01-01T00:00:00Z",
                     last_modified="2020-01-0100:00:00Z",
                 ),
                 NavigatorCollectionFactory.build(
@@ -123,7 +124,7 @@ def navigator_family_with_single_matching_document() -> Identified[NavigatorFami
                     title="Collection title",
                     description="Collection description",
                     slug="collection-slug",
-                    created="2020-01-0100:00:00Z",
+                    created="2020-01-01T00:00:00Z",
                     last_modified="2020-01-0100:00:00Z",
                 ),
             ],
@@ -149,6 +150,7 @@ def navigator_family_with_no_matching_transformations() -> Identified[NavigatorF
             category="UNFCCC",
             last_updated_date="2020-01-0100:00:00Z",
             published_date="2020-01-0100:00:00Z",
+            created="2020-01-01T00:00:00Z",
             corpus=_cclw_corpus(),
             documents=[
                 NavigatorDocumentFactory.build(
@@ -780,6 +782,7 @@ def test_transform_navigator_family_with_laws_and_policies_corpus_type(
             category="LEGISLATIVE",
             published_date=None,
             last_updated_date=None,
+            created="2020-01-01T00:00:00Z",
             corpus=NavigatorCorpusFactory.build(
                 import_id=corpus_id,
                 corpus_type=NavigatorCorpusTypeFactory.build(name="Laws and Policies"),
@@ -941,6 +944,7 @@ def test_transform_navigator_family_with_published_and_unpublished_documents():
             category="LEGISLATIVE",
             published_date=None,
             last_updated_date=None,
+            created="2020-01-01T00:00:00Z",
             corpus=_cclw_corpus(),
             documents=[
                 NavigatorDocumentFactory.build(
@@ -1365,6 +1369,7 @@ def test_transform_navigator_family_with_no_published_documents():
             category="LEGISLATIVE",
             published_date=None,
             last_updated_date=None,
+            created="2020-01-01T00:00:00Z",
             corpus=_cclw_corpus(),
             documents=[
                 NavigatorDocumentFactory.build(
@@ -1642,6 +1647,7 @@ def test_transform_to_category_corpus_ids(corpus_id: str, expected_category: str
             category="REPORTS",
             published_date=None,
             last_updated_date=None,
+            created="2020-01-01T00:00:00Z",
             corpus=NavigatorCorpusFactory.build(
                 import_id=corpus_id,
                 corpus_type=NavigatorCorpusTypeFactory.build(name="corpus_type"),
@@ -1655,7 +1661,7 @@ def test_transform_to_category_corpus_ids(corpus_id: str, expected_category: str
             collections=[],
             geographies=[],
             slug="family-slug",
-            metadata={},
+            metadata={"author_type": ["Party"]},
             concepts=[],
         ),
     )

--- a/data-in-pipeline/tests/transform/test_navigator_family_GST1.py
+++ b/data-in-pipeline/tests/transform/test_navigator_family_GST1.py
@@ -142,11 +142,11 @@ def test_transform_navigator_family_UNFCCC_party_submission_to_GST1_label():
                 ),
             ),
             LabelRelationship(
-                type="?",
+                type="entity_type",
                 value=Label(
-                    id="?::GST1",
-                    value="GST1",
-                    type="?",
+                    id="entity_type::GST1",
+                    value="GST1 Submission",
+                    type="entity_type",
                 ),
             ),
             LabelRelationship(
@@ -252,11 +252,11 @@ def test_transform_navigator_family_UNFCCC_non_party_submission_to_GST1_label():
                 ),
             ),
             LabelRelationship(
-                type="?",
+                type="entity_type",
                 value=Label(
-                    id="?::GST1",
-                    value="GST1",
-                    type="?",
+                    id="entity_type::GST1",
+                    value="GST1 Submission",
+                    type="entity_type",
                 ),
             ),
             LabelRelationship(

--- a/data-in-pipeline/tests/transform/test_navigator_family_GST1.py
+++ b/data-in-pipeline/tests/transform/test_navigator_family_GST1.py
@@ -9,7 +9,10 @@ from data_in_models.models import (
 )
 
 from app.models import Identified
-from app.transform.navigator_family import _part_of_gst1, transform_navigator_family
+from app.transform.navigator_family import (
+    _part_of_global_stock_take_1,
+    transform_navigator_family,
+)
 from tests.factories import (
     NavigatorCorpusFactory,
     NavigatorCorpusTypeFactory,
@@ -97,7 +100,7 @@ def test_part_of_gst1_correctly_assesses_if_family_is_part_of_global_stocktake(
         },
     )
 
-    assert _part_of_gst1(test_family) == expected_result
+    assert _part_of_global_stock_take_1(test_family) == expected_result
 
 
 def test_transform_navigator_family_UNFCCC_party_submission_to_GST1_label():

--- a/data-in-pipeline/tests/transform/test_navigator_family_GST1.py
+++ b/data-in-pipeline/tests/transform/test_navigator_family_GST1.py
@@ -10,7 +10,7 @@ from data_in_models.models import (
 
 from app.models import Identified
 from app.transform.navigator_family import (
-    _part_of_global_stock_take_1,
+    _part_of_gst1,
     transform_navigator_family,
 )
 from tests.factories import (
@@ -100,7 +100,7 @@ def test_part_of_gst1_correctly_assesses_if_family_is_part_of_global_stocktake(
         },
     )
 
-    assert _part_of_global_stock_take_1(test_family) == expected_result
+    assert _part_of_gst1(test_family) == expected_result
 
 
 def test_transform_navigator_family_UNFCCC_party_submission_to_GST1_label():

--- a/data-in-pipeline/tests/transform/test_navigator_family_GST1.py
+++ b/data-in-pipeline/tests/transform/test_navigator_family_GST1.py
@@ -1,6 +1,9 @@
 import pytest
 from data_in_models.models import (
     Document,
+    DocumentRelationship,
+    DocumentWithoutRelationships,
+    Item,
     Label,
     LabelRelationship,
 )
@@ -10,6 +13,7 @@ from app.transform.navigator_family import _part_of_gst1, transform_navigator_fa
 from tests.factories import (
     NavigatorCorpusFactory,
     NavigatorCorpusTypeFactory,
+    NavigatorDocumentFactory,
     NavigatorFamilyFactory,
     NavigatorOrganisationFactory,
 )
@@ -116,7 +120,23 @@ def test_transform_navigator_family_UNFCCC_party_submission_to_GST1_label():
                 corpus_text="Test corpus",
                 corpus_image_url="corpus_image.png",
             ),
-            documents=[],
+            documents=[
+                NavigatorDocumentFactory.build(
+                    import_id="document",
+                    title="GST1 party document",
+                    cdn_object="https://cdn.climatepolicyradar.org/path/to/file.pdf",
+                    variant="Original language",
+                    content_type="application/pdf",
+                    source_url="https://source.climatepolicyradar.org/path/to/file.pdf",
+                    language="eng",
+                    languages=["eng"],
+                    md5_sum="aaaaa11111bbbbb",
+                    events=[],
+                    valid_metadata={},
+                    slug="document-slug",
+                    document_status="published",
+                ),
+            ],
             events=[],
             collections=[],
             geographies=["AUS"],
@@ -195,14 +215,167 @@ def test_transform_navigator_family_UNFCCC_party_submission_to_GST1_label():
                 ),
             ),
         ],
-        documents=[],
+        documents=[
+            DocumentRelationship(
+                type="has_member",
+                value=DocumentWithoutRelationships(
+                    id="document",
+                    title="GST1 party document",
+                    labels=[
+                        LabelRelationship(
+                            type="provider",
+                            value=Label(
+                                type="agent",
+                                id="agent::UNFCCC",
+                                value="UNFCCC",
+                                attributes={
+                                    "attribution_url": "testurl.org",
+                                    "corpus_text": "Test corpus",
+                                    "corpus_image_url": "https://cdn.climatepolicyradar.org/corpus_image.png",
+                                },
+                            ),
+                        ),
+                        LabelRelationship(
+                            type="entity_type",
+                            value=Label(
+                                id="entity_type::GST1",
+                                value="GST1 Submission",
+                                type="entity_type",
+                            ),
+                        ),
+                        LabelRelationship(
+                            type="geography",
+                            value=Label(
+                                type="geography",
+                                id="geography::AUS",
+                                value="Australia",
+                            ),
+                        ),
+                        LabelRelationship(
+                            type="category",
+                            value=Label(
+                                id="category::UN submission",
+                                value="UN submission",
+                                type="category",
+                            ),
+                        ),
+                        LabelRelationship(
+                            type="language",
+                            value=Label(
+                                id="language::eng",
+                                value="eng",
+                                type="language",
+                            ),
+                        ),
+                    ],
+                    items=[
+                        Item(
+                            url="https://cdn.climatepolicyradar.org/path/to/file.pdf",
+                            type="cdn",
+                            content_type="application/pdf",
+                        ),
+                        Item(
+                            url="https://source.climatepolicyradar.org/path/to/file.pdf",
+                            type="source",
+                            content_type="application/pdf",
+                        ),
+                    ],
+                    attributes={
+                        "deprecated_slug": "document-slug",
+                        "variant": "Original language",
+                        "md5_sum": "aaaaa11111bbbbb",
+                        "status": "published",
+                    },
+                ),
+            ),
+        ],
         attributes={
             "deprecated_slug": "family-with-different-document-statuses-slug",
+            "status": "published",
         },
     )
     assert_model_list_equality(
         result.unwrap(),
-        [expected_document_from_family],
+        [
+            expected_document_from_family,
+            Document(
+                id="document",
+                title="GST1 party document",
+                labels=[
+                    LabelRelationship(
+                        type="provider",
+                        value=Label(
+                            type="agent",
+                            id="agent::UNFCCC",
+                            value="UNFCCC",
+                            attributes={
+                                "attribution_url": "testurl.org",
+                                "corpus_text": "Test corpus",
+                                "corpus_image_url": "https://cdn.climatepolicyradar.org/corpus_image.png",
+                            },
+                        ),
+                    ),
+                    LabelRelationship(
+                        type="entity_type",
+                        value=Label(
+                            id="entity_type::GST1",
+                            value="GST1 Submission",
+                            type="entity_type",
+                        ),
+                    ),
+                    LabelRelationship(
+                        type="geography",
+                        value=Label(
+                            type="geography",
+                            id="geography::AUS",
+                            value="Australia",
+                        ),
+                    ),
+                    LabelRelationship(
+                        type="category",
+                        value=Label(
+                            id="category::UN submission",
+                            value="UN submission",
+                            type="category",
+                        ),
+                    ),
+                    LabelRelationship(
+                        type="language",
+                        value=Label(
+                            id="language::eng",
+                            value="eng",
+                            type="language",
+                        ),
+                    ),
+                ],
+                documents=[
+                    DocumentRelationship(
+                        type="member_of",
+                        value=DocumentWithoutRelationships(
+                            **expected_document_from_family.model_dump()
+                        ),
+                    ),
+                ],
+                items=[
+                    Item(
+                        url="https://cdn.climatepolicyradar.org/path/to/file.pdf",
+                        type="cdn",
+                        content_type="application/pdf",
+                    ),
+                    Item(
+                        url="https://source.climatepolicyradar.org/path/to/file.pdf",
+                        type="source",
+                        content_type="application/pdf",
+                    ),
+                ],
+                attributes={
+                    "deprecated_slug": "document-slug",
+                    "variant": "Original language",
+                    "md5_sum": "aaaaa11111bbbbb",
+                    "status": "published",
+                },
+            ),
+        ],
     )
 
 
@@ -226,7 +399,23 @@ def test_transform_navigator_family_UNFCCC_non_party_submission_to_GST1_label():
                 corpus_text="Test corpus",
                 corpus_image_url="corpus_image.png",
             ),
-            documents=[],
+            documents=[
+                NavigatorDocumentFactory.build(
+                    import_id="document",
+                    title="GST1 party document",
+                    cdn_object="https://cdn.climatepolicyradar.org/path/to/file.pdf",
+                    variant="Original language",
+                    content_type="application/pdf",
+                    source_url="https://source.climatepolicyradar.org/path/to/file.pdf",
+                    language="eng",
+                    languages=["eng"],
+                    md5_sum="aaaaa11111bbbbb",
+                    events=[],
+                    valid_metadata={},
+                    slug="document-slug",
+                    document_status="published",
+                ),
+            ],
             events=[],
             collections=[],
             geographies=["AUS"],
@@ -305,12 +494,165 @@ def test_transform_navigator_family_UNFCCC_non_party_submission_to_GST1_label():
                 ),
             ),
         ],
-        documents=[],
+        documents=[
+            DocumentRelationship(
+                type="has_member",
+                value=DocumentWithoutRelationships(
+                    id="document",
+                    title="GST1 party document",
+                    labels=[
+                        LabelRelationship(
+                            type="provider",
+                            value=Label(
+                                type="agent",
+                                id="agent::UNFCCC",
+                                value="UNFCCC",
+                                attributes={
+                                    "attribution_url": "testurl.org",
+                                    "corpus_text": "Test corpus",
+                                    "corpus_image_url": "https://cdn.climatepolicyradar.org/corpus_image.png",
+                                },
+                            ),
+                        ),
+                        LabelRelationship(
+                            type="entity_type",
+                            value=Label(
+                                id="entity_type::GST1",
+                                value="GST1 Submission",
+                                type="entity_type",
+                            ),
+                        ),
+                        LabelRelationship(
+                            type="geography",
+                            value=Label(
+                                type="geography",
+                                id="geography::AUS",
+                                value="Australia",
+                            ),
+                        ),
+                        LabelRelationship(
+                            type="category",
+                            value=Label(
+                                id="category::UN submission",
+                                value="UN submission",
+                                type="category",
+                            ),
+                        ),
+                        LabelRelationship(
+                            type="language",
+                            value=Label(
+                                id="language::eng",
+                                value="eng",
+                                type="language",
+                            ),
+                        ),
+                    ],
+                    items=[
+                        Item(
+                            url="https://cdn.climatepolicyradar.org/path/to/file.pdf",
+                            type="cdn",
+                            content_type="application/pdf",
+                        ),
+                        Item(
+                            url="https://source.climatepolicyradar.org/path/to/file.pdf",
+                            type="source",
+                            content_type="application/pdf",
+                        ),
+                    ],
+                    attributes={
+                        "deprecated_slug": "document-slug",
+                        "variant": "Original language",
+                        "md5_sum": "aaaaa11111bbbbb",
+                        "status": "published",
+                    },
+                ),
+            ),
+        ],
         attributes={
             "deprecated_slug": "family-with-different-document-statuses-slug",
+            "status": "published",
         },
     )
     assert_model_list_equality(
         result.unwrap(),
-        [expected_document_from_family],
+        [
+            expected_document_from_family,
+            Document(
+                id="document",
+                title="GST1 party document",
+                labels=[
+                    LabelRelationship(
+                        type="provider",
+                        value=Label(
+                            type="agent",
+                            id="agent::UNFCCC",
+                            value="UNFCCC",
+                            attributes={
+                                "attribution_url": "testurl.org",
+                                "corpus_text": "Test corpus",
+                                "corpus_image_url": "https://cdn.climatepolicyradar.org/corpus_image.png",
+                            },
+                        ),
+                    ),
+                    LabelRelationship(
+                        type="entity_type",
+                        value=Label(
+                            id="entity_type::GST1",
+                            value="GST1 Submission",
+                            type="entity_type",
+                        ),
+                    ),
+                    LabelRelationship(
+                        type="geography",
+                        value=Label(
+                            type="geography",
+                            id="geography::AUS",
+                            value="Australia",
+                        ),
+                    ),
+                    LabelRelationship(
+                        type="category",
+                        value=Label(
+                            id="category::UN submission",
+                            value="UN submission",
+                            type="category",
+                        ),
+                    ),
+                    LabelRelationship(
+                        type="language",
+                        value=Label(
+                            id="language::eng",
+                            value="eng",
+                            type="language",
+                        ),
+                    ),
+                ],
+                documents=[
+                    DocumentRelationship(
+                        type="member_of",
+                        value=DocumentWithoutRelationships(
+                            **expected_document_from_family.model_dump()
+                        ),
+                    ),
+                ],
+                items=[
+                    Item(
+                        url="https://cdn.climatepolicyradar.org/path/to/file.pdf",
+                        type="cdn",
+                        content_type="application/pdf",
+                    ),
+                    Item(
+                        url="https://source.climatepolicyradar.org/path/to/file.pdf",
+                        type="source",
+                        content_type="application/pdf",
+                    ),
+                ],
+                attributes={
+                    "deprecated_slug": "document-slug",
+                    "variant": "Original language",
+                    "md5_sum": "aaaaa11111bbbbb",
+                    "status": "published",
+                },
+            ),
+        ],
     )

--- a/data-in-pipeline/tests/transform/test_navigator_family_GST1.py
+++ b/data-in-pipeline/tests/transform/test_navigator_family_GST1.py
@@ -165,11 +165,11 @@ def test_transform_navigator_family_UNFCCC_party_submission_to_GST1_label():
                 ),
             ),
             LabelRelationship(
-                type="entity_type",
+                type="process",
                 value=Label(
-                    id="entity_type::GST1",
+                    id="process::GST1",
                     value="GST1 Submission",
-                    type="entity_type",
+                    type="process",
                 ),
             ),
             LabelRelationship(
@@ -239,11 +239,11 @@ def test_transform_navigator_family_UNFCCC_party_submission_to_GST1_label():
                             ),
                         ),
                         LabelRelationship(
-                            type="entity_type",
+                            type="process",
                             value=Label(
-                                id="entity_type::GST1",
+                                id="process::GST1",
                                 value="GST1 Submission",
-                                type="entity_type",
+                                type="process",
                             ),
                         ),
                         LabelRelationship(
@@ -319,11 +319,11 @@ def test_transform_navigator_family_UNFCCC_party_submission_to_GST1_label():
                         ),
                     ),
                     LabelRelationship(
-                        type="entity_type",
+                        type="process",
                         value=Label(
-                            id="entity_type::GST1",
+                            id="process::GST1",
                             value="GST1 Submission",
-                            type="entity_type",
+                            type="process",
                         ),
                     ),
                     LabelRelationship(
@@ -444,11 +444,11 @@ def test_transform_navigator_family_UNFCCC_non_party_submission_to_GST1_label():
                 ),
             ),
             LabelRelationship(
-                type="entity_type",
+                type="process",
                 value=Label(
-                    id="entity_type::GST1",
+                    id="process::GST1",
                     value="GST1 Submission",
-                    type="entity_type",
+                    type="process",
                 ),
             ),
             LabelRelationship(
@@ -518,11 +518,11 @@ def test_transform_navigator_family_UNFCCC_non_party_submission_to_GST1_label():
                             ),
                         ),
                         LabelRelationship(
-                            type="entity_type",
+                            type="process",
                             value=Label(
-                                id="entity_type::GST1",
+                                id="process::GST1",
                                 value="GST1 Submission",
-                                type="entity_type",
+                                type="process",
                             ),
                         ),
                         LabelRelationship(
@@ -598,11 +598,11 @@ def test_transform_navigator_family_UNFCCC_non_party_submission_to_GST1_label():
                         ),
                     ),
                     LabelRelationship(
-                        type="entity_type",
+                        type="process",
                         value=Label(
-                            id="entity_type::GST1",
+                            id="process::GST1",
                             value="GST1 Submission",
-                            type="entity_type",
+                            type="process",
                         ),
                     ),
                     LabelRelationship(

--- a/data-in-pipeline/tests/transform/test_navigator_family_GST1.py
+++ b/data-in-pipeline/tests/transform/test_navigator_family_GST1.py
@@ -1,0 +1,316 @@
+import pytest
+from data_in_models.models import (
+    Document,
+    Label,
+    LabelRelationship,
+)
+
+from app.models import Identified
+from app.transform.navigator_family import _part_of_gst1, transform_navigator_family
+from tests.factories import (
+    NavigatorCorpusFactory,
+    NavigatorCorpusTypeFactory,
+    NavigatorFamilyFactory,
+    NavigatorOrganisationFactory,
+)
+from tests.transform.assertions import assert_model_list_equality
+
+
+@pytest.mark.parametrize(
+    "corpus_id, author_type, created_date, expected_result",
+    [
+        # valid cases
+        ("UNFCCC.corpus.i00000001.n0000", "Party", "2023-11-30T00:00:00Z", True),
+        ("UNFCCC.corpus.i00000001.n0000", "Non-Party", "2023-11-30T00:00:00Z", True),
+        ("UNFCCC.corpus.i00000001.n0000", "Non-Party", "2024-10-15T00:00:00Z", True),
+        ("UNFCCC.corpus.i00000001.n0000", "Non-Party", "2024-10-17T00:00:00Z", True),
+        ("UNFCCC.corpus.i00000001.n0000", "Non-Party", "2024-11-06T00:00:00Z", True),
+        ("UNFCCC.corpus.i00000001.n0000", "Non-Party", "2024-11-15T00:00:00Z", True),
+        ("UNFCCC.corpus.i00000001.n0000", "Non-Party", "2024-11-18T00:00:00Z", True),
+        #
+        # invalid cases - Party
+        (
+            "Invalid.corpus.i00000001.n0000",
+            "Party",
+            "2023-11-30T00:00:00Z",
+            False,
+        ),  # wrong corpus
+        (
+            "UNFCCC.corpus.i00000001.n0000",
+            "Invalid",
+            "2023-11-30T00:00:00Z",
+            False,
+        ),  # wrong author type
+        (
+            "UNFCCC.corpus.i00000001.n0000",
+            "Party",
+            "2026-01-01T00:00:00Z",
+            False,
+        ),  # wrong date
+        #
+        # invalid cases - Non-Party
+        (
+            "Invalid.corpus.i00000001.n0000",
+            "Non-Party",
+            "2023-11-30T00:00:00Z",
+            False,
+        ),  # wrong corpus
+        (
+            "UNFCCC.corpus.i00000001.n0000",
+            "Non-Party",
+            "2026-01-01T00:00:00Z",
+            False,
+        ),  # wrong date
+    ],
+)
+def test_part_of_gst1_correctly_assesses_if_family_is_part_of_global_stocktake(
+    corpus_id, author_type, created_date, expected_result
+):
+    test_family = NavigatorFamilyFactory.build(
+        import_id="family",
+        title="GST1 party family",
+        summary="Family summary",
+        category="EXECUTIVE",
+        published_date=None,
+        last_updated_date=None,
+        created=created_date,
+        corpus=NavigatorCorpusFactory.build(
+            import_id=corpus_id,
+            corpus_type=NavigatorCorpusTypeFactory.build(name="Intl. agreements"),
+            organisation=NavigatorOrganisationFactory.build(id=1, name="UNFCCC"),
+            attribution_url="testurl.org",
+            corpus_text="Test corpus",
+            corpus_image_url="corpus_image.png",
+        ),
+        documents=[],
+        events=[],
+        collections=[],
+        geographies=["AUS"],
+        slug="family-with-different-document-statuses-slug",
+        metadata={
+            "author": ["Australia"],
+            "author_type": [author_type],
+        },
+    )
+
+    assert _part_of_gst1(test_family) == expected_result
+
+
+def test_transform_navigator_family_UNFCCC_party_submission_to_GST1_label():
+    navigator_family_with_GST1_documents = Identified(
+        id="family",
+        source="navigator_family",
+        data=NavigatorFamilyFactory.build(
+            import_id="family",
+            title="GST1 party family",
+            summary="Family summary",
+            category="EXECUTIVE",
+            published_date=None,
+            last_updated_date=None,
+            created="2023-11-30T00:00:00Z",
+            corpus=NavigatorCorpusFactory.build(
+                import_id="UNFCCC.corpus.i00000001.n0000",
+                corpus_type=NavigatorCorpusTypeFactory.build(name="Intl. agreements"),
+                organisation=NavigatorOrganisationFactory.build(id=1, name="UNFCCC"),
+                attribution_url="testurl.org",
+                corpus_text="Test corpus",
+                corpus_image_url="corpus_image.png",
+            ),
+            documents=[],
+            events=[],
+            collections=[],
+            geographies=["AUS"],
+            slug="family-with-different-document-statuses-slug",
+            metadata={
+                "author": ["Australia"],
+                "author_type": ["Party"],
+            },
+        ),
+    )
+    result = transform_navigator_family(navigator_family_with_GST1_documents)
+    expected_document_from_family = Document(
+        id="family",
+        title="GST1 party family",
+        description="Family summary",
+        labels=[
+            LabelRelationship(
+                type="status",
+                value=Label(
+                    type="status",
+                    id="status::Principal",
+                    value="Principal",
+                ),
+            ),
+            LabelRelationship(
+                type="?",
+                value=Label(
+                    id="?::GST1",
+                    value="GST1",
+                    type="?",
+                ),
+            ),
+            LabelRelationship(
+                type="provider",
+                value=Label(
+                    type="agent",
+                    id="agent::UNFCCC",
+                    value="UNFCCC",
+                    attributes={
+                        "attribution_url": "testurl.org",
+                        "corpus_text": "Test corpus",
+                        "corpus_image_url": "https://cdn.climatepolicyradar.org/corpus_image.png",
+                    },
+                ),
+            ),
+            LabelRelationship(
+                type="geography",
+                value=Label(
+                    id="geography::AUS",
+                    value="Australia",
+                    type="geography",
+                ),
+            ),
+            LabelRelationship(
+                type="author",
+                value=Label(
+                    id="party::Australia",
+                    value="Australia",
+                    type="party",
+                ),
+            ),
+            LabelRelationship(
+                type="deprecated_category",
+                value=Label(
+                    id="deprecated_category::EXECUTIVE",
+                    value="EXECUTIVE",
+                    type="deprecated_category",
+                ),
+            ),
+            LabelRelationship(
+                type="category",
+                value=Label(
+                    id="category::UN submission",
+                    value="UN submission",
+                    type="category",
+                ),
+            ),
+        ],
+        documents=[],
+        attributes={
+            "deprecated_slug": "family-with-different-document-statuses-slug",
+        },
+    )
+    assert_model_list_equality(
+        result.unwrap(),
+        [expected_document_from_family],
+    )
+
+
+def test_transform_navigator_family_UNFCCC_non_party_submission_to_GST1_label():
+    navigator_family_with_GST1_documents = Identified(
+        id="family",
+        source="navigator_family",
+        data=NavigatorFamilyFactory.build(
+            import_id="family",
+            title="GST1 party family",
+            summary="Family summary",
+            category="EXECUTIVE",
+            published_date=None,
+            last_updated_date=None,
+            created="2024-10-17T00:00:00Z",
+            corpus=NavigatorCorpusFactory.build(
+                import_id="UNFCCC.corpus.i00000001.n0000",
+                corpus_type=NavigatorCorpusTypeFactory.build(name="Intl. agreements"),
+                organisation=NavigatorOrganisationFactory.build(id=1, name="UNFCCC"),
+                attribution_url="testurl.org",
+                corpus_text="Test corpus",
+                corpus_image_url="corpus_image.png",
+            ),
+            documents=[],
+            events=[],
+            collections=[],
+            geographies=["AUS"],
+            slug="family-with-different-document-statuses-slug",
+            metadata={
+                "author": ["Australia"],
+                "author_type": ["Non-Party"],
+            },
+        ),
+    )
+    result = transform_navigator_family(navigator_family_with_GST1_documents)
+    expected_document_from_family = Document(
+        id="family",
+        title="GST1 party family",
+        description="Family summary",
+        labels=[
+            LabelRelationship(
+                type="status",
+                value=Label(
+                    type="status",
+                    id="status::Principal",
+                    value="Principal",
+                ),
+            ),
+            LabelRelationship(
+                type="?",
+                value=Label(
+                    id="?::GST1",
+                    value="GST1",
+                    type="?",
+                ),
+            ),
+            LabelRelationship(
+                type="provider",
+                value=Label(
+                    type="agent",
+                    id="agent::UNFCCC",
+                    value="UNFCCC",
+                    attributes={
+                        "attribution_url": "testurl.org",
+                        "corpus_text": "Test corpus",
+                        "corpus_image_url": "https://cdn.climatepolicyradar.org/corpus_image.png",
+                    },
+                ),
+            ),
+            LabelRelationship(
+                type="geography",
+                value=Label(
+                    id="geography::AUS",
+                    value="Australia",
+                    type="geography",
+                ),
+            ),
+            LabelRelationship(
+                type="author",
+                value=Label(
+                    id="non-party::Australia",
+                    value="Australia",
+                    type="non-party",
+                ),
+            ),
+            LabelRelationship(
+                type="deprecated_category",
+                value=Label(
+                    id="deprecated_category::EXECUTIVE",
+                    value="EXECUTIVE",
+                    type="deprecated_category",
+                ),
+            ),
+            LabelRelationship(
+                type="category",
+                value=Label(
+                    id="category::UN submission",
+                    value="UN submission",
+                    type="category",
+                ),
+            ),
+        ],
+        documents=[],
+        attributes={
+            "deprecated_slug": "family-with-different-document-statuses-slug",
+        },
+    )
+    assert_model_list_equality(
+        result.unwrap(),
+        [expected_document_from_family],
+    )

--- a/data-in-pipeline/tests/transform/test_navigator_family_litigation.py
+++ b/data-in-pipeline/tests/transform/test_navigator_family_litigation.py
@@ -39,6 +39,7 @@ def navigator_family_with_litigation_corpus_type() -> Identified[NavigatorFamily
             category="LITIGATION",
             last_updated_date="2020-01-0100:00:00Z",
             published_date="2020-01-0100:00:00Z",
+            created="2020-01-01T00:00:00Z",
             corpus=NavigatorCorpusFactory.build(
                 import_id="Academic.corpus.Litigation.n0000",
                 corpus_type=NavigatorCorpusTypeFactory.build(name="Litigation"),
@@ -133,6 +134,7 @@ def navigator_family_with_litigation_concepts() -> Identified[NavigatorFamily]:
             category="LITIGATION",
             last_updated_date="2020-01-0100:00:00Z",
             published_date="2020-01-0100:00:00Z",
+            created="2020-01-01T00:00:00Z",
             corpus=NavigatorCorpusFactory.build(
                 import_id="Academic.corpus.Litigation.n0000",
                 corpus_type=NavigatorCorpusTypeFactory.build(name="Litigation"),
@@ -224,6 +226,7 @@ def navigator_family_with_litigation_concept_missing_parent() -> (
             category="LITIGATION",
             last_updated_date="2020-01-0100:00:00Z",
             published_date="2020-01-0100:00:00Z",
+            created="2020-01-01T00:00:00Z",
             corpus=NavigatorCorpusFactory.build(
                 import_id="Academic.corpus.Litigation.n0000",
                 corpus_type=NavigatorCorpusTypeFactory.build(name="Litigation"),
@@ -283,6 +286,7 @@ def navigator_family_with_duplicate_legal_case() -> Identified[NavigatorFamily]:
             category="LITIGATION",
             last_updated_date=None,
             published_date=None,
+            created="2020-01-01T00:00:00Z",
             summary="Family summary",
             corpus=NavigatorCorpusFactory.build(
                 import_id="Academic.corpus.Litigation.n0000",

--- a/data-in-pipeline/tests/transform/test_navigator_family_mcf.py
+++ b/data-in-pipeline/tests/transform/test_navigator_family_mcf.py
@@ -88,6 +88,7 @@ def navigator_family_multilateral_climate_fund_project() -> Identified[Navigator
             category="MCF",
             last_updated_date=None,
             published_date=None,
+            created="2020-01-01T00:00:00Z",
             corpus=NavigatorCorpusFactory.build(
                 import_id="MCF.corpus.AF.n0000",
                 corpus_type=NavigatorCorpusTypeFactory.build(name="AF"),
@@ -158,6 +159,7 @@ def navigator_family_multilateral_climate_fund_guidance() -> (
             category="REPORTS",
             last_updated_date=None,
             published_date=None,
+            created="2020-01-01T00:00:00Z",
             corpus=NavigatorCorpusFactory.build(
                 import_id="MCF.corpus.AF.Guidance",
                 corpus_type=NavigatorCorpusTypeFactory.build(name="AF"),

--- a/families-api/app/models.py
+++ b/families-api/app/models.py
@@ -268,7 +268,7 @@ class FamilyBase(SQLModel):
     description: str
     concepts: list[dict[str, Any]]
     last_modified: datetime = Field(default_factory=datetime.now, exclude=True)
-    created: datetime = Field(default_factory=datetime.now, exclude=True)
+    created: datetime = Field(default_factory=datetime.now)
     family_category: str
 
 
@@ -449,6 +449,7 @@ class FamilyDocumentBase(SQLModel):
     variant_name: str | None
     document_status: FamilyDocumentStatus
     last_modified: datetime
+    created: datetime = Field(default_factory=datetime.now)
 
 
 class FamilyDocument(FamilyDocumentBase, table=True):


### PR DESCRIPTION
# What does this do?

Adds a `GST1 Submission` label to all documents that are:

- part of the `UNFCCC.corpus.i00000001.n0000` corpus
- and have been created on the following dates: `2023-11-30` (for party documents), [`2023-11-30`, `2024-10-15`,
`2024-10-17`, `2024-11-06`, `2024-11-15`, `2024-11-18`] (for non-party documents)

Makes the `created` field available on the families and documents served from the `families-api`

## Why is it needed?

To support future work of allowing users to search for GST1 submissions.

## How was it tested?

Unit tests
