### PR TITLE
Remove --target flag from deploy recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -25,7 +25,6 @@ build service environment tag:
     docker buildx build \
         --platform linux/amd64 \
         --output type=docker \
-        --target prod \
         --build-arg SERVICE={{service}} \
         --build-arg ENV={{environment}} \
         --build-arg GITHUB_SHA={{GITHUB_SHA}} \


### PR DESCRIPTION
# What does this do?

Removes `--target prod` flag from the just deploy recipe in the root justfile.

## Why is it needed?

We added the flag to make sure the services that have multistage builds are definitely building production. But not all services in this repo have multistage builds so the deploy command fails. The services that do have multistage builds have the production stage listed at the end of the Dockerfile so they will default to production unless specified.


