### PR TITLE
Remove versions for collections

### DIFF
--- a/data-in-pipeline/app/transform/navigator_family.py
+++ b/data-in-pipeline/app/transform/navigator_family.py
@@ -195,20 +195,16 @@ def transform(
                 value=DocumentWithoutRelationships(**document.model_dump()),
             )
             for document in documents_from_collections
-            if not _documents_match(document, document_from_family)
         ]
     )
 
     for document in documents_from_collections:
-        if not _documents_match(document, document_from_family):
-            document.documents = [
-                DocumentRelationship(
-                    type="has_member",
-                    value=DocumentWithoutRelationships(
-                        **document_from_family.model_dump()
-                    ),
-                )
-            ]
+        document.documents = [
+            DocumentRelationship(
+                type="has_member",
+                value=DocumentWithoutRelationships(**document_from_family.model_dump()),
+            )
+        ]
 
     """
     Versions
@@ -235,26 +231,6 @@ def transform(
     for document in documents_from_documents:
         if _documents_match(document, document_from_family):
             document.documents.append(
-                DocumentRelationship(
-                    type="is_version_of",
-                    value=DocumentWithoutRelationships(
-                        **document_from_family.model_dump()
-                    ),
-                )
-            )
-
-    # collections
-    document_from_family.documents.extend(
-        DocumentRelationship(
-            type="has_version",
-            value=DocumentWithoutRelationships(**collection.model_dump()),
-        )
-        for collection in documents_from_collections
-        if _documents_match(collection, document_from_family)
-    )
-    for collection in documents_from_collections:
-        if _documents_match(collection, document_from_family):
-            collection.documents.append(
                 DocumentRelationship(
                     type="is_version_of",
                     value=DocumentWithoutRelationships(

--- a/data-in-pipeline/tests/transform/test_navigator_family.py
+++ b/data-in-pipeline/tests/transform/test_navigator_family.py
@@ -421,6 +421,29 @@ def test_transform_navigator_family_with_single_matching_document(
             DocumentRelationship(
                 type="member_of",
                 value=DocumentWithoutRelationships(
+                    id="collection_matching",
+                    title="Matching title on family and document and collection",
+                    labels=[
+                        LabelRelationship(
+                            type="entity_type",
+                            value=Label(
+                                id="entity_type::Collection",
+                                value="Collection",
+                                type="entity_type",
+                            ),
+                        )
+                    ],
+                    items=[],
+                    attributes={
+                        "deprecated_slug": "collection-matching-slug",
+                        "published_date": "2020-01-01T00:00:00Z",
+                        "last_updated_date": "2020-01-01T00:00:00Z",
+                    },
+                ),
+            ),
+            DocumentRelationship(
+                type="member_of",
+                value=DocumentWithoutRelationships(
                     id="collection",
                     title="Collection title",
                     labels=[
@@ -549,29 +572,6 @@ def test_transform_navigator_family_with_single_matching_document(
                         "variant": "Original language",
                         "md5_sum": "aaaaa11111bbbbb",
                         "status": "published",
-                        "published_date": "2020-01-01T00:00:00Z",
-                        "last_updated_date": "2020-01-01T00:00:00Z",
-                    },
-                ),
-            ),
-            DocumentRelationship(
-                type="has_version",
-                value=DocumentWithoutRelationships(
-                    id="collection_matching",
-                    title="Matching title on family and document and collection",
-                    labels=[
-                        LabelRelationship(
-                            type="entity_type",
-                            value=Label(
-                                id="entity_type::Collection",
-                                value="Collection",
-                                type="entity_type",
-                            ),
-                        )
-                    ],
-                    items=[],
-                    attributes={
-                        "deprecated_slug": "collection-matching-slug",
                         "published_date": "2020-01-01T00:00:00Z",
                         "last_updated_date": "2020-01-01T00:00:00Z",
                     },
@@ -728,7 +728,7 @@ def test_transform_navigator_family_with_single_matching_document(
                 ],
                 documents=[
                     DocumentRelationship(
-                        type="is_version_of",
+                        type="has_member",
                         value=DocumentWithoutRelationships(
                             **expected_document_from_family.model_dump()
                         ),


### PR DESCRIPTION
# What does this do?

Removes `versions` for collections.

## Why is it needed?

Initially a collection could be a version of a family. However, conceptually this doesn't make sense and also we ended up with a scenario like [this one](https://api.climatepolicyradar.org/data-in/documents/CCLW.collection.i00000271.n0000), where a collection had 6 families and 5 of them were `has_member` relationships and 1 family `is_version_of` because the title of the family happened to be the same as the collection's title. This wasn't right, especially as the family held a lot more data than the collection so they were not direct duplicates as in the case of some families and their documents (e.g. MCF projects).

## How was it tested?

Unit tests
