### PR TITLE
fix: use search ECS service for search-api

### DIFF
--- a/api/infra/__main__.py
+++ b/api/infra/__main__.py
@@ -151,7 +151,10 @@ api_cloudfront_distribution = aws.cloudfront.Distribution(
     + (
         [
             aws.cloudfront.DistributionOriginArgs(
-                domain_name=search_stack.get_output("apprunner_service_url"),
+                # ECS give the full URL
+                domain_name=search_stack.get_output("ecs_express_service_url").apply(
+                    lambda url: url.removeprefix("https://")
+                ),
                 origin_id="search-apprunner",
                 custom_origin_config=aws.cloudfront.DistributionOriginCustomOriginConfigArgs(
                     http_port=80,


### PR DESCRIPTION
# What does this do?

- uses the export from here as the [new ECS service](https://github.com/climatepolicyradar/search/pull/254)

## Why is it needed?

- [ECS migration](https://linear.app/climate-policy-radar/issue/APP-2035/apprunner-ecs-express-migration)

Depends on https://github.com/climatepolicyradar/search/pull/254

[RFC](https://www.notion.so/climatepolicyradar/RFC-Migrating-services-off-AppRunner-33d9109609a4804c9538e70bbb153101) (🔒)