### PR TITLE
fix: add some loose label types

### DIFF
--- a/backend-api/app/models/search.py
+++ b/backend-api/app/models/search.py
@@ -1,6 +1,5 @@
-from collections.abc import Mapping, Sequence
 from enum import Enum
-from typing import Annotated, Literal, Optional
+from typing import List, Literal, Mapping, Optional, Sequence
 
 from cpr_sdk.models.search import Passage
 from cpr_sdk.models.search import SearchParameters as CprSdkSearchParameters
@@ -15,6 +14,7 @@ from pydantic import (
 )
 from pydantic.json_schema import JsonSchemaValue
 from pydantic_core.core_schema import CoreSchema
+from typing_extensions import Annotated
 
 from app.models import CLIMATE_LAWS_MATCH
 
@@ -148,10 +148,10 @@ class SearchResponseDocumentPassage(BaseModel):
 
     text: str
     text_block_id: str
-    text_block_page: int | None = None
-    text_block_coords: Sequence[Coord] | None = None
-    concepts: Sequence[Passage.Concept] | None = None
-    block_id_sort_key: int | None = None
+    text_block_page: Optional[int] = None
+    text_block_coords: Optional[Sequence[Coord]] = None
+    concepts: Optional[Sequence[Passage.Concept]] = None
+    block_id_sort_key: Optional[int] = None
 
 
 class SearchResponseFamilyDocument(BaseModel):
@@ -172,22 +172,22 @@ class SearchResponseFamilyDocument(BaseModel):
     https://app.climatepolicyradar.org/documents/national-climate-change-adaptation-strategy_06f8
     """
 
-    document_type: str | None = None
+    document_type: Optional[str] = None
     """
     The type of document, for example: “Strategy”
     """
 
-    document_source_url: str | None = None
+    document_source_url: Optional[str] = None
     """
     The source url of the external site that was used to ingest into the system.
     """
 
-    document_url: str | None = None
+    document_url: Optional[str] = None
     """
     The CDN url of where the document can be found within our system.
     """
 
-    document_content_type: str | None = None
+    document_content_type: Optional[str] = None
     """
     The content_type of the document found at the `document_url`. For example:
     “application/pdf” or “text/html”.
@@ -259,7 +259,7 @@ class SearchResponseFamily(BaseModel):
     The name given to the type of corpus the family belongs to. E.G. 'Laws and Policies'
     """
 
-    family_geographies: list[str]
+    family_geographies: List[str]
     """
     The geographical locations of the family in ISO 3166-1 alpha-3
     """
@@ -286,20 +286,20 @@ class SearchResponseFamily(BaseModel):
 
     family_documents: list[SearchResponseFamilyDocument]
 
-    continuation_token: str | None = None
+    continuation_token: Optional[str] = None
     """
     Passage level continuation token. Can be used in conjunction with the family level
     `this continuation_token` to get the next page of passages for this specific family
     """
 
-    prev_continuation_token: str | None = None
+    prev_continuation_token: Optional[str] = None
     """
     Passage level continuation token. Can be used in conjunction with the family level
     `this continuation_token` to get the previous page of passages for this specific
     family
     """
 
-    metadata: Sequence[dict[str, str]] | None = None
+    metadata: Optional[Sequence[dict[str, str]]] = None
     """
     This is the metadata is from Vespa which is a mixture of document and family metadata.
     """
@@ -322,16 +322,16 @@ class SearchResponse(BaseModel):
     total_time_ms: int
     """query_time + extra processing"""
 
-    continuation_token: str | None = None
+    continuation_token: Optional[str] = None
     """
     A token that can be sent in a followup request to the search endpoint in order to
     get the next page from the search database for this specific query.
     """
 
-    this_continuation_token: str | None = None
+    this_continuation_token: Optional[str] = None
     """Relevant when using passage level continuations on a search page"""
 
-    prev_continuation_token: str | None = None
+    prev_continuation_token: Optional[str] = None
     """
     A token that can be sent in a followup request to the search endpoint in order to
     get the previous page from the search database for this specific query.
@@ -361,7 +361,7 @@ class SearchResponse(BaseModel):
         return self
 
 
-Top5FamilyList = Annotated[list[SearchResponseFamily], Field(max_length=5)]
+Top5FamilyList = Annotated[List[SearchResponseFamily], Field(max_length=5)]
 # Alias required for type hinting
 _T5FamL = Top5FamilyList
 
@@ -392,11 +392,11 @@ class LatestFamilyResponse(BaseModel):
 class BrowseArgs(BaseModel):
     """Arguments for the browse_rds function"""
 
-    geography_slugs: Sequence[str] | None = None
-    country_codes: Sequence[str] | None = None
-    corpora_ids: Sequence[str] | None = None
-    categories: Sequence[str] | None = None
+    geography_slugs: Optional[Sequence[str]] = None
+    country_codes: Optional[Sequence[str]] = None
+    corpora_ids: Optional[Sequence[str]] = None
+    categories: Optional[Sequence[str]] = None
     sort_field: SortField = SortField.DATE
     sort_order: SortOrder = SortOrder.DESCENDING
-    offset: int | None = 0
-    limit: int | None = 10
+    offset: Optional[int] = 0
+    limit: Optional[int] = 10

--- a/backend-api/app/models/search.py
+++ b/backend-api/app/models/search.py
@@ -60,6 +60,8 @@ class SearchRequestBody(CprSdkSearchParameters):
         populate_by_name=True,
     )
 
+    exact_match: bool = True
+
     # Query string should be required in backend (its not in dal)
     query_string: str  # type: ignore
     """

--- a/backend-api/app/models/search.py
+++ b/backend-api/app/models/search.py
@@ -1,5 +1,6 @@
+from collections.abc import Mapping, Sequence
 from enum import Enum
-from typing import List, Literal, Mapping, Optional, Sequence
+from typing import Annotated, Literal, Optional
 
 from cpr_sdk.models.search import Passage
 from cpr_sdk.models.search import SearchParameters as CprSdkSearchParameters
@@ -14,7 +15,6 @@ from pydantic import (
 )
 from pydantic.json_schema import JsonSchemaValue
 from pydantic_core.core_schema import CoreSchema
-from typing_extensions import Annotated
 
 from app.models import CLIMATE_LAWS_MATCH
 
@@ -59,8 +59,6 @@ class SearchRequestBody(CprSdkSearchParameters):
         use_attribute_docstrings=True,
         populate_by_name=True,
     )
-
-    exact_match: bool = True
 
     # Query string should be required in backend (its not in dal)
     query_string: str  # type: ignore
@@ -150,10 +148,10 @@ class SearchResponseDocumentPassage(BaseModel):
 
     text: str
     text_block_id: str
-    text_block_page: Optional[int] = None
-    text_block_coords: Optional[Sequence[Coord]] = None
-    concepts: Optional[Sequence[Passage.Concept]] = None
-    block_id_sort_key: Optional[int] = None
+    text_block_page: int | None = None
+    text_block_coords: Sequence[Coord] | None = None
+    concepts: Sequence[Passage.Concept] | None = None
+    block_id_sort_key: int | None = None
 
 
 class SearchResponseFamilyDocument(BaseModel):
@@ -174,22 +172,22 @@ class SearchResponseFamilyDocument(BaseModel):
     https://app.climatepolicyradar.org/documents/national-climate-change-adaptation-strategy_06f8
     """
 
-    document_type: Optional[str] = None
+    document_type: str | None = None
     """
     The type of document, for example: “Strategy”
     """
 
-    document_source_url: Optional[str] = None
+    document_source_url: str | None = None
     """
     The source url of the external site that was used to ingest into the system.
     """
 
-    document_url: Optional[str] = None
+    document_url: str | None = None
     """
     The CDN url of where the document can be found within our system.
     """
 
-    document_content_type: Optional[str] = None
+    document_content_type: str | None = None
     """
     The content_type of the document found at the `document_url`. For example:
     “application/pdf” or “text/html”.
@@ -261,7 +259,7 @@ class SearchResponseFamily(BaseModel):
     The name given to the type of corpus the family belongs to. E.G. 'Laws and Policies'
     """
 
-    family_geographies: List[str]
+    family_geographies: list[str]
     """
     The geographical locations of the family in ISO 3166-1 alpha-3
     """
@@ -288,20 +286,20 @@ class SearchResponseFamily(BaseModel):
 
     family_documents: list[SearchResponseFamilyDocument]
 
-    continuation_token: Optional[str] = None
+    continuation_token: str | None = None
     """
     Passage level continuation token. Can be used in conjunction with the family level
     `this continuation_token` to get the next page of passages for this specific family
     """
 
-    prev_continuation_token: Optional[str] = None
+    prev_continuation_token: str | None = None
     """
     Passage level continuation token. Can be used in conjunction with the family level
     `this continuation_token` to get the previous page of passages for this specific
     family
     """
 
-    metadata: Optional[Sequence[dict[str, str]]] = None
+    metadata: Sequence[dict[str, str]] | None = None
     """
     This is the metadata is from Vespa which is a mixture of document and family metadata.
     """
@@ -324,16 +322,16 @@ class SearchResponse(BaseModel):
     total_time_ms: int
     """query_time + extra processing"""
 
-    continuation_token: Optional[str] = None
+    continuation_token: str | None = None
     """
     A token that can be sent in a followup request to the search endpoint in order to
     get the next page from the search database for this specific query.
     """
 
-    this_continuation_token: Optional[str] = None
+    this_continuation_token: str | None = None
     """Relevant when using passage level continuations on a search page"""
 
-    prev_continuation_token: Optional[str] = None
+    prev_continuation_token: str | None = None
     """
     A token that can be sent in a followup request to the search endpoint in order to
     get the previous page from the search database for this specific query.
@@ -363,7 +361,7 @@ class SearchResponse(BaseModel):
         return self
 
 
-Top5FamilyList = Annotated[List[SearchResponseFamily], Field(max_length=5)]
+Top5FamilyList = Annotated[list[SearchResponseFamily], Field(max_length=5)]
 # Alias required for type hinting
 _T5FamL = Top5FamilyList
 
@@ -394,11 +392,11 @@ class LatestFamilyResponse(BaseModel):
 class BrowseArgs(BaseModel):
     """Arguments for the browse_rds function"""
 
-    geography_slugs: Optional[Sequence[str]] = None
-    country_codes: Optional[Sequence[str]] = None
-    corpora_ids: Optional[Sequence[str]] = None
-    categories: Optional[Sequence[str]] = None
+    geography_slugs: Sequence[str] | None = None
+    country_codes: Sequence[str] | None = None
+    corpora_ids: Sequence[str] | None = None
+    categories: Sequence[str] | None = None
     sort_field: SortField = SortField.DATE
     sort_order: SortOrder = SortOrder.DESCENDING
-    offset: Optional[int] = 0
-    limit: Optional[int] = 10
+    offset: int | None = 0
+    limit: int | None = 10

--- a/data-in-pipeline/app/transform/navigator_family.py
+++ b/data-in-pipeline/app/transform/navigator_family.py
@@ -31,6 +31,30 @@ from app.transform.models import (
 # Constants
 # ---------------------------------------------------------------------------
 
+_corpus_to_provider_map = {
+    "CCLW.corpus.i00000001.n0000": "Grantham Research Institute",
+    "Academic.corpus.Litigation.n0000": "Sabin Center for Climate Change Law",
+    "CPR.corpus.Goldstandard.n0000": "Gold Standard",
+    "CPR.corpus.i00000589.n0000": "Naturebase",
+    "CPR.corpus.i00000001.n0000": "NewClimate Institute",
+    "CPR.corpus.i00000002.n0000": "Climate Policy Radar",
+    "CPR.corpus.i00000591.n0000": "Laws Africa",
+    "CPR.corpus.i00000592.n0000": "UNDRR",
+    "MCF.corpus.AF.n0000": "Adaptation Fund",
+    "MCF.corpus.AF.Guidance": "Adaptation Fund",
+    "MCF.corpus.CIF.n0000": "The Climate Investment Funds",
+    "MCF.corpus.CIF.Guidance": "The Climate Investment Funds",
+    "MCF.corpus.GCF.n0000": "Green Climate Fund",
+    "MCF.corpus.GCF.Guidance": "Green Climate Fund",
+    "MCF.corpus.GEF.n0000": "Global Environment Facility",
+    "MCF.corpus.GEF.Guidance": "Global Environment Facility",
+    "OEP.corpus.i00000001.n0000": "Ocean Energy Pathways",
+    "UNFCCC.corpus.i00000001.n0000": "UNFCCC",
+    "UN.corpus.UNCCD.n0000": "UNCCD",
+    "UN.corpus.UNCBD.n0000": "UNCBD",
+    "ICCN.corpus.i00000001.n0000": "International Climate Councils Network",
+}
+
 mcf_projects_corpus_import_ids = [
     "MCF.corpus.AF.n0000",
     "MCF.corpus.CIF.n0000",
@@ -369,31 +393,8 @@ def _transform_family_corpus_organisation(
     @see: https://schema.org/provider
     """
     labels: list[LabelRelationship] = []
-    corpus_to_provider_map = {
-        "CCLW.corpus.i00000001.n0000": "Grantham Research Institute",
-        "Academic.corpus.Litigation.n0000": "Sabin Center for Climate Change Law",
-        "CPR.corpus.Goldstandard.n0000": "Gold Standard",
-        "CPR.corpus.i00000589.n0000": "Naturebase",
-        "CPR.corpus.i00000001.n0000": "NewClimate Institute",
-        "CPR.corpus.i00000002.n0000": "Climate Policy Radar",
-        "CPR.corpus.i00000591.n0000": "Laws Africa",
-        "CPR.corpus.i00000592.n0000": "UNDRR",
-        "MCF.corpus.AF.n0000": "Adaptation Fund",
-        "MCF.corpus.AF.Guidance": "Adaptation Fund",
-        "MCF.corpus.CIF.n0000": "The Climate Investment Funds",
-        "MCF.corpus.CIF.Guidance": "The Climate Investment Funds",
-        "MCF.corpus.GCF.n0000": "Green Climate Fund",
-        "MCF.corpus.GCF.Guidance": "Green Climate Fund",
-        "MCF.corpus.GEF.n0000": "Global Environment Facility",
-        "MCF.corpus.GEF.Guidance": "Global Environment Facility",
-        "OEP.corpus.i00000001.n0000": "Ocean Energy Pathways",
-        "UNFCCC.corpus.i00000001.n0000": "UNFCCC",
-        "UN.corpus.UNCCD.n0000": "UNCCD",
-        "UN.corpus.UNCBD.n0000": "UNCBD",
-        "ICCN.corpus.i00000001.n0000": "International Climate Councils Network",
-    }
 
-    provider_name = corpus_to_provider_map.get(
+    provider_name = _corpus_to_provider_map.get(
         navigator_family.corpus.import_id, "Unknown"
     )
     labels.append(
@@ -1168,6 +1169,15 @@ def _transform_navigator_family(
     if navigator_family.documents and contains_published_document:
         attributes["status"] = "published"
 
+    labels = (
+        labels
+        + _author_label(navigator_family)
+        + _author_type_label(navigator_family)
+        + _stakeholder_type_label(navigator_family)
+        + _un_convention_label(navigator_family)
+        + _multilateral_climate_fund_label(navigator_family)
+    )
+
     document = Document(
         id=navigator_family.import_id,
         title=navigator_family.title,
@@ -1436,3 +1446,138 @@ def _deduplicate_labels(
         unique_labels.append(label_rel)
         dedup_keys.add(key)
     return unique_labels
+
+
+# Anything below this point is quite loosey goosey
+# on the label types taxonomy but we need this data
+# for to support faceted search that looks
+# similar to our legacy search.
+
+
+# region author label
+def _author_label(
+    navigator_family: NavigatorFamily,
+) -> list[LabelRelationship]:
+    labels: list[LabelRelationship] = []
+    author_values = navigator_family.metadata.get("author")
+    if author_values and author_values[0] not in _stakeholder_types:
+        author = author_values[0]
+        labels.append(
+            LabelRelationship(
+                type="author",
+                value=Label(
+                    id=f"author::{author}",
+                    value=author,
+                    type="author",
+                ),
+            )
+        )
+    return labels
+
+
+# region author_type label
+_stakeholder_types = ["Party", "Non-Party"]
+
+
+def _author_type_label(
+    navigator_family: NavigatorFamily,
+) -> list[LabelRelationship]:
+    labels: list[LabelRelationship] = []
+    author_type_values = navigator_family.metadata.get("author_type")
+    if author_type_values and author_type_values[0] not in _stakeholder_types:
+        author_type = author_type_values[0]
+        labels.append(
+            LabelRelationship(
+                type="author_type",
+                value=Label(
+                    id=f"author_type::{author_type}",
+                    value=author_type,
+                    type="author_type",
+                ),
+            )
+        )
+    return labels
+
+
+# region stakeholder_type label
+def _stakeholder_type_label(
+    navigator_family: NavigatorFamily,
+) -> list[LabelRelationship]:
+    labels: list[LabelRelationship] = []
+    author_type_values = navigator_family.metadata.get("author_type")
+    if author_type_values and author_type_values[0] in _stakeholder_types:
+        author_type = author_type_values[0]
+        labels.append(
+            LabelRelationship(
+                type="stakeholder_type",
+                value=Label(
+                    id=f"stakeholder_type::{author_type}",
+                    value=author_type,
+                    type="stakeholder_type",
+                ),
+            )
+        )
+
+    return labels
+
+
+# region un_convention label
+_corpus_import_id_to_un_convention = {
+    "UNFCCC.corpus.i00000001.n0000": "UNFCCC",
+    "UN.corpus.UNCCD.n0000": "UNCCD",
+    "UN.corpus.UNCBD.n0000": "UNCBD",
+}
+
+
+def _un_convention_label(
+    navigator_family: NavigatorFamily,
+) -> list[LabelRelationship]:
+    labels: list[LabelRelationship] = []
+    if navigator_family.corpus.import_id in _corpus_import_id_to_un_convention:
+        un_convention = _corpus_import_id_to_un_convention[
+            navigator_family.corpus.import_id
+        ]
+        labels.append(
+            LabelRelationship(
+                type="un_convention",
+                value=Label(
+                    id=f"un_convention::{un_convention}",
+                    value=un_convention,
+                    type="un_convention",
+                ),
+            )
+        )
+
+    return labels
+
+
+# region multilateral_climate_fund label
+_corpus_import_id_to_multilateral_climate_fund = {
+    "MCF.corpus.AF.n0000": "Adaptation Fund",
+    "MCF.corpus.CIF.n0000": "Climate Investment Funds",
+    "MCF.corpus.GCF.n0000": "Global Environment Facility",
+    "MCF.corpus.GEF.n0000": "Green Climate Fund",
+}
+
+
+def _multilateral_climate_fund_label(
+    navigator_family: NavigatorFamily,
+) -> list[LabelRelationship]:
+    labels: list[LabelRelationship] = []
+    if navigator_family.corpus.import_id in MCF_CORPORA:
+        multilateral_climate_fund = _corpus_import_id_to_multilateral_climate_fund.get(
+            navigator_family.corpus.import_id
+        )
+        if multilateral_climate_fund:
+            labels.append(
+                LabelRelationship(
+                    type="multilateral_climate_fund",
+                    value=Label(
+                        id=f"multilateral_climate_fund::{multilateral_climate_fund}",
+                        value=multilateral_climate_fund,
+                        type="multilateral_climate_fund",
+                    ),
+                )
+            )
+
+    return labels

--- a/data-in-pipeline/tests/transform/test_navigator_family.py
+++ b/data-in-pipeline/tests/transform/test_navigator_family.py
@@ -14,7 +14,14 @@ from app.extract.connectors import (
     NavigatorFamily,
 )
 from app.models import Identified
-from app.transform.navigator_family import transform_navigator_family
+from app.transform.navigator_family import (
+    _author_label,
+    _author_type_label,
+    _multilateral_climate_fund_label,
+    _stakeholder_type_label,
+    _un_convention_label,
+    transform_navigator_family,
+)
 from tests.factories import (
     NavigatorCollectionFactory,
     NavigatorCorpusFactory,
@@ -1707,3 +1714,134 @@ def test_transform_to_category_corpus_ids(corpus_id: str, expected_category: str
     assert any(
         label.value.id == expected_category for label in category_labels
     ), f"Expected category '{expected_category}' not found in labels for corpus '{corpus_id}'"
+
+
+# region labels
+@pytest.mark.parametrize("author_type", ["Party", "Non-Party"])
+def test_author_type_label_returns_empty_for_stakeholder_types(author_type):
+    family = NavigatorFamilyFactory.build(
+        corpus=NavigatorCorpusFactory.build(import_id="UNFCCC.corpus.i00000001.n0000"),
+        metadata={"author_type": [author_type]},
+    )
+    assert _author_type_label(family) == []
+
+
+def test_author_type_label_returns_label_for_non_stakeholder():
+    family = NavigatorFamilyFactory.build(
+        corpus=NavigatorCorpusFactory.build(import_id="UNFCCC.corpus.i00000001.n0000"),
+        metadata={"author_type": ["Government"]},
+    )
+    labels = _author_type_label(family)
+    assert len(labels) == 1
+    assert labels[0].type == "author_type"
+    assert labels[0].value.id == "author_type::Government"
+
+
+def test_author_type_label_returns_empty_when_no_metadata():
+    family = NavigatorFamilyFactory.build(
+        corpus=NavigatorCorpusFactory.build(import_id="UNFCCC.corpus.i00000001.n0000"),
+        metadata={},
+    )
+    assert _author_type_label(family) == []
+
+
+@pytest.mark.parametrize("author_type", ["Party", "Non-Party"])
+def test_stakeholder_type_label_returns_label(author_type):
+    family = NavigatorFamilyFactory.build(
+        corpus=NavigatorCorpusFactory.build(import_id="UNFCCC.corpus.i00000001.n0000"),
+        metadata={"author_type": [author_type]},
+    )
+    labels = _stakeholder_type_label(family)
+    assert len(labels) == 1
+    assert labels[0].type == "stakeholder_type"
+    assert labels[0].value.id == f"stakeholder_type::{author_type}"
+
+
+def test_stakeholder_type_label_returns_empty_for_non_stakeholder():
+    family = NavigatorFamilyFactory.build(
+        corpus=NavigatorCorpusFactory.build(import_id="UNFCCC.corpus.i00000001.n0000"),
+        metadata={"author_type": ["Government"]},
+    )
+    assert _stakeholder_type_label(family) == []
+
+
+def test_stakeholder_type_label_returns_empty_when_no_metadata():
+    family = NavigatorFamilyFactory.build(
+        corpus=NavigatorCorpusFactory.build(import_id="UNFCCC.corpus.i00000001.n0000"),
+        metadata={},
+    )
+    assert _stakeholder_type_label(family) == []
+
+
+@pytest.mark.parametrize(
+    "corpus_import_id, expected_convention",
+    [
+        ("UNFCCC.corpus.i00000001.n0000", "UNFCCC"),
+        ("UN.corpus.UNCCD.n0000", "UNCCD"),
+        ("UN.corpus.UNCBD.n0000", "UNCBD"),
+    ],
+)
+def test_un_convention_label_returns_label(corpus_import_id, expected_convention):
+    family = NavigatorFamilyFactory.build(
+        corpus=NavigatorCorpusFactory.build(import_id=corpus_import_id),
+        metadata={},
+    )
+    labels = _un_convention_label(family)
+    assert len(labels) == 1
+    assert labels[0].type == "un_convention"
+    assert labels[0].value.id == f"un_convention::{expected_convention}"
+
+
+def test_un_convention_label_returns_empty_for_non_un_corpus():
+    family = NavigatorFamilyFactory.build(
+        corpus=NavigatorCorpusFactory.build(import_id="CCLW.corpus.i00000001.n0000"),
+        metadata={},
+    )
+    assert _un_convention_label(family) == []
+
+
+@pytest.mark.parametrize(
+    "corpus_import_id, expected_fund",
+    [
+        ("MCF.corpus.AF.n0000", "Adaptation Fund"),
+        ("MCF.corpus.CIF.n0000", "Climate Investment Funds"),
+        ("MCF.corpus.GCF.n0000", "Global Environment Facility"),
+        ("MCF.corpus.GEF.n0000", "Green Climate Fund"),
+    ],
+)
+def test_multilateral_climate_fund_label_returns_label(corpus_import_id, expected_fund):
+    family = NavigatorFamilyFactory.build(
+        corpus=NavigatorCorpusFactory.build(import_id=corpus_import_id),
+        metadata={},
+    )
+    labels = _multilateral_climate_fund_label(family)
+    assert len(labels) == 1
+    assert labels[0].type == "multilateral_climate_fund"
+    assert labels[0].value.id == f"multilateral_climate_fund::{expected_fund}"
+
+
+def test_multilateral_climate_fund_label_returns_empty_for_non_mcf_corpus():
+    family = NavigatorFamilyFactory.build(
+        corpus=NavigatorCorpusFactory.build(import_id="CCLW.corpus.i00000001.n0000"),
+        metadata={},
+    )
+    assert _multilateral_climate_fund_label(family) == []
+
+
+def test_author_label_returns_label():
+    family = NavigatorFamilyFactory.build(
+        corpus=NavigatorCorpusFactory.build(import_id="UNFCCC.corpus.i00000001.n0000"),
+        metadata={"author": ["Greenpeace"]},
+    )
+    labels = _author_label(family)
+    assert len(labels) == 1
+    assert labels[0].type == "author"
+    assert labels[0].value.id == "author::Greenpeace"
+
+
+def test_author_label_returns_empty_when_no_metadata():
+    family = NavigatorFamilyFactory.build(
+        corpus=NavigatorCorpusFactory.build(import_id="UNFCCC.corpus.i00000001.n0000"),
+        metadata={},
+    )
+    assert _author_label(family) == []

--- a/data-in-pipeline/tests/transform/test_navigator_family_GST1.py
+++ b/data-in-pipeline/tests/transform/test_navigator_family_GST1.py
@@ -223,6 +223,30 @@ def test_transform_navigator_family_UNFCCC_party_submission_to_GST1_label():
                     type="category",
                 ),
             ),
+            LabelRelationship(
+                type="author",
+                value=Label(
+                    id="author::Australia",
+                    value="Australia",
+                    type="author",
+                ),
+            ),
+            LabelRelationship(
+                type="stakeholder_type",
+                value=Label(
+                    id="stakeholder_type::Party",
+                    value="Party",
+                    type="stakeholder_type",
+                ),
+            ),
+            LabelRelationship(
+                type="un_convention",
+                value=Label(
+                    id="un_convention::UNFCCC",
+                    value="UNFCCC",
+                    type="un_convention",
+                ),
+            ),
         ],
         documents=[
             DocumentRelationship(
@@ -506,6 +530,30 @@ def test_transform_navigator_family_UNFCCC_non_party_submission_to_GST1_label():
                     id="category::UN submission",
                     value="UN submission",
                     type="category",
+                ),
+            ),
+            LabelRelationship(
+                type="author",
+                value=Label(
+                    id="author::Australia",
+                    value="Australia",
+                    type="author",
+                ),
+            ),
+            LabelRelationship(
+                type="stakeholder_type",
+                value=Label(
+                    id="stakeholder_type::Non-Party",
+                    value="Non-Party",
+                    type="stakeholder_type",
+                ),
+            ),
+            LabelRelationship(
+                type="un_convention",
+                value=Label(
+                    id="un_convention::UNFCCC",
+                    value="UNFCCC",
+                    type="un_convention",
                 ),
             ),
         ],

--- a/data-in-pipeline/tests/transform/test_navigator_family_mcf.py
+++ b/data-in-pipeline/tests/transform/test_navigator_family_mcf.py
@@ -306,6 +306,14 @@ def test_transform_navigator_family_with_multilateral_climate_fund_project(
                     value="International Bank for Reconstruction",
                 ),
             ),
+            LabelRelationship(
+                type="multilateral_climate_fund",
+                value=Label(
+                    id="multilateral_climate_fund::Adaptation Fund",
+                    value="Adaptation Fund",
+                    type="multilateral_climate_fund",
+                ),
+            ),
         ],
         documents=[
             DocumentRelationship(


### PR DESCRIPTION
# What does this do?

- adds more granularity to our label types
  - `author`
  - `author_type`
  - `stakeholder_type`
  - `multilateral_climate_fund`
  - `un_convention`

I do not think these are very good types to add to our taxonomy, but they are also not hard to clear out and refine once we have migrated over to using the new search<sup>1️⃣</sup>.

This also follows a pattern of 1 transformer / `label.type` which @annaCPR and I had spoken about - and I think this makes it much more clearer and easy to describe and understand. 👉 https://linear.app/climate-policy-radar/issue/APP-2088/move-transformnavigator-family-1-transformer-label-pattern

## Why is it needed?

- we need this to replicate the legacy search filters on new search

## How was it tested?

Pytest


---


## <sup>1️⃣</sup> Example

UNCCD` or `Adaptation Fund` should probably both be `agent`s, and related to the Document as e.g.

```
Document -- provided_by --> agent::Adaptation Fund
Document -- part_of --> agent::Adaptation Fund

Document -- provided_by --> agent::UNCCD
Document -- submitted_to --> agent::UNCCD
```

Allowing you then query for anything to do with that `Label`. We could then ask for anything to do with that label, or specific questions. This would require us to relatively heavily refactor of search to facet on relationship. The requirements in that project feel to loose to warrant that work though.

👉  [tech debt captured here](https://linear.app/climate-policy-radar/issue/APP-2087/investigate-whether-faceting-on-relationships-makes-more-sense-for-the)

Toward https://linear.app/climate-policy-radar/issue/APP-2084/extend-labels-to-support-current-search-filters