### PR TITLE
Add discriminator for country & subdivision

### DIFF
--- a/data-in-pipeline/app/transform/navigator_family.py
+++ b/data-in-pipeline/app/transform/navigator_family.py
@@ -20,7 +20,7 @@ from app.extract.connectors import (
     NavigatorDocumentStatus,
     NavigatorFamily,
 )
-from app.geographies import geographies_lookup
+from app.geographies import Country, Subdivision, geographies_lookup
 from app.models import Identified, NavigatorConcept
 from app.transform.models import (
     CouldNotTransform,
@@ -599,13 +599,21 @@ def _transform_geographies(
                 )
             )
             continue
+
+        geography_type = "geography"
+        if isinstance(geography, Country):
+            geography_type = "country"
+
+        if isinstance(geography, Subdivision):
+            geography_type = "subdivision"
+
         labels.append(
             LabelRelationship(
                 type="geography",
                 value=Label(
-                    id=f"geography::{geography.id}",
+                    id=f"{geography_type}::{geography.id}",
                     value=geography.name,
-                    type="geography",
+                    type=geography_type,
                 ),
             )
         )

--- a/data-in-pipeline/tests/transform/test_navigator_documents.py
+++ b/data-in-pipeline/tests/transform/test_navigator_documents.py
@@ -231,8 +231,8 @@ def test_transform_navigator_documents_litigation_events_without_documents():
                     LabelRelationship(
                         type="geography",
                         value=Label(
-                            type="geography",
-                            id="geography::AUS",
+                            type="country",
+                            id="country::AUS",
                             value="Australia",
                         ),
                     ),

--- a/data-in-pipeline/tests/transform/test_navigator_family.py
+++ b/data-in-pipeline/tests/transform/test_navigator_family.py
@@ -402,16 +402,16 @@ def test_transform_navigator_family_with_single_matching_document(
             LabelRelationship(
                 type="geography",
                 value=Label(
-                    type="geography",
-                    id="geography::AU-NSW",
+                    type="subdivision",
+                    id="subdivision::AU-NSW",
                     value="New South Wales",
                 ),
             ),
             LabelRelationship(
                 type="geography",
                 value=Label(
-                    type="geography",
-                    id="geography::AUS",
+                    type="country",
+                    id="country::AUS",
                     value="Australia",
                 ),
             ),
@@ -548,16 +548,16 @@ def test_transform_navigator_family_with_single_matching_document(
                         LabelRelationship(
                             type="geography",
                             value=Label(
-                                type="geography",
-                                id="geography::AU-NSW",
+                                type="subdivision",
+                                id="subdivision::AU-NSW",
                                 value="New South Wales",
                             ),
                         ),
                         LabelRelationship(
                             type="geography",
                             value=Label(
-                                type="geography",
-                                id="geography::AUS",
+                                type="country",
+                                id="country::AUS",
                                 value="Australia",
                             ),
                         ),
@@ -672,16 +672,16 @@ def test_transform_navigator_family_with_single_matching_document(
                     LabelRelationship(
                         type="geography",
                         value=Label(
-                            type="geography",
-                            id="geography::AU-NSW",
+                            type="subdivision",
+                            id="subdivision::AU-NSW",
                             value="New South Wales",
                         ),
                     ),
                     LabelRelationship(
                         type="geography",
                         value=Label(
-                            type="geography",
-                            id="geography::AUS",
+                            type="country",
+                            id="country::AUS",
                             value="Australia",
                         ),
                     ),
@@ -905,9 +905,9 @@ def test_transform_navigator_family_with_laws_and_policies_corpus_type(
             LabelRelationship(
                 type="geography",
                 value=Label(
-                    id="geography::AUS",
+                    id="country::AUS",
                     value="Australia",
-                    type="geography",
+                    type="country",
                 ),
             ),
             LabelRelationship(
@@ -1082,9 +1082,9 @@ def test_transform_navigator_family_with_published_and_unpublished_documents():
             LabelRelationship(
                 type="geography",
                 value=Label(
-                    id="geography::AUS",
+                    id="country::AUS",
                     value="Australia",
-                    type="geography",
+                    type="country",
                 ),
             ),
             LabelRelationship(
@@ -1135,8 +1135,8 @@ def test_transform_navigator_family_with_published_and_unpublished_documents():
                         LabelRelationship(
                             type="geography",
                             value=Label(
-                                type="geography",
-                                id="geography::AUS",
+                                type="country",
+                                id="country::AUS",
                                 value="Australia",
                             ),
                         ),
@@ -1207,8 +1207,8 @@ def test_transform_navigator_family_with_published_and_unpublished_documents():
                         LabelRelationship(
                             type="geography",
                             value=Label(
-                                type="geography",
-                                id="geography::AUS",
+                                type="country",
+                                id="country::AUS",
                                 value="Australia",
                             ),
                         ),
@@ -1287,8 +1287,8 @@ def test_transform_navigator_family_with_published_and_unpublished_documents():
                     LabelRelationship(
                         type="geography",
                         value=Label(
-                            type="geography",
-                            id="geography::AUS",
+                            type="country",
+                            id="country::AUS",
                             value="Australia",
                         ),
                     ),
@@ -1364,8 +1364,8 @@ def test_transform_navigator_family_with_published_and_unpublished_documents():
                     LabelRelationship(
                         type="geography",
                         value=Label(
-                            type="geography",
-                            id="geography::AUS",
+                            type="country",
+                            id="country::AUS",
                             value="Australia",
                         ),
                     ),
@@ -1500,9 +1500,9 @@ def test_transform_navigator_family_with_no_published_documents():
             LabelRelationship(
                 type="geography",
                 value=Label(
-                    id="geography::AUS",
+                    id="country::AUS",
                     value="Australia",
-                    type="geography",
+                    type="country",
                 ),
             ),
             LabelRelationship(
@@ -1553,8 +1553,8 @@ def test_transform_navigator_family_with_no_published_documents():
                         LabelRelationship(
                             type="geography",
                             value=Label(
-                                type="geography",
-                                id="geography::AUS",
+                                type="country",
+                                id="country::AUS",
                                 value="Australia",
                             ),
                         ),
@@ -1632,8 +1632,8 @@ def test_transform_navigator_family_with_no_published_documents():
                     LabelRelationship(
                         type="geography",
                         value=Label(
-                            type="geography",
-                            id="geography::AUS",
+                            type="country",
+                            id="country::AUS",
                             value="Australia",
                         ),
                     ),

--- a/data-in-pipeline/tests/transform/test_navigator_family_GST1.py
+++ b/data-in-pipeline/tests/transform/test_navigator_family_GST1.py
@@ -194,9 +194,9 @@ def test_transform_navigator_family_UNFCCC_party_submission_to_GST1_label():
             LabelRelationship(
                 type="geography",
                 value=Label(
-                    id="geography::AUS",
+                    id="country::AUS",
                     value="Australia",
-                    type="geography",
+                    type="country",
                 ),
             ),
             LabelRelationship(
@@ -279,8 +279,8 @@ def test_transform_navigator_family_UNFCCC_party_submission_to_GST1_label():
                         LabelRelationship(
                             type="geography",
                             value=Label(
-                                type="geography",
-                                id="geography::AUS",
+                                type="country",
+                                id="country::AUS",
                                 value="Australia",
                             ),
                         ),
@@ -359,8 +359,8 @@ def test_transform_navigator_family_UNFCCC_party_submission_to_GST1_label():
                     LabelRelationship(
                         type="geography",
                         value=Label(
-                            type="geography",
-                            id="geography::AUS",
+                            type="country",
+                            id="country::AUS",
                             value="Australia",
                         ),
                     ),
@@ -503,9 +503,9 @@ def test_transform_navigator_family_UNFCCC_non_party_submission_to_GST1_label():
             LabelRelationship(
                 type="geography",
                 value=Label(
-                    id="geography::AUS",
+                    id="country::AUS",
                     value="Australia",
-                    type="geography",
+                    type="country",
                 ),
             ),
             LabelRelationship(
@@ -588,8 +588,8 @@ def test_transform_navigator_family_UNFCCC_non_party_submission_to_GST1_label():
                         LabelRelationship(
                             type="geography",
                             value=Label(
-                                type="geography",
-                                id="geography::AUS",
+                                type="country",
+                                id="country::AUS",
                                 value="Australia",
                             ),
                         ),
@@ -668,8 +668,8 @@ def test_transform_navigator_family_UNFCCC_non_party_submission_to_GST1_label():
                     LabelRelationship(
                         type="geography",
                         value=Label(
-                            type="geography",
-                            id="geography::AUS",
+                            type="country",
+                            id="country::AUS",
                             value="Australia",
                         ),
                     ),


### PR DESCRIPTION
# What does this do?

What it says on the tin

## Why is it needed?

here's no way for the frontend to know whether Texas is a state, country, or region. 

## How was it tested?

n/a