### PR TITLE
fix: transform entity_type => role

### DIFF
--- a/data-in-pipeline/app/transform/navigator_family.py
+++ b/data-in-pipeline/app/transform/navigator_family.py
@@ -1128,6 +1128,9 @@ def _transform_navigator_document(
     These values are controlled
     @see: https://github.com/climatepolicyradar/data-migrations/blob/main/taxonomies/Intl.%20agreements.json#L42-L51
     @see: https://github.com/climatepolicyradar/data-migrations/blob/main/taxonomies/Laws%20and%20Policies.json#L381-L396
+
+    Based on 
+    @see: https://schema.org/Role
     """
     metadata_role = navigator_document.valid_metadata.get("role")
     if metadata_role is not None and len(metadata_role) > 0:
@@ -1136,9 +1139,9 @@ def _transform_navigator_document(
             LabelRelationship(
                 type="role",
                 value=Label(
-                    id=f"entity_type::{normalised_role}",
+                    id=f"role::{normalised_role}",
                     value=normalised_role,
-                    type="entity_type",
+                    type="role",
                 ),
             )
         )

--- a/data-in-pipeline/tests/transform/test_navigator_family.py
+++ b/data-in-pipeline/tests/transform/test_navigator_family.py
@@ -443,8 +443,8 @@ def test_transform_navigator_family_with_single_matching_document(
                         LabelRelationship(
                             type="role",
                             value=Label(
-                                type="entity_type",
-                                id="entity_type::Supporting legislation",
+                                type="role",
+                                id="role::Supporting legislation",
                                 value="Supporting legislation",
                             ),
                         ),
@@ -590,8 +590,8 @@ def test_transform_navigator_family_with_single_matching_document(
                     LabelRelationship(
                         type="role",
                         value=Label(
-                            type="entity_type",
-                            id="entity_type::Supporting legislation",
+                            type="role",
+                            id="role::Supporting legislation",
                             value="Supporting legislation",
                         ),
                     ),


### PR DESCRIPTION
# What does this do?
- swaps `entity_type` => `role`

## Why is it needed?

- mainly because the data is a little messy and we need to differentiate

Towards https://linear.app/climate-policy-radar/issue/APP-2015/removing-document-role-from-entity-type-list