### PR TITLE
Feature/app 2069 bug missing litigation documents

### DIFF
--- a/data-in-pipeline/app/extract/connectors.py
+++ b/data-in-pipeline/app/extract/connectors.py
@@ -16,6 +16,7 @@ from app.util import generate_envelope_uuid
 class NavigatorEvent(BaseModel):
     import_id: str
     event_type: str
+    title: str
     date: datetime.datetime
     # We have quite a few families that fail model validation due to
     # event.metadata.even_type being a string rather than a list.

--- a/data-in-pipeline/app/transform/navigator_family.py
+++ b/data-in-pipeline/app/transform/navigator_family.py
@@ -118,41 +118,50 @@ def transform_navigator_family(
 
 def _transform_litigation_events(data: NavigatorFamily) -> list[Document]:
     documents = []
+    labels = []
+    attributes = {}
     navigator_family_events = data.events
     navigator_document_event_ids = {doc.events[0].import_id for doc in data.documents}
 
     # Remove events with links to documents as they will have already been transformed
+    # and remove Filing Year For Action events as they are only used to store the filing date
+    # for a case
     deduplicated_events = [
         event
         for event in navigator_family_events
         if event.import_id not in navigator_document_event_ids
+        and event.event_type != "Filing Year For Action"
     ]
 
     for event in deduplicated_events:
-        labels = [
-            LabelRelationship(
-                type="entity_type",
-                value=Label(
-                    id=f"entity_type::{event.event_type}",
-                    value=event.event_type,
+        labels.extend(
+            [
+                LabelRelationship(
                     type="entity_type",
+                    value=Label(
+                        id=f"entity_type::{event.event_type}",
+                        value=event.event_type,
+                        type="entity_type",
+                    ),
                 ),
-            ),
-            LabelRelationship(
-                type="activity_status",
-                timestamp=event.date,
-                value=Label(
-                    id="activity_status::Filed",
-                    value="Filed",
+                LabelRelationship(
                     type="activity_status",
+                    timestamp=event.date,
+                    value=Label(
+                        id="activity_status::Filed",
+                        value="Filed",
+                        type="activity_status",
+                    ),
                 ),
-            ),
-            _transform_family_corpus_organisation(data)[0],
-        ]
+                _transform_family_corpus_organisation(data)[0],
+            ]
+        )
 
         labels.extend(_transform_to_category(data))
         geo_labels, _ = _transform_geographies(data)
         labels.extend(geo_labels)
+        if event.metadata["action_taken"]:
+            attributes["action_taken"] = event.metadata["action_taken"][0]
 
         documents.append(
             Document(
@@ -161,7 +170,7 @@ def _transform_litigation_events(data: NavigatorFamily) -> list[Document]:
                 description=event.metadata["description"][0],
                 labels=labels,
                 items=[],
-                attributes={"action_taken": event.metadata["action_taken"][0]},
+                attributes=attributes,
             )
         )
     return documents

--- a/data-in-pipeline/app/transform/navigator_family.py
+++ b/data-in-pipeline/app/transform/navigator_family.py
@@ -116,6 +116,18 @@ def transform_navigator_family(
         return result
 
 
+def _transform_navigator_documents(
+    data: NavigatorFamily,
+) -> tuple[list[Document], list[TransformWarning]]:
+    transformed_documents = []
+    warnings = []
+    for nav_doc in data.documents:
+        doc, doc_warnings = _transform_navigator_document(nav_doc, data)
+        transformed_documents.append(doc)
+        warnings.extend(doc_warnings)
+    return transformed_documents, warnings
+
+
 def transform(
     input: Identified[NavigatorFamily],
 ) -> Result[TransformOutput, CouldNotTransform]:
@@ -134,11 +146,7 @@ def transform(
     document_from_family, family_warnings = _transform_navigator_family(input.data)
     warnings.extend(family_warnings)
 
-    documents_from_documents: list[Document] = []
-    for nav_doc in input.data.documents:
-        doc, doc_warnings = _transform_navigator_document(nav_doc, input.data)
-        documents_from_documents.append(doc)
-        warnings.extend(doc_warnings)
+    documents_from_documents, warnings = _transform_navigator_documents(input.data)
 
     documents_from_collections: list[Document] = [
         _transform_navigator_collection(collection, input.data)

--- a/data-in-pipeline/app/transform/navigator_family.py
+++ b/data-in-pipeline/app/transform/navigator_family.py
@@ -116,6 +116,57 @@ def transform_navigator_family(
         return result
 
 
+def _transform_litigation_events(data: NavigatorFamily) -> list[Document]:
+    documents = []
+    navigator_family_events = data.events
+    navigator_document_event_ids = {doc.events[0].import_id for doc in data.documents}
+
+    # Remove events with links to documents as they will have already been transformed
+    deduplicated_events = [
+        event
+        for event in navigator_family_events
+        if event.import_id not in navigator_document_event_ids
+    ]
+
+    for event in deduplicated_events:
+        labels = [
+            LabelRelationship(
+                type="entity_type",
+                value=Label(
+                    id=f"entity_type::{event.event_type}",
+                    value=event.event_type,
+                    type="entity_type",
+                ),
+            ),
+            LabelRelationship(
+                type="activity_status",
+                timestamp=event.date,
+                value=Label(
+                    id="activity_status::Filed",
+                    value="Filed",
+                    type="activity_status",
+                ),
+            ),
+            _transform_family_corpus_organisation(data)[0],
+        ]
+
+        labels.extend(_transform_to_category(data))
+        geo_labels, _ = _transform_geographies(data)
+        labels.extend(geo_labels)
+
+        documents.append(
+            Document(
+                id=event.import_id,
+                title=event.title,
+                description=event.metadata["description"][0],
+                labels=labels,
+                items=[],
+                attributes={"action_taken": event.metadata["action_taken"][0]},
+            )
+        )
+    return documents
+
+
 def _transform_navigator_documents(
     data: NavigatorFamily,
 ) -> tuple[list[Document], list[TransformWarning]]:
@@ -125,6 +176,8 @@ def _transform_navigator_documents(
         doc, doc_warnings = _transform_navigator_document(nav_doc, data)
         transformed_documents.append(doc)
         warnings.extend(doc_warnings)
+    if data.corpus.import_id == "Academic.corpus.Litigation.n0000":
+        transformed_documents.extend(_transform_litigation_events(data))
     return transformed_documents, warnings
 
 
@@ -879,7 +932,6 @@ def _part_of_gst1(navigator_family: NavigatorFamily) -> bool:
 # ---------------------------------------------------------------------------
 
 
-# trunk-ignore(ruff/PLR0912)
 def _transform_navigator_family(
     navigator_family: NavigatorFamily,
 ) -> tuple[Document, list[TransformWarning]]:

--- a/data-in-pipeline/app/transform/navigator_family.py
+++ b/data-in-pipeline/app/transform/navigator_family.py
@@ -121,7 +121,9 @@ def _transform_litigation_events(data: NavigatorFamily) -> list[Document]:
     labels = []
     attributes = {}
     navigator_family_events = data.events
-    navigator_document_event_ids = {doc.events[0].import_id for doc in data.documents}
+    navigator_document_event_ids = {
+        doc.events[0].import_id for doc in data.documents if doc.events
+    }
 
     # Remove events with links to documents as they will have already been transformed
     # and remove Filing Year For Action events as they are only used to store the filing date

--- a/data-in-pipeline/tests/transform/test_navigator_documents.py
+++ b/data-in-pipeline/tests/transform/test_navigator_documents.py
@@ -1,0 +1,251 @@
+from datetime import datetime
+
+from data_in_models.models import (
+    Document,
+    Label,
+    LabelRelationship,
+)
+
+from app.transform.navigator_family import _transform_navigator_documents
+from tests.factories import (
+    NavigatorCorpusFactory,
+    NavigatorCorpusTypeFactory,
+    NavigatorDocumentFactory,
+    NavigatorEventFactory,
+    NavigatorFamilyFactory,
+    NavigatorOrganisationFactory,
+)
+from tests.transform.assertions import assert_model_list_equality
+
+
+def test_transform_navigator_documents_litigation_events_with_documents():
+    litigation_event = NavigatorEventFactory.build(
+        import_id="123",
+        event_type="Decision",
+        title="decision",
+        date=datetime(2020, 1, 1),
+        metadata={
+            "event_type": ["Decision"],
+            "datetime_event_name": ["Decision"],
+            "action_taken": ["Action taken on decision"],
+            "description": ["Summary of the filed document"],
+        },
+    )
+    litigation_family = NavigatorFamilyFactory.build(
+        import_id="family",
+        title="Litigation family",
+        category="LITIGATION",
+        last_updated_date=None,
+        published_date=None,
+        created="2020-01-01T00:00:00Z",
+        summary="Family summary",
+        corpus=NavigatorCorpusFactory.build(
+            import_id="Academic.corpus.Litigation.n0000",
+            corpus_type=NavigatorCorpusTypeFactory.build(name="Litigation"),
+            organisation=NavigatorOrganisationFactory.build(
+                id=1, name="Sabin Center for Climate Change Law"
+            ),
+            attribution_url="testurl.org",
+            corpus_text="Test corpus",
+            corpus_image_url=None,
+        ),
+        documents=[
+            NavigatorDocumentFactory.build(
+                import_id="document",
+                title="Litigation family document",
+                cdn_object=None,
+                source_url=None,
+                slug="litigation-document-slug",
+                events=[litigation_event],
+                variant="Original language",
+                md5_sum="aaaaa11111bbbbb",
+                languages=[],
+                document_status="published",
+            ),
+        ],
+        events=[litigation_event],
+        collections=[],
+        geographies=[],
+        concepts=[],
+    )
+
+    result, warnings = _transform_navigator_documents(litigation_family)
+
+    assert not warnings
+
+    assert_model_list_equality(
+        result,
+        [
+            Document(
+                id="document",
+                title="Litigation family document",
+                description="Summary of the filed document",
+                labels=[
+                    LabelRelationship(
+                        type="entity_type",
+                        value=Label(
+                            id="entity_type::Decision",
+                            value="Decision",
+                            type="entity_type",
+                        ),
+                    ),
+                    LabelRelationship(
+                        timestamp=datetime(2020, 1, 1, 0, 0),
+                        type="activity_status",
+                        value=Label(
+                            attributes={},
+                            documents=[],
+                            id="activity_status::Filed",
+                            labels=[],
+                            type="activity_status",
+                            value="Filed",
+                        ),
+                    ),
+                    LabelRelationship(
+                        type="provider",
+                        value=Label(
+                            type="agent",
+                            id="agent::Sabin Center for Climate Change Law",
+                            value="Sabin Center for Climate Change Law",
+                            attributes={
+                                "attribution_url": "testurl.org",
+                                "corpus_text": "Test corpus",
+                                "corpus_image_url": "",
+                            },
+                        ),
+                    ),
+                    LabelRelationship(
+                        type="category",
+                        value=Label(
+                            id="category::Litigation",
+                            value="Litigation",
+                            type="category",
+                        ),
+                    ),
+                ],
+                documents=[],
+                attributes={
+                    "deprecated_slug": "litigation-document-slug",
+                    "md5_sum": "aaaaa11111bbbbb",
+                    "variant": "Original language",
+                    "status": "published",
+                    "action_taken": "Action taken on decision",
+                },
+            ),
+        ],
+    )
+
+
+def test_transform_navigator_documents_litigation_events_without_documents():
+    litigation_family = NavigatorFamilyFactory.build(
+        import_id="family",
+        title="Litigation family",
+        category="LITIGATION",
+        last_updated_date=None,
+        published_date=None,
+        created="2020-01-01T00:00:00Z",
+        summary="Family summary",
+        corpus=NavigatorCorpusFactory.build(
+            import_id="Academic.corpus.Litigation.n0000",
+            corpus_type=NavigatorCorpusTypeFactory.build(name="Litigation"),
+            organisation=NavigatorOrganisationFactory.build(
+                id=1, name="Sabin Center for Climate Change Law"
+            ),
+            attribution_url="testurl.org",
+            corpus_text="Test corpus",
+            corpus_image_url=None,
+        ),
+        documents=[],
+        events=[
+            NavigatorEventFactory.build(
+                import_id="123",
+                event_type="Decision",
+                title="decision",
+                date=datetime(2020, 1, 1),
+                metadata={
+                    "event_type": ["Decision"],
+                    "datetime_event_name": ["Decision"],
+                    "action_taken": ["Action taken on decision"],
+                    "description": ["Summary of the filed document"],
+                },
+            )
+        ],
+        collections=[],
+        geographies=["AUS"],
+        concepts=[],
+    )
+
+    result, warnings = _transform_navigator_documents(litigation_family)
+
+    assert not warnings
+
+    assert_model_list_equality(
+        result,
+        [
+            Document(
+                id="123",
+                title="decision",
+                description="Summary of the filed document",
+                labels=[
+                    LabelRelationship(
+                        type="entity_type",
+                        value=Label(
+                            id="entity_type::Decision",
+                            value="Decision",
+                            type="entity_type",
+                        ),
+                    ),
+                    LabelRelationship(
+                        timestamp=datetime(2020, 1, 1, 0, 0),
+                        type="activity_status",
+                        value=Label(
+                            attributes={},
+                            documents=[],
+                            id="activity_status::Filed",
+                            labels=[],
+                            type="activity_status",
+                            value="Filed",
+                        ),
+                    ),
+                    LabelRelationship(
+                        type="provider",
+                        value=Label(
+                            type="agent",
+                            id="agent::Sabin Center for Climate Change Law",
+                            value="Sabin Center for Climate Change Law",
+                            attributes={
+                                "attribution_url": "testurl.org",
+                                "corpus_text": "Test corpus",
+                                "corpus_image_url": "",
+                            },
+                        ),
+                    ),
+                    LabelRelationship(
+                        type="category",
+                        value=Label(
+                            id="category::Litigation",
+                            value="Litigation",
+                            type="category",
+                        ),
+                    ),
+                    LabelRelationship(
+                        type="geography",
+                        value=Label(
+                            type="geography",
+                            id="geography::AUS",
+                            value="Australia",
+                        ),
+                    ),
+                ],
+                documents=[],
+                attributes={
+                    "action_taken": "Action taken on decision",
+                },
+            ),
+        ],
+    )
+
+
+# Test cases:
+# - filing year for action does not get transformed to a document
+# - placeholder docs still get transformed with an obsolete label

--- a/data-in-pipeline/tests/transform/test_navigator_documents.py
+++ b/data-in-pipeline/tests/transform/test_navigator_documents.py
@@ -289,7 +289,3 @@ def test_transform_navigator_documents_litigation_filing_year_for_action_events_
 
     assert not warnings
     assert not result
-
-
-# Test cases:
-# - placeholder docs still get transformed with an obsolete label

--- a/data-in-pipeline/tests/transform/test_navigator_documents.py
+++ b/data-in-pipeline/tests/transform/test_navigator_documents.py
@@ -246,6 +246,50 @@ def test_transform_navigator_documents_litigation_events_without_documents():
     )
 
 
+def test_transform_navigator_documents_litigation_filing_year_for_action_events_are_skipped():
+    litigation_family = NavigatorFamilyFactory.build(
+        import_id="family",
+        title="Litigation family",
+        category="LITIGATION",
+        last_updated_date=None,
+        published_date=None,
+        created="2020-01-01T00:00:00Z",
+        summary="Family summary",
+        corpus=NavigatorCorpusFactory.build(
+            import_id="Academic.corpus.Litigation.n0000",
+            corpus_type=NavigatorCorpusTypeFactory.build(name="Litigation"),
+            organisation=NavigatorOrganisationFactory.build(
+                id=1, name="Sabin Center for Climate Change Law"
+            ),
+            attribution_url="testurl.org",
+            corpus_text="Test corpus",
+            corpus_image_url=None,
+        ),
+        documents=[],
+        events=[
+            NavigatorEventFactory.build(
+                import_id="123",
+                event_type="Filing Year For Action",
+                title="Filing Year For Action",
+                date=datetime(2020, 1, 1),
+                metadata={
+                    "event_type": ["Filing Year For Action"],
+                    "datetime_event_name": ["Filing Year For Action"],
+                    "action_taken": [],
+                    "description": ["Filing Year For Action"],
+                },
+            )
+        ],
+        collections=[],
+        geographies=[],
+        concepts=[],
+    )
+
+    result, warnings = _transform_navigator_documents(litigation_family)
+
+    assert not warnings
+    assert not result
+
+
 # Test cases:
-# - filing year for action does not get transformed to a document
 # - placeholder docs still get transformed with an obsolete label


### PR DESCRIPTION
# What does this do?

Maps litigation events not linked to navigator documents to the new document model.

## Why is it needed?

Litigation events hold data regarding documents even if a physical document is not yet available (in which case a Navigator Document will not be created). We want to display this data to users.

## How was it tested?
Unit tests