### PR TITLE
Deduplicate collection documents and fix links to families

### DIFF
--- a/data-in-pipeline/app/navigator_family_etl_pipeline.py
+++ b/data-in-pipeline/app/navigator_family_etl_pipeline.py
@@ -206,6 +206,20 @@ def identify(
     return identify_navigator_families(extracted)
 
 
+def transform_duplicate_collections(
+    collections: dict[str, Document], documents: list[Document]
+):
+    """
+    Combines duplicate collection documents with a single link to a different related family document
+    into one collection document with links to all related family documents
+    """
+    for doc in documents:
+        if doc.id not in collections:
+            collections[doc.id] = doc
+        else:
+            collections[doc.id].documents.extend(doc.documents)
+
+
 @task(log_prints=True)
 @pipeline_metrics.track(operation=Operation.TRANSFORM)
 def transform(
@@ -215,13 +229,15 @@ def transform(
     _LOGGER = get_logger()
 
     all_documents = []
+    all_collections = {}
     errors = []
     for family in identified_families:
-        transformed = transform_navigator_family(family)
+        result = transform_navigator_family(family)
 
-        match transformed:
-            case Success(documents):
+        match result:
+            case Success((documents, collection_documents)):
                 all_documents.extend(documents)
+                transform_duplicate_collections(all_collections, collection_documents)
             case Failure(error):
                 _LOGGER.warning(f"Transformation failed: {error}")
                 pipeline_metrics.record_error(Operation.TRANSFORM, ErrorType.TRANSFORM)
@@ -236,7 +252,8 @@ def transform(
         f"{len(identified_families)} families ({len(errors)} failures)"
     )
 
-    return all_documents, errors
+    all_transformed = all_documents + list(all_collections.values())
+    return all_transformed, errors
 
 
 @task(

--- a/data-in-pipeline/app/transform/navigator_family.py
+++ b/data-in-pipeline/app/transform/navigator_family.py
@@ -63,15 +63,17 @@ MCF_ATTRIBUTE_KEYS = {
 
 def transform_navigator_family(
     input: Identified[NavigatorFamily],
-) -> Result[list[Document], CouldNotTransform | NoMatchingTransformations]:
+) -> Result[
+    tuple[list[Document], list[Document]], CouldNotTransform | NoMatchingTransformations
+]:
     logger = get_logger()
     with log_context(import_id=input.id):
         logger.info(f"Transforming family with {len(input.data.documents)} documents")
 
         match transform(input):
-            case Success(d):
+            case Success((d, c)):
                 logger.info(f"Transform completed, produced {len(d)} documents")
-                return Success(d)
+                return Success((d, c))
             case Failure(error):
                 logger.warning(f"Transformation failed: {error}")
                 return Failure(error)
@@ -113,7 +115,7 @@ def _family_document_merged(
 
 def transform(
     input: Identified[NavigatorFamily],
-) -> Result[list[Document], CouldNotTransform]:
+) -> Result[tuple[list[Document], list[Document]], CouldNotTransform]:
     documents: list[Document] = []
 
     """
@@ -263,9 +265,8 @@ def transform(
     """
     documents.append(document_from_family)
     documents.extend(documents_from_documents)
-    documents.extend(documents_from_collections)
 
-    return Success(documents)
+    return Success((documents, documents_from_collections))
 
 
 def _transform_family_corpus_organisation(

--- a/data-in-pipeline/tests/test_family_pipeline.py
+++ b/data-in-pipeline/tests/test_family_pipeline.py
@@ -6,16 +6,27 @@ from unittest.mock import MagicMock, patch
 import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
-from data_in_models.models import Document
+from data_in_models.models import (
+    Document,
+    DocumentRelationship,
+    DocumentWithoutRelationships,
+    Label,
+    LabelRelationship,
+)
 from requests.exceptions import HTTPError
 from returns.result import Failure, Success
 
 from app.extract.connectors import FamilyFetchResult
-from app.models import ExtractedEnvelope, ExtractedMetadata, PipelineResult
-from app.navigator_family_etl_pipeline import cache_parquet_to_s3, data_in_pipeline
+from app.models import ExtractedEnvelope, ExtractedMetadata, Identified, PipelineResult
+from app.navigator_family_etl_pipeline import (
+    cache_parquet_to_s3,
+    data_in_pipeline,
+    transform,
+)
 from app.transform.models import NoMatchingTransformations
 from tests.factories import (
     DocumentWithoutRelationshipsFactory,
+    NavigatorCollectionFactory,
     NavigatorCorpusFactory,
     NavigatorCorpusTypeFactory,
     NavigatorDocumentFactory,
@@ -23,6 +34,7 @@ from tests.factories import (
     NavigatorOrganisationFactory,
     PageFetchFailureFactory,
 )
+from tests.transform.assertions import assert_model_list_equality
 
 
 @patch("app.navigator_family_etl_pipeline.cache_jsonl_to_s3")
@@ -370,7 +382,7 @@ def test_etl_pipeline_partial_transformation_failure(  # noqa: PLR0913
     ]
 
     mock_transform_families.side_effect = [
-        Success(mock_transformed_documents),
+        Success((mock_transformed_documents, [])),
         Failure(NoMatchingTransformations()),
     ]
 
@@ -521,3 +533,273 @@ def test_cache_parquet_to_s3_includes_attributes_as_json_string(mock_get_s3_clie
     assert parsed_attr_2 == {"other_key": "other_value"}
 
     assert rows[2]["attributes"] is None
+
+
+def test_transform_correctly_transforms_collections_with_multiple_families():
+    test_corpus = NavigatorCorpusFactory.build(
+        import_id="CCLW.corpus.i00000001.n0000",
+        corpus_type=NavigatorCorpusTypeFactory.build(name="Laws and Policies"),
+        organisation=NavigatorOrganisationFactory.build(id=1, name="CCLW"),
+        attribution_url="testurl.org",
+        corpus_text="Test corpus",
+        corpus_image_url="corpus_image.png",
+    )
+
+    test_collection = NavigatorCollectionFactory.build(
+        import_id="collection",
+        title="Collection title",
+        description="Collection description",
+        slug="collection-slug",
+        created="2020-01-01T00:00:00Z",
+        last_modified="2020-01-01T00:00:00Z",
+    )
+
+    test_families = [
+        Identified(
+            id="family1",
+            source="navigator_family",
+            data=NavigatorFamilyFactory.build(
+                import_id="family1",
+                title="Family 1 title",
+                summary="Family summary",
+                category="LEGISLATIVE",
+                corpus=test_corpus,
+                last_updated_date="2020-01-01T00:00:00Z",
+                published_date="2020-01-01T00:00:00Z",
+                created="2020-01-01T00:00:00Z",
+                documents=[],
+                events=[],
+                collections=[test_collection],
+                geographies=[],
+                metadata={},
+                slug="family1-slug",
+            ),
+        ),
+        Identified(
+            id="family2",
+            source="navigator_family",
+            data=NavigatorFamilyFactory.build(
+                import_id="family2",
+                title="Family 2 title",
+                summary="Family summary",
+                category="LEGISLATIVE",
+                corpus=test_corpus,
+                last_updated_date="2020-01-01T00:00:00Z",
+                published_date="2020-01-01T00:00:00Z",
+                created="2020-01-01T00:00:00Z",
+                documents=[],
+                events=[],
+                collections=[test_collection],
+                geographies=[],
+                metadata={},
+                slug="family2-slug",
+            ),
+        ),
+    ]
+
+    expected_family1_transform_result = Document(
+        id="family1",
+        title="Family 1 title",
+        description="Family summary",
+        labels=[
+            LabelRelationship(
+                type="status",
+                value=Label(
+                    type="status",
+                    id="status::Principal",
+                    value="Principal",
+                ),
+            ),
+            LabelRelationship(
+                type="provider",
+                value=Label(
+                    type="agent",
+                    id="agent::Grantham Research Institute",
+                    value="Grantham Research Institute",
+                    attributes={
+                        "attribution_url": "testurl.org",
+                        "corpus_text": "Test corpus",
+                        "corpus_image_url": "https://cdn.climatepolicyradar.org/corpus_image.png",
+                    },
+                ),
+            ),
+            LabelRelationship(
+                type="deprecated_category",
+                value=Label(
+                    id="deprecated_category::LEGISLATIVE",
+                    value="LEGISLATIVE",
+                    type="deprecated_category",
+                ),
+            ),
+            LabelRelationship(
+                type="deprecated_category",
+                value=Label(
+                    id="deprecated_category::Laws and Policies",
+                    value="Laws and Policies",
+                    type="deprecated_category",
+                ),
+            ),
+            LabelRelationship(
+                type="category",
+                value=Label(
+                    id="category::Law",
+                    value="Law",
+                    type="category",
+                ),
+            ),
+        ],
+        documents=[
+            DocumentRelationship(
+                type="member_of",
+                value=DocumentWithoutRelationships(
+                    id="collection",
+                    title="Collection title",
+                    labels=[
+                        LabelRelationship(
+                            type="entity_type",
+                            value=Label(
+                                id="entity_type::Collection",
+                                value="Collection",
+                                type="entity_type",
+                            ),
+                        )
+                    ],
+                    attributes={
+                        "deprecated_slug": "collection-slug",
+                        "published_date": "2020-01-01T00:00:00Z",
+                        "last_updated_date": "2020-01-01T00:00:00Z",
+                    },
+                ),
+            ),
+        ],
+        attributes={
+            "deprecated_slug": "family1-slug",
+            "published_date": "2020-01-01T00:00:00Z",
+            "last_updated_date": "2020-01-01T00:00:00Z",
+        },
+    )
+    expected_family2_transform_result = Document(
+        id="family2",
+        title="Family 2 title",
+        description="Family summary",
+        labels=[
+            LabelRelationship(
+                type="status",
+                value=Label(
+                    type="status",
+                    id="status::Principal",
+                    value="Principal",
+                ),
+            ),
+            LabelRelationship(
+                type="provider",
+                value=Label(
+                    type="agent",
+                    id="agent::Grantham Research Institute",
+                    value="Grantham Research Institute",
+                    attributes={
+                        "attribution_url": "testurl.org",
+                        "corpus_text": "Test corpus",
+                        "corpus_image_url": "https://cdn.climatepolicyradar.org/corpus_image.png",
+                    },
+                ),
+            ),
+            LabelRelationship(
+                type="deprecated_category",
+                value=Label(
+                    id="deprecated_category::LEGISLATIVE",
+                    value="LEGISLATIVE",
+                    type="deprecated_category",
+                ),
+            ),
+            LabelRelationship(
+                type="deprecated_category",
+                value=Label(
+                    id="deprecated_category::Laws and Policies",
+                    value="Laws and Policies",
+                    type="deprecated_category",
+                ),
+            ),
+            LabelRelationship(
+                type="category",
+                value=Label(
+                    id="category::Law",
+                    value="Law",
+                    type="category",
+                ),
+            ),
+        ],
+        documents=[
+            DocumentRelationship(
+                type="member_of",
+                value=DocumentWithoutRelationships(
+                    id="collection",
+                    title="Collection title",
+                    labels=[
+                        LabelRelationship(
+                            type="entity_type",
+                            value=Label(
+                                id="entity_type::Collection",
+                                value="Collection",
+                                type="entity_type",
+                            ),
+                        )
+                    ],
+                    attributes={
+                        "deprecated_slug": "collection-slug",
+                        "published_date": "2020-01-01T00:00:00Z",
+                        "last_updated_date": "2020-01-01T00:00:00Z",
+                    },
+                ),
+            ),
+        ],
+        attributes={
+            "deprecated_slug": "family2-slug",
+            "published_date": "2020-01-01T00:00:00Z",
+            "last_updated_date": "2020-01-01T00:00:00Z",
+        },
+    )
+    expected_collection_transform_result = Document(
+        attributes={
+            "deprecated_slug": "collection-slug",
+            "published_date": "2020-01-01T00:00:00Z",
+            "last_updated_date": "2020-01-01T00:00:00Z",
+        },
+        id="collection",
+        title="Collection title",
+        labels=[
+            LabelRelationship(
+                type="entity_type",
+                value=Label(
+                    id="entity_type::Collection",
+                    value="Collection",
+                    type="entity_type",
+                ),
+            )
+        ],
+        documents=[
+            DocumentRelationship(
+                type="has_member",
+                value=DocumentWithoutRelationships(
+                    **expected_family1_transform_result.model_dump()
+                ),
+            ),
+            DocumentRelationship(
+                type="has_member",
+                value=DocumentWithoutRelationships(
+                    **expected_family2_transform_result.model_dump()
+                ),
+            ),
+        ],
+    )
+
+    expected_family_transform_result = [
+        expected_family1_transform_result,
+        expected_family2_transform_result,
+        expected_collection_transform_result,
+    ]
+
+    (transform_result, errors) = transform(test_families)
+
+    assert not errors
+    assert_model_list_equality(transform_result, expected_family_transform_result)

--- a/data-in-pipeline/tests/transform/test_navigator_family.py
+++ b/data-in-pipeline/tests/transform/test_navigator_family.py
@@ -170,7 +170,9 @@ def navigator_family_with_no_matching_transformations() -> Identified[NavigatorF
 def test_transform_navigator_family_with_single_matching_document(
     navigator_family_with_single_matching_document: Identified[NavigatorFamily],
 ):
-    result = transform_navigator_family(navigator_family_with_single_matching_document)
+    family_result, collection_result = transform_navigator_family(
+        navigator_family_with_single_matching_document
+    ).unwrap()
     expected_document_from_family = Document(
         id="family",
         title="Matching title on family and document and collection",
@@ -578,7 +580,7 @@ def test_transform_navigator_family_with_single_matching_document(
         },
     )
     assert_model_list_equality(
-        result.unwrap(),
+        family_result + collection_result,
         [
             expected_document_from_family,
             Document(
@@ -812,9 +814,9 @@ def test_transform_navigator_family_with_laws_and_policies_corpus_type(
             },
         ),
     )
-    result = transform_navigator_family(
+    family_result, _ = transform_navigator_family(
         navigator_family_with_laws_and_policies_corpus_type
-    )
+    ).unwrap()
     expected_document_from_family = Document(
         id="family",
         title="Laws and policies family",
@@ -928,7 +930,7 @@ def test_transform_navigator_family_with_laws_and_policies_corpus_type(
         },
     )
     assert_model_list_equality(
-        result.unwrap(),
+        family_result,
         [expected_document_from_family],
     )
 
@@ -983,9 +985,9 @@ def test_transform_navigator_family_with_published_and_unpublished_documents():
             metadata={},
         ),
     )
-    result = transform_navigator_family(
+    result, _ = transform_navigator_family(
         navigator_family_with_different_document_statuses
-    )
+    ).unwrap()
     expected_document_from_family = Document(
         id="family",
         title="Family with different document statuses",
@@ -1197,7 +1199,7 @@ def test_transform_navigator_family_with_published_and_unpublished_documents():
         },
     )
     assert_model_list_equality(
-        result.unwrap(),
+        result,
         [
             expected_document_from_family,
             Document(
@@ -1394,7 +1396,9 @@ def test_transform_navigator_family_with_no_published_documents():
             metadata={},
         ),
     )
-    result = transform_navigator_family(navigator_family_with_no_published_documents)
+    result, _ = transform_navigator_family(
+        navigator_family_with_no_published_documents
+    ).unwrap()
     expected_document_from_family = Document(
         id="family",
         title="Family with no published documents",
@@ -1533,7 +1537,7 @@ def test_transform_navigator_family_with_no_published_documents():
         },
     )
     assert_model_list_equality(
-        result.unwrap(),
+        result,
         [
             expected_document_from_family,
             Document(
@@ -1666,8 +1670,8 @@ def test_transform_to_category_corpus_ids(corpus_id: str, expected_category: str
         ),
     )
 
-    result = transform_navigator_family(navigator_family)
-    documents = result.unwrap()
+    result, _ = transform_navigator_family(navigator_family).unwrap()
+    documents = result
     family_doc = documents[0]
 
     category_labels = [label for label in family_doc.labels if label.type == "category"]

--- a/data-in-pipeline/tests/transform/test_navigator_family_GST1.py
+++ b/data-in-pipeline/tests/transform/test_navigator_family_GST1.py
@@ -150,7 +150,9 @@ def test_transform_navigator_family_UNFCCC_party_submission_to_GST1_label():
             },
         ),
     )
-    result = transform_navigator_family(navigator_family_with_GST1_documents)
+    result, _ = transform_navigator_family(
+        navigator_family_with_GST1_documents
+    ).unwrap()
     expected_document_from_family = Document(
         id="family",
         title="GST1 party family",
@@ -298,7 +300,7 @@ def test_transform_navigator_family_UNFCCC_party_submission_to_GST1_label():
         },
     )
     assert_model_list_equality(
-        result.unwrap(),
+        result,
         [
             expected_document_from_family,
             Document(
@@ -429,7 +431,9 @@ def test_transform_navigator_family_UNFCCC_non_party_submission_to_GST1_label():
             },
         ),
     )
-    result = transform_navigator_family(navigator_family_with_GST1_documents)
+    result, _ = transform_navigator_family(
+        navigator_family_with_GST1_documents
+    ).unwrap()
     expected_document_from_family = Document(
         id="family",
         title="GST1 party family",
@@ -577,7 +581,7 @@ def test_transform_navigator_family_UNFCCC_non_party_submission_to_GST1_label():
         },
     )
     assert_model_list_equality(
-        result.unwrap(),
+        result,
         [
             expected_document_from_family,
             Document(

--- a/data-in-pipeline/tests/transform/test_navigator_family_litigation.py
+++ b/data-in-pipeline/tests/transform/test_navigator_family_litigation.py
@@ -310,7 +310,9 @@ def navigator_family_with_duplicate_legal_case() -> Identified[NavigatorFamily]:
 def test_transform_navigator_family_with_litigation_corpus_type(
     navigator_family_with_litigation_corpus_type: Identified[NavigatorFamily],
 ):
-    result = transform_navigator_family(navigator_family_with_litigation_corpus_type)
+    result, _ = transform_navigator_family(
+        navigator_family_with_litigation_corpus_type
+    ).unwrap()
     expected_document_from_family = Document(
         id="family",
         title="Litigation family",
@@ -483,7 +485,7 @@ def test_transform_navigator_family_with_litigation_corpus_type(
         },
     )
     assert_model_list_equality(
-        result.unwrap(),
+        result,
         [
             expected_document_from_family,
             Document(
@@ -608,7 +610,9 @@ def test_transform_navigator_family_with_litigation_corpus_type(
 def test_transform_navigator_family_with_litigation_corpus_type_and_litigation_concepts(
     navigator_family_with_litigation_concepts: Identified[NavigatorFamily],
 ):
-    result = transform_navigator_family(navigator_family_with_litigation_concepts)
+    result, _ = transform_navigator_family(
+        navigator_family_with_litigation_concepts
+    ).unwrap()
     expected_document_from_family = Document(
         id="family",
         title="Litigation family",
@@ -768,7 +772,7 @@ def test_transform_navigator_family_with_litigation_corpus_type_and_litigation_c
         },
     )
     assert_model_list_equality(
-        result.unwrap(),
+        result,
         [
             expected_document_from_family,
             Document(

--- a/data-in-pipeline/tests/transform/test_navigator_family_mcf.py
+++ b/data-in-pipeline/tests/transform/test_navigator_family_mcf.py
@@ -181,9 +181,9 @@ def navigator_family_multilateral_climate_fund_guidance() -> (
 def test_transform_navigator_family_with_multilateral_climate_fund_project(
     navigator_family_multilateral_climate_fund_project: Identified[NavigatorFamily],
 ):
-    result = transform_navigator_family(
+    result, _ = transform_navigator_family(
         navigator_family_multilateral_climate_fund_project
-    )
+    ).unwrap()
     expected_document_from_family = Document(
         id="family",
         title="Multilateral climate fund project",
@@ -429,7 +429,7 @@ def test_transform_navigator_family_with_multilateral_climate_fund_project(
         },
     )
     assert_model_list_equality(
-        result.unwrap(),
+        result,
         [
             expected_document_from_family,
             Document(
@@ -561,11 +561,11 @@ def test_transform_navigator_family_with_multilateral_climate_fund_project(
 def test_transform_navigator_family_with_multilateral_climate_fund_guidance(
     navigator_family_multilateral_climate_fund_guidance: Identified[NavigatorFamily],
 ):
-    result = transform_navigator_family(
+    result, _ = transform_navigator_family(
         navigator_family_multilateral_climate_fund_guidance
-    )
+    ).unwrap()
     assert_model_list_equality(
-        result.unwrap(),
+        result,
         [
             Document(
                 id="family",


### PR DESCRIPTION
# What does this do?

Adds a function to combine duplicate collection document entries with a single link each to a different related family in the transformed response into one collection document which includes all of the related families.

## Why is it needed?

We were only including a link to a single family on collection documents, even if multiple families were part of a collection.

## How was it tested?

Unit tests