### PR TITLE
Fix no transformation warnings should be sent for custom id lookups

### DIFF
--- a/data-in-pipeline/app/transform/navigator_family.py
+++ b/data-in-pipeline/app/transform/navigator_family.py
@@ -40,7 +40,7 @@ from app.transform.models import (
 # Constants
 # ---------------------------------------------------------------------------
 
-_custom_countries_by_id = {c.id: c for c in custom_countries}
+_eu_and_international_region_ids = {c.id: c for c in custom_countries}
 
 _corpus_to_provider_map = {
     "CCLW.corpus.i00000001.n0000": "Grantham Research Institute",
@@ -627,7 +627,7 @@ def _transform_geographies(
                         value=region_label,
                     )
                 )
-            elif geography.id not in _custom_countries_by_id:
+            elif geography.id not in _eu_and_international_region_ids:
                 warnings.append(
                     UnknownGeography(
                         family_import_id=navigator_family.import_id,

--- a/data-in-pipeline/app/transform/navigator_family.py
+++ b/data-in-pipeline/app/transform/navigator_family.py
@@ -24,6 +24,7 @@ from app.geographies import (
     Country,
     Subdivision,
     countries_by_alpha_2,
+    custom_countries,
     geographies_lookup,
     regions_lookup,
 )
@@ -38,6 +39,8 @@ from app.transform.models import (
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
+
+_custom_countries_by_id = {c.id: c for c in custom_countries}
 
 _corpus_to_provider_map = {
     "CCLW.corpus.i00000001.n0000": "Grantham Research Institute",
@@ -624,7 +627,7 @@ def _transform_geographies(
                         value=region_label,
                     )
                 )
-            else:
+            elif geography.id not in _custom_countries_by_id:
                 warnings.append(
                     UnknownGeography(
                         family_import_id=navigator_family.import_id,

--- a/data-in-pipeline/tests/factories.py
+++ b/data-in-pipeline/tests/factories.py
@@ -4,7 +4,7 @@ Use ModelFactory.build(...) with overrides for specific test data; factories
 fill the rest with sensible defaults.
 """
 
-from data_in_models.models import DocumentWithoutRelationships
+from data_in_models.models import Document, DocumentWithoutRelationships
 from polyfactory.factories.pydantic_factory import ModelFactory
 
 from app.extract.connectors import (
@@ -58,3 +58,7 @@ class ExtractedMetadataFactory(ModelFactory[ExtractedMetadata]):
 
 class DocumentWithoutRelationshipsFactory(ModelFactory[DocumentWithoutRelationships]):
     """Factory for DocumentWithoutRelationships. Override id, title, labels, items."""
+
+
+class DocumentFactory(ModelFactory[Document]):
+    """Factory for Document. Override id, title, labels, items."""


### PR DESCRIPTION
per title we were getting lots of transformation errors for unknown geographies when trying to read the regions for XAB and EUR, as these are custom ids they will not have world bank region. 

As such I am skipping the transformation warning as this is not applicable in this sense. 

These were the errors coming through in the AWS logs. 

```
"kind='unknown_geography' family_import_id='CCLW.family.i00006367.n0000' geography_id='EUR'",
"kind='unknown_geography' family_import_id='CCLW.family.i00006367.n0000' geography_id='EUR'",
"kind='unknown_geography' family_import_id='Sabin.family.92290.0' geography_id='XAB'",
"kind='unknown_geography' family_import_id='Sabin.family.92290.0' geography_id='XAB'",
```


