### PR TITLE
fix: use label type transformers and add subconcept_of

### DIFF
--- a/data-in-pipeline/app/extract/connectors.py
+++ b/data-in-pipeline/app/extract/connectors.py
@@ -1,6 +1,7 @@
 import datetime
 from enum import Enum
 from http import HTTPStatus
+from typing import Literal
 
 import requests
 from pydantic import BaseModel, ValidationError
@@ -70,8 +71,33 @@ class NavigatorOrganisation(BaseModel):
     name: str
 
 
+type CorpusId = Literal[
+    "CCLW.corpus.i00000001.n0000",
+    "Academic.corpus.Litigation.n0000",
+    "CPR.corpus.Goldstandard.n0000",
+    "CPR.corpus.i00000589.n0000",
+    "CPR.corpus.i00000001.n0000",
+    "CPR.corpus.i00000002.n0000",
+    "CPR.corpus.i00000591.n0000",
+    "CPR.corpus.i00000592.n0000",
+    "MCF.corpus.AF.n0000",
+    "MCF.corpus.AF.Guidance",
+    "MCF.corpus.CIF.n0000",
+    "MCF.corpus.CIF.Guidance",
+    "MCF.corpus.GCF.n0000",
+    "MCF.corpus.GCF.Guidance",
+    "MCF.corpus.GEF.n0000",
+    "MCF.corpus.GEF.Guidance",
+    "OEP.corpus.i00000001.n0000",
+    "UNFCCC.corpus.i00000001.n0000",
+    "UN.corpus.UNCCD.n0000",
+    "UN.corpus.UNCBD.n0000",
+    "ICCN.corpus.i00000001.n0000",
+]
+
+
 class NavigatorCorpus(BaseModel):
-    import_id: str
+    import_id: CorpusId
     corpus_type: NavigatorCorpusType
     organisation: NavigatorOrganisation
     attribution_url: str = ""
@@ -387,7 +413,7 @@ class NavigatorConnector(HTTPConnector):
                             )
                         except ValidationError as e:
                             logger.info(
-                                f"Error validating family {family["import_id"]}: {e.json()}"
+                                f"Error validating family {family['import_id']}: {e.json()}"
                             )
                             failures.append(
                                 RecordValidationFailure(

--- a/data-in-pipeline/app/transform/navigator_family.py
+++ b/data-in-pipeline/app/transform/navigator_family.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Literal
 
 from data_in_models.models import (
     Document,
@@ -14,6 +15,7 @@ from returns.result import Failure, Result, Success
 
 from app.bootstrap_telemetry import get_logger, log_context
 from app.extract.connectors import (
+    CorpusId,
     LitigationDocumentStatus,
     NavigatorCollection,
     NavigatorDocument,
@@ -40,9 +42,37 @@ from app.transform.models import (
 # Constants
 # ---------------------------------------------------------------------------
 
+# region category label relationships
+corporate_discloser = Label(
+    type="category", id="category::Corporate Disclosures", value="Corporate Disclosures"
+)
+multilateral_climate_fund_project = Label(
+    type="category",
+    id="category::Multilateral Climate Fund project",
+    value="Multilateral Climate Fund project",
+)
+multilateral_climate_fund_project_guidance = Label(
+    id="entity_type::Guidance",
+    value="Guidance",
+    type="entity_type",
+    labels=[
+        LabelRelationship(type="subconcept_of", value=multilateral_climate_fund_project)
+    ],
+)
+multilateral_climate_fund_project_project = Label(
+    id="entity_type::Project",
+    value="Project",
+    type="entity_type",
+    labels=[
+        LabelRelationship(type="subconcept_of", value=multilateral_climate_fund_project)
+    ],
+)
+
+
 _eu_and_international_region_ids = {c.id: c for c in custom_countries}
 
-_corpus_to_provider_map = {
+
+_corpus_to_provider_map: dict[CorpusId, str] = {
     "CCLW.corpus.i00000001.n0000": "Grantham Research Institute",
     "Academic.corpus.Litigation.n0000": "Sabin Center for Climate Change Law",
     "CPR.corpus.Goldstandard.n0000": "Gold Standard",
@@ -65,6 +95,7 @@ _corpus_to_provider_map = {
     "UN.corpus.UNCBD.n0000": "UNCBD",
     "ICCN.corpus.i00000001.n0000": "International Climate Councils Network",
 }
+
 
 mcf_projects_corpus_import_ids = [
     "MCF.corpus.AF.n0000",
@@ -194,13 +225,14 @@ def _transform_litigation_events(data: NavigatorFamily) -> list[Document]:
             ]
         )
 
-        labels.extend(_transform_to_category(data))
         geo_labels, _ = _transform_geographies(data)
         labels.extend(geo_labels)
         if event.metadata["action_taken"]:
             attributes["action_taken"] = event.metadata["action_taken"][0]
 
         attributes["status"] = LitigationDocumentStatus.AWAITING_SOURCE_FILE.value
+
+        labels = labels + _category_label(data) + _deprecated_category_label(data)
 
         documents.append(
             Document(
@@ -250,7 +282,7 @@ def transform(
     documents_from_documents, warnings = _transform_navigator_documents(input.data)
 
     documents_from_collections: list[Document] = [
-        _transform_navigator_collection(collection, input.data)
+        _transform_navigator_collection(collection)
         for collection in input.data.collections
     ]
 
@@ -763,149 +795,6 @@ def _transform_litigation_concepts_to_label_relationships(
     return labels, warnings
 
 
-def _transform_to_category(
-    navigator_family: NavigatorFamily,
-) -> list[LabelRelationship]:
-    labels = []
-
-    un_submission_corpora = [
-        "UNFCCC.corpus.i00000001.n0000",
-        "UN.corpus.UNCCD.n0000",
-        "UN.corpus.UNCBD.n0000",
-    ]
-    if navigator_family.corpus.import_id in un_submission_corpora:
-        labels.append(
-            LabelRelationship(
-                type="category",
-                value=Label(
-                    id="category::UN submission",
-                    value="UN submission",
-                    type="category",
-                ),
-            )
-        )
-
-    oep_corpora = [
-        "OEP.corpus.i00000001.n0000",
-    ]
-    if navigator_family.corpus.import_id in oep_corpora:
-        labels.append(
-            LabelRelationship(
-                type="category",
-                value=Label(
-                    id="category::Report",
-                    value="Report",
-                    type="category",
-                ),
-            )
-        )
-
-    litigation_corpora = [
-        "Academic.corpus.Litigation.n0000",
-    ]
-    if navigator_family.corpus.import_id in litigation_corpora:
-        labels.append(
-            LabelRelationship(
-                type="category",
-                value=Label(
-                    id="category::Litigation",
-                    value="Litigation",
-                    type="category",
-                ),
-            )
-        )
-
-    corporate_disclosures_corpora = [
-        "CPR.corpus.i00000002.n0000",
-    ]
-    if navigator_family.corpus.import_id in corporate_disclosures_corpora:
-        labels.append(
-            LabelRelationship(
-                type="category",
-                value=Label(
-                    id="category::Corporate Disclosure",
-                    value="Corporate Disclosure",
-                    type="category",
-                ),
-            )
-        )
-
-    if navigator_family.corpus.import_id in MCF_CORPORA:
-        labels.append(
-            LabelRelationship(
-                type="category",
-                value=Label(
-                    id="category::Multilateral Climate Fund project",
-                    value="Multilateral Climate Fund project",
-                    type="category",
-                ),
-            )
-        )
-
-        if navigator_family.corpus.import_id in mcf_guidance_corpus_import_ids:
-            labels.append(
-                LabelRelationship(
-                    type="entity_type",
-                    value=Label(
-                        id="entity_type::Guidance",
-                        value="Guidance",
-                        type="entity_type",
-                    ),
-                )
-            )
-        if navigator_family.corpus.import_id in mcf_projects_corpus_import_ids:
-            labels.append(
-                LabelRelationship(
-                    type="entity_type",
-                    value=Label(
-                        id="entity_type::Project",
-                        value="Project",
-                        type="entity_type",
-                    ),
-                )
-            )
-
-    if navigator_family.corpus.corpus_type.name == "Laws and Policies":
-        # We are maintaing this as the assumption is all Laws and policies
-        # have been tagged as "LEGISLATIVE" OR "EXECUTIVE", but there is a possiblity
-        # that they have not as the system allows it. This should allow us
-        # to assess that data.
-        labels.append(
-            LabelRelationship(
-                type="deprecated_category",
-                value=Label(
-                    id="deprecated_category::Laws and Policies",
-                    value="Laws and Policies",
-                    type="deprecated_category",
-                ),
-            )
-        )
-        if navigator_family.category == "LEGISLATIVE":
-            labels.append(
-                LabelRelationship(
-                    type="category",
-                    value=Label(
-                        id="category::Law",
-                        value="Law",
-                        type="category",
-                    ),
-                )
-            )
-        if navigator_family.category == "EXECUTIVE":
-            labels.append(
-                LabelRelationship(
-                    type="category",
-                    value=Label(
-                        id="category::Policy",
-                        value="Policy",
-                        type="category",
-                    ),
-                )
-            )
-
-    return labels
-
-
 def _transform_litigation_data(
     navigator_family: NavigatorFamily,
 ) -> tuple[list[LabelRelationship], list[TransformWarning]]:
@@ -1196,11 +1085,6 @@ def _transform_navigator_family(
     )
 
     """
-    Canonical category
-    """
-    labels.extend(_transform_to_category(navigator_family))
-
-    """
     Slug
     We should not couple to this implementation as it is an incomplete ID service which is unmaintained.
     But we need it for migration purposes.
@@ -1248,6 +1132,9 @@ def _transform_navigator_family(
 
     labels = (
         labels
+        + _category_label(navigator_family)
+        + _deprecated_category_label(navigator_family)
+        + _entity_type_label(navigator_family)
         + _author_label(navigator_family)
         + _author_type_label(navigator_family)
         + _un_convention_label(navigator_family)
@@ -1419,11 +1306,6 @@ def _transform_navigator_document(
     warnings.extend(geography_warnings)
 
     """
-    Canonical category
-    """
-    labels.extend(_transform_to_category(navigator_family))
-
-    """
     Language labels
     """
     for lang in navigator_document.languages:
@@ -1461,6 +1343,12 @@ def _transform_navigator_document(
             )
         )
 
+    labels = (
+        labels
+        + _category_label(navigator_family)
+        + _deprecated_category_label(navigator_family)
+    )
+
     document = Document(
         id=navigator_document.import_id,
         title=navigator_document.title,
@@ -1473,7 +1361,7 @@ def _transform_navigator_document(
 
 
 def _transform_navigator_collection(
-    navigator_collection: NavigatorCollection, navigator_family: NavigatorFamily
+    navigator_collection: NavigatorCollection,
 ) -> Document:
     labels: list[LabelRelationship] = []
 
@@ -1533,11 +1421,174 @@ def _deduplicate_labels(
 # similar to our legacy search.
 
 
+# region category label
+type Category = Literal[
+    "Law",
+    "Policy",
+    "UN submission",
+    "Report",
+    "Litigation",
+    "Corporate Disclosure",
+    "Multilateral Climate Fund project",
+]
+type DeprecatedCategory = Literal["Laws and Policies"]
+
+_corpus_import_id_to_category_map: dict[CorpusId, Category | DeprecatedCategory] = {
+    "UNFCCC.corpus.i00000001.n0000": "UN submission",
+    "UN.corpus.UNCCD.n0000": "UN submission",
+    "UN.corpus.UNCBD.n0000": "UN submission",
+    "OEP.corpus.i00000001.n0000": "Report",
+    "ICCN.corpus.i00000001.n0000": "Report",
+    "Academic.corpus.Litigation.n0000": "Litigation",
+    "CPR.corpus.i00000002.n0000": "Corporate Disclosure",
+    "MCF.corpus.AF.n0000": "Multilateral Climate Fund project",
+    "MCF.corpus.CIF.n0000": "Multilateral Climate Fund project",
+    "MCF.corpus.GCF.n0000": "Multilateral Climate Fund project",
+    "MCF.corpus.GEF.n0000": "Multilateral Climate Fund project",
+    "MCF.corpus.AF.Guidance": "Multilateral Climate Fund project",
+    "MCF.corpus.CIF.Guidance": "Multilateral Climate Fund project",
+    "MCF.corpus.GCF.Guidance": "Multilateral Climate Fund project",
+    "MCF.corpus.GEF.Guidance": "Multilateral Climate Fund project",
+    # Laws and Policies are treated slightly different in the transformer i.e.
+    # They are split between `Law` and `Policy`
+    "CCLW.corpus.i00000001.n0000": "Laws and Policies",
+    "CPR.corpus.i00000001.n0000": "Laws and Policies",
+    "CPR.corpus.Goldstandard.n0000": "Laws and Policies",
+    "CPR.corpus.i00000591.n0000": "Laws and Policies",
+    "CPR.corpus.i00000589.n0000": "Laws and Policies",
+    "CPR.corpus.i00000592.n0000": "Laws and Policies",
+}
+
+
+def _category_import_id_to_category(
+    navigator_family: NavigatorFamily,
+) -> Category:
+    logger = get_logger()
+    category = _corpus_import_id_to_category_map[navigator_family.corpus.import_id]
+    if category == "Laws and Policies":
+        if navigator_family.category == "LEGISLATIVE":
+            return "Law"
+        if navigator_family.category == "EXECUTIVE":
+            return "Policy"
+        else:
+            # We should never reach this code path
+            logger.warning(
+                f"Navigator family {navigator_family.import_id} has category 'Laws and Policies' but unexpected family category {navigator_family.category}. Defaulting to 'Law'"
+            )
+            return "Law"
+    else:
+        return category
+
+
+def _category_label(
+    navigator_family: NavigatorFamily,
+) -> list[LabelRelationship]:
+    labels = []
+    category = _corpus_import_id_to_category_map[navigator_family.corpus.import_id]
+
+    if category == "Laws and Policies":
+        if navigator_family.category == "LEGISLATIVE":
+            labels.append(
+                LabelRelationship(
+                    type="category",
+                    value=Label(
+                        id="category::Law",
+                        value="Law",
+                        type="category",
+                    ),
+                )
+            )
+        if navigator_family.category == "EXECUTIVE":
+            labels.append(
+                LabelRelationship(
+                    type="category",
+                    value=Label(
+                        id="category::Policy",
+                        value="Policy",
+                        type="category",
+                    ),
+                )
+            )
+    else:
+        labels.append(
+            LabelRelationship(
+                type="category",
+                value=Label(
+                    id=f"category::{category}",
+                    value=category,
+                    type="category",
+                ),
+            )
+        )
+
+    return labels
+
+
+# region deprecated_category label
+
+
+def _deprecated_category_label(
+    navigator_family: NavigatorFamily,
+) -> list[LabelRelationship]:
+    labels = []
+    if navigator_family.corpus.corpus_type.name == "Laws and Policies":
+        # We are maintaing this as the assumption is all Laws and policies
+        # have been tagged as "LEGISLATIVE" OR "EXECUTIVE", but there is a possiblity
+        # that they have not as the system allows it. This should allow us
+        # to assess that data.
+        labels.append(
+            LabelRelationship(
+                type="deprecated_category",
+                value=Label(
+                    id="deprecated_category::Laws and Policies",
+                    value="Laws and Policies",
+                    type="deprecated_category",
+                ),
+            )
+        )
+
+    return labels
+
+
+#  region entity_type label
+def _entity_type_label(
+    navigator_family: NavigatorFamily,
+) -> list[LabelRelationship]:
+    labels: list[LabelRelationship] = []
+    category = _category_import_id_to_category(navigator_family)
+
+    if category == "Multilateral Climate Fund project":
+        if navigator_family.corpus.import_id in mcf_guidance_corpus_import_ids:
+            labels.append(
+                LabelRelationship(
+                    type="entity_type",
+                    value=multilateral_climate_fund_project_guidance,
+                )
+            )
+        if navigator_family.corpus.import_id in mcf_projects_corpus_import_ids:
+            labels.append(
+                LabelRelationship(
+                    type="entity_type",
+                    value=multilateral_climate_fund_project_project,
+                )
+            )
+
+    return labels
+
+
 # region author label
 def _author_label(
     navigator_family: NavigatorFamily,
 ) -> list[LabelRelationship]:
     labels: list[LabelRelationship] = []
+    category = _category_import_id_to_category(navigator_family)
+    related_labels: list[LabelRelationship] = []
+
+    if category == "Corporate Disclosure":
+        related_labels = [
+            LabelRelationship(type="subconcept_of", value=corporate_discloser)
+        ]
+
     author_values = navigator_family.metadata.get("author")
     if author_values and author_values[0]:
         author = author_values[0]
@@ -1548,6 +1599,7 @@ def _author_label(
                     id=f"author::{author}",
                     value=author,
                     type="author",
+                    labels=related_labels,
                 ),
             )
         )

--- a/data-in-pipeline/tests/extract/test_family_extract_step.py
+++ b/data-in-pipeline/tests/extract/test_family_extract_step.py
@@ -50,7 +50,7 @@ def test_extract_families_handles_valid_ids_success():
                 summary="Summary 1",
                 documents=[],
                 corpus=NavigatorCorpusFactory.build(
-                    import_id="COR-001",
+                    import_id="CCLW.corpus.i00000001.n0000",
                     corpus_type=NavigatorCorpusTypeFactory.build(name="corpus_type"),
                     organisation=NavigatorOrganisationFactory.build(
                         id=1, name="UNFCCC"
@@ -67,7 +67,7 @@ def test_extract_families_handles_valid_ids_success():
                 summary="Summary 2",
                 documents=[],
                 corpus=NavigatorCorpusFactory.build(
-                    import_id="COR-002",
+                    import_id="CPR.corpus.i00000001.n0000",
                     corpus_type=NavigatorCorpusTypeFactory.build(name="corpus_type"),
                     organisation=NavigatorOrganisationFactory.build(
                         id=1, name="UNFCCC"

--- a/data-in-pipeline/tests/identify/test_family_identify_step.py
+++ b/data-in-pipeline/tests/identify/test_family_identify_step.py
@@ -44,7 +44,7 @@ def test_fetch_family_success(base_config):
             title="Test Family",
             summary="Family summary",
             corpus=NavigatorCorpusFactory.build(
-                import_id="COR-111",
+                import_id="CCLW.corpus.i00000001.n0000",
                 corpus_type=NavigatorCorpusTypeFactory.build(name="corpus_type"),
                 organisation=NavigatorOrganisationFactory.build(id=1, name="UNFCCC"),
             ),
@@ -120,12 +120,12 @@ def test_fetch_all_families_successfully(base_config):
     flow_run_id = "flow-001"
 
     corpus_1 = NavigatorCorpusFactory.build(
-        import_id="COR-001",
+        import_id="CCLW.corpus.i00000001.n0000",
         corpus_type=NavigatorCorpusTypeFactory.build(name="corpus_type"),
         organisation=NavigatorOrganisationFactory.build(id=1, name="UNFCCC"),
     )
     corpus_2 = NavigatorCorpusFactory.build(
-        import_id="COR-002",
+        import_id="CPR.corpus.i00000001.n0000",
         corpus_type=NavigatorCorpusTypeFactory.build(name="corpus_type"),
         organisation=NavigatorOrganisationFactory.build(id=1, name="UNFCCC"),
     )
@@ -225,7 +225,7 @@ def test_fetch_all_families_handles_successful_retrievals_and_errors(base_config
                 title="Family 1",
                 summary="Family summary",
                 corpus=NavigatorCorpusFactory.build(
-                    import_id="COR-001",
+                    import_id="CCLW.corpus.i00000001.n0000",
                     corpus_type=NavigatorCorpusTypeFactory.build(name="corpus_type"),
                     organisation=NavigatorOrganisationFactory.build(
                         id=1, name="UNFCCC"

--- a/data-in-pipeline/tests/test_family_pipeline.py
+++ b/data-in-pipeline/tests/test_family_pipeline.py
@@ -69,7 +69,7 @@ def test_process_family_updates_flow_multiple_families(  # noqa: PLR0913
     mock_post.return_value = mock_post_response
 
     corpus = NavigatorCorpusFactory.build(
-        import_id="UNFCCC",
+        import_id="UNFCCC.corpus.i00000001.n0000",
         corpus_type=NavigatorCorpusTypeFactory.build(name="corpus_type"),
         organisation=NavigatorOrganisationFactory.build(id=1, name="UNFCCC"),
     )
@@ -226,7 +226,7 @@ def test_etl_pipeline_load_failure(  # noqa: PLR0913
     expected_error_message = "One or more batches failed to load"
 
     corpus = NavigatorCorpusFactory.build(
-        import_id="UNFCCC",
+        import_id="UNFCCC.corpus.i00000001.n0000",
         corpus_type=NavigatorCorpusTypeFactory.build(name="corpus_type"),
         organisation=NavigatorOrganisationFactory.build(id=1, name="UNFCCC"),
     )
@@ -314,7 +314,7 @@ def test_etl_pipeline_partial_transformation_failure(  # noqa: PLR0913
     mock_put.return_value = mock_put_response
 
     valid_corpus = NavigatorCorpusFactory.build(
-        import_id="UNFCCC",
+        import_id="UNFCCC.corpus.i00000001.n0000",
         corpus_type=NavigatorCorpusTypeFactory.build(name="corpus_type"),
         organisation=NavigatorOrganisationFactory.build(id=1, name="UNFCCC"),
     )
@@ -341,7 +341,7 @@ def test_etl_pipeline_partial_transformation_failure(  # noqa: PLR0913
         summary="",
         category="UNKNOWN_CATEGORY",
         corpus=NavigatorCorpusFactory.build(
-            import_id="UNKNOWN.corpus.i00000001.n0000",
+            import_id="CCLW.corpus.i00000001.n0000",
             corpus_type=NavigatorCorpusTypeFactory.build(name="Unknown"),
             organisation=NavigatorOrganisationFactory.build(id=999, name="Unknown"),
         ),
@@ -417,7 +417,7 @@ def test_etl_pipeline_all_families_fail_transformation(
     mock_connector_instance.close.return_value = None
 
     failing_corpus = NavigatorCorpusFactory.build(
-        import_id="UNKNOWN.corpus.i00000001.n0000",
+        import_id="CCLW.corpus.i00000001.n0000",
         corpus_type=NavigatorCorpusTypeFactory.build(name="Unknown"),
         organisation=NavigatorOrganisationFactory.build(id=999, name="Unknown"),
     )
@@ -640,19 +640,19 @@ def test_transform_correctly_transforms_collections_with_multiple_families():
                 ),
             ),
             LabelRelationship(
-                type="deprecated_category",
-                value=Label(
-                    id="deprecated_category::Laws and Policies",
-                    value="Laws and Policies",
-                    type="deprecated_category",
-                ),
-            ),
-            LabelRelationship(
                 type="category",
                 value=Label(
                     id="category::Law",
                     value="Law",
                     type="category",
+                ),
+            ),
+            LabelRelationship(
+                type="deprecated_category",
+                value=Label(
+                    id="deprecated_category::Laws and Policies",
+                    value="Laws and Policies",
+                    type="deprecated_category",
                 ),
             ),
         ],
@@ -721,19 +721,19 @@ def test_transform_correctly_transforms_collections_with_multiple_families():
                 ),
             ),
             LabelRelationship(
-                type="deprecated_category",
-                value=Label(
-                    id="deprecated_category::Laws and Policies",
-                    value="Laws and Policies",
-                    type="deprecated_category",
-                ),
-            ),
-            LabelRelationship(
                 type="category",
                 value=Label(
                     id="category::Law",
                     value="Law",
                     type="category",
+                ),
+            ),
+            LabelRelationship(
+                type="deprecated_category",
+                value=Label(
+                    id="deprecated_category::Laws and Policies",
+                    value="Laws and Policies",
+                    type="deprecated_category",
                 ),
             ),
         ],

--- a/data-in-pipeline/tests/transform/test_navigator_documents.py
+++ b/data-in-pipeline/tests/transform/test_navigator_documents.py
@@ -221,14 +221,6 @@ def test_transform_navigator_documents_litigation_events_without_documents():
                         ),
                     ),
                     LabelRelationship(
-                        type="category",
-                        value=Label(
-                            id="category::Litigation",
-                            value="Litigation",
-                            type="category",
-                        ),
-                    ),
-                    LabelRelationship(
                         type="geography",
                         value=Label(
                             type="region",
@@ -252,6 +244,14 @@ def test_transform_navigator_documents_litigation_events_without_documents():
                                     ),
                                 ),
                             ],
+                        ),
+                    ),
+                    LabelRelationship(
+                        type="category",
+                        value=Label(
+                            id="category::Litigation",
+                            value="Litigation",
+                            type="category",
                         ),
                     ),
                 ],

--- a/data-in-pipeline/tests/transform/test_navigator_family.py
+++ b/data-in-pipeline/tests/transform/test_navigator_family.py
@@ -17,6 +17,9 @@ from app.models import Identified
 from app.transform.navigator_family import (
     _author_label,
     _author_type_label,
+    _category_label,
+    _deprecated_category_label,
+    _entity_type_label,
     _multilateral_climate_fund_label,
     _un_convention_label,
     transform_navigator_family,
@@ -451,22 +454,6 @@ def test_transform_navigator_family_with_single_matching_document(
                 ),
             ),
             LabelRelationship(
-                type="deprecated_category",
-                value=Label(
-                    id="deprecated_category::Laws and Policies",
-                    value="Laws and Policies",
-                    type="deprecated_category",
-                ),
-            ),
-            LabelRelationship(
-                type="category",
-                value=Label(
-                    id="category::Policy",
-                    value="Policy",
-                    type="category",
-                ),
-            ),
-            LabelRelationship(
                 type="author",
                 value=Label(
                     id="author::Test Author",
@@ -480,6 +467,22 @@ def test_transform_navigator_family_with_single_matching_document(
                     id="author_type::Person",
                     type="author_type",
                     value="Person",
+                ),
+            ),
+            LabelRelationship(
+                type="category",
+                value=Label(
+                    id="category::Policy",
+                    value="Policy",
+                    type="category",
+                ),
+            ),
+            LabelRelationship(
+                type="deprecated_category",
+                value=Label(
+                    id="deprecated_category::Laws and Policies",
+                    value="Laws and Policies",
+                    type="deprecated_category",
                 ),
             ),
         ],
@@ -609,22 +612,6 @@ def test_transform_navigator_family_with_single_matching_document(
                             ),
                         ),
                         LabelRelationship(
-                            type="deprecated_category",
-                            value=Label(
-                                id="deprecated_category::Laws and Policies",
-                                value="Laws and Policies",
-                                type="deprecated_category",
-                            ),
-                        ),
-                        LabelRelationship(
-                            type="category",
-                            value=Label(
-                                id="category::Policy",
-                                value="Policy",
-                                type="category",
-                            ),
-                        ),
-                        LabelRelationship(
                             type="language",
                             value=Label(
                                 id="language::eng",
@@ -646,6 +633,22 @@ def test_transform_navigator_family_with_single_matching_document(
                                 id="status::Merged",
                                 value="Merged",
                                 type="status",
+                            ),
+                        ),
+                        LabelRelationship(
+                            type="category",
+                            value=Label(
+                                id="category::Policy",
+                                value="Policy",
+                                type="category",
+                            ),
+                        ),
+                        LabelRelationship(
+                            type="deprecated_category",
+                            value=Label(
+                                id="deprecated_category::Laws and Policies",
+                                value="Laws and Policies",
+                                type="deprecated_category",
                             ),
                         ),
                     ],
@@ -761,22 +764,6 @@ def test_transform_navigator_family_with_single_matching_document(
                         ),
                     ),
                     LabelRelationship(
-                        type="deprecated_category",
-                        value=Label(
-                            id="deprecated_category::Laws and Policies",
-                            value="Laws and Policies",
-                            type="deprecated_category",
-                        ),
-                    ),
-                    LabelRelationship(
-                        type="category",
-                        value=Label(
-                            id="category::Policy",
-                            value="Policy",
-                            type="category",
-                        ),
-                    ),
-                    LabelRelationship(
                         type="language",
                         value=Label(
                             id="language::eng",
@@ -798,6 +785,22 @@ def test_transform_navigator_family_with_single_matching_document(
                             id="status::Merged",
                             value="Merged",
                             type="status",
+                        ),
+                    ),
+                    LabelRelationship(
+                        type="category",
+                        value=Label(
+                            id="category::Policy",
+                            value="Policy",
+                            type="category",
+                        ),
+                    ),
+                    LabelRelationship(
+                        type="deprecated_category",
+                        value=Label(
+                            id="deprecated_category::Laws and Policies",
+                            value="Laws and Policies",
+                            type="deprecated_category",
                         ),
                     ),
                 ],
@@ -1012,22 +1015,6 @@ def test_transform_navigator_family_with_laws_and_policies_corpus_type(
                 ),
             ),
             LabelRelationship(
-                type="deprecated_category",
-                value=Label(
-                    id="deprecated_category::Laws and Policies",
-                    value="Laws and Policies",
-                    type="deprecated_category",
-                ),
-            ),
-            LabelRelationship(
-                type="category",
-                value=Label(
-                    id="category::Law",
-                    value="Law",
-                    type="category",
-                ),
-            ),
-            LabelRelationship(
                 type="topic",
                 value=Label(
                     id="topic::Mitigation",
@@ -1073,6 +1060,22 @@ def test_transform_navigator_family_with_laws_and_policies_corpus_type(
                     id="instrument::Planning|Governance",
                     value="Planning|Governance",
                     type="instrument",
+                ),
+            ),
+            LabelRelationship(
+                type="category",
+                value=Label(
+                    id="category::Law",
+                    value="Law",
+                    type="category",
+                ),
+            ),
+            LabelRelationship(
+                type="deprecated_category",
+                value=Label(
+                    id="deprecated_category::Laws and Policies",
+                    value="Laws and Policies",
+                    type="deprecated_category",
                 ),
             ),
         ],
@@ -1207,19 +1210,19 @@ def test_transform_navigator_family_with_published_and_unpublished_documents():
                 ),
             ),
             LabelRelationship(
-                type="deprecated_category",
-                value=Label(
-                    id="deprecated_category::Laws and Policies",
-                    value="Laws and Policies",
-                    type="deprecated_category",
-                ),
-            ),
-            LabelRelationship(
                 type="category",
                 value=Label(
                     id="category::Law",
                     value="Law",
                     type="category",
+                ),
+            ),
+            LabelRelationship(
+                type="deprecated_category",
+                value=Label(
+                    id="deprecated_category::Laws and Policies",
+                    value="Laws and Policies",
+                    type="deprecated_category",
                 ),
             ),
         ],
@@ -1270,11 +1273,11 @@ def test_transform_navigator_family_with_published_and_unpublished_documents():
                             ),
                         ),
                         LabelRelationship(
-                            type="deprecated_category",
+                            type="language",
                             value=Label(
-                                id="deprecated_category::Laws and Policies",
-                                value="Laws and Policies",
-                                type="deprecated_category",
+                                id="language::eng",
+                                value="eng",
+                                type="language",
                             ),
                         ),
                         LabelRelationship(
@@ -1286,11 +1289,11 @@ def test_transform_navigator_family_with_published_and_unpublished_documents():
                             ),
                         ),
                         LabelRelationship(
-                            type="language",
+                            type="deprecated_category",
                             value=Label(
-                                id="language::eng",
-                                value="eng",
-                                type="language",
+                                id="deprecated_category::Laws and Policies",
+                                value="Laws and Policies",
+                                type="deprecated_category",
                             ),
                         ),
                     ],
@@ -1360,11 +1363,11 @@ def test_transform_navigator_family_with_published_and_unpublished_documents():
                             ),
                         ),
                         LabelRelationship(
-                            type="deprecated_category",
+                            type="language",
                             value=Label(
-                                id="deprecated_category::Laws and Policies",
-                                value="Laws and Policies",
-                                type="deprecated_category",
+                                id="language::eng",
+                                value="eng",
+                                type="language",
                             ),
                         ),
                         LabelRelationship(
@@ -1376,11 +1379,11 @@ def test_transform_navigator_family_with_published_and_unpublished_documents():
                             ),
                         ),
                         LabelRelationship(
-                            type="language",
+                            type="deprecated_category",
                             value=Label(
-                                id="language::eng",
-                                value="eng",
-                                type="language",
+                                id="deprecated_category::Laws and Policies",
+                                value="Laws and Policies",
+                                type="deprecated_category",
                             ),
                         ),
                     ],
@@ -1458,11 +1461,11 @@ def test_transform_navigator_family_with_published_and_unpublished_documents():
                         ),
                     ),
                     LabelRelationship(
-                        type="deprecated_category",
+                        type="language",
                         value=Label(
-                            id="deprecated_category::Laws and Policies",
-                            value="Laws and Policies",
-                            type="deprecated_category",
+                            id="language::eng",
+                            value="eng",
+                            type="language",
                         ),
                     ),
                     LabelRelationship(
@@ -1474,11 +1477,11 @@ def test_transform_navigator_family_with_published_and_unpublished_documents():
                         ),
                     ),
                     LabelRelationship(
-                        type="language",
+                        type="deprecated_category",
                         value=Label(
-                            id="language::eng",
-                            value="eng",
-                            type="language",
+                            id="deprecated_category::Laws and Policies",
+                            value="Laws and Policies",
+                            type="deprecated_category",
                         ),
                     ),
                 ],
@@ -1553,11 +1556,11 @@ def test_transform_navigator_family_with_published_and_unpublished_documents():
                         ),
                     ),
                     LabelRelationship(
-                        type="deprecated_category",
+                        type="language",
                         value=Label(
-                            id="deprecated_category::Laws and Policies",
-                            value="Laws and Policies",
-                            type="deprecated_category",
+                            id="language::eng",
+                            value="eng",
+                            type="language",
                         ),
                     ),
                     LabelRelationship(
@@ -1569,11 +1572,11 @@ def test_transform_navigator_family_with_published_and_unpublished_documents():
                         ),
                     ),
                     LabelRelationship(
-                        type="language",
+                        type="deprecated_category",
                         value=Label(
-                            id="language::eng",
-                            value="eng",
-                            type="language",
+                            id="deprecated_category::Laws and Policies",
+                            value="Laws and Policies",
+                            type="deprecated_category",
                         ),
                     ),
                 ],
@@ -1715,19 +1718,19 @@ def test_transform_navigator_family_with_no_published_documents():
                 ),
             ),
             LabelRelationship(
-                type="deprecated_category",
-                value=Label(
-                    id="deprecated_category::Laws and Policies",
-                    value="Laws and Policies",
-                    type="deprecated_category",
-                ),
-            ),
-            LabelRelationship(
                 type="category",
                 value=Label(
                     id="category::Law",
                     value="Law",
                     type="category",
+                ),
+            ),
+            LabelRelationship(
+                type="deprecated_category",
+                value=Label(
+                    id="deprecated_category::Laws and Policies",
+                    value="Laws and Policies",
+                    type="deprecated_category",
                 ),
             ),
         ],
@@ -1778,11 +1781,11 @@ def test_transform_navigator_family_with_no_published_documents():
                             ),
                         ),
                         LabelRelationship(
-                            type="deprecated_category",
+                            type="language",
                             value=Label(
-                                id="deprecated_category::Laws and Policies",
-                                value="Laws and Policies",
-                                type="deprecated_category",
+                                id="language::eng",
+                                value="eng",
+                                type="language",
                             ),
                         ),
                         LabelRelationship(
@@ -1794,11 +1797,11 @@ def test_transform_navigator_family_with_no_published_documents():
                             ),
                         ),
                         LabelRelationship(
-                            type="language",
+                            type="deprecated_category",
                             value=Label(
-                                id="language::eng",
-                                value="eng",
-                                type="language",
+                                id="deprecated_category::Laws and Policies",
+                                value="Laws and Policies",
+                                type="deprecated_category",
                             ),
                         ),
                     ],
@@ -1875,11 +1878,11 @@ def test_transform_navigator_family_with_no_published_documents():
                         ),
                     ),
                     LabelRelationship(
-                        type="deprecated_category",
+                        type="language",
                         value=Label(
-                            id="deprecated_category::Laws and Policies",
-                            value="Laws and Policies",
-                            type="deprecated_category",
+                            id="language::eng",
+                            value="eng",
+                            type="language",
                         ),
                     ),
                     LabelRelationship(
@@ -1891,11 +1894,11 @@ def test_transform_navigator_family_with_no_published_documents():
                         ),
                     ),
                     LabelRelationship(
-                        type="language",
+                        type="deprecated_category",
                         value=Label(
-                            id="language::eng",
-                            value="eng",
-                            type="language",
+                            id="deprecated_category::Laws and Policies",
+                            value="Laws and Policies",
+                            type="deprecated_category",
                         ),
                     ),
                 ],
@@ -2052,19 +2055,19 @@ def test_transform_navigator_family_and_document_with_domain_metadata(
                             ),
                         ),
                         LabelRelationship(
-                            type="deprecated_category",
-                            value=Label(
-                                id="deprecated_category::Laws and Policies",
-                                value="Laws and Policies",
-                                type="deprecated_category",
-                            ),
-                        ),
-                        LabelRelationship(
                             type="language",
                             value=Label(
                                 id="language::eng",
                                 value="eng",
                                 type="language",
+                            ),
+                        ),
+                        LabelRelationship(
+                            type="deprecated_category",
+                            value=Label(
+                                id="deprecated_category::Laws and Policies",
+                                value="Laws and Policies",
+                                type="deprecated_category",
                             ),
                         ),
                     ],
@@ -2156,19 +2159,19 @@ def test_transform_navigator_family_and_document_with_domain_metadata(
                         ),
                     ),
                     LabelRelationship(
-                        type="deprecated_category",
-                        value=Label(
-                            id="deprecated_category::Laws and Policies",
-                            value="Laws and Policies",
-                            type="deprecated_category",
-                        ),
-                    ),
-                    LabelRelationship(
                         type="language",
                         value=Label(
                             id="language::eng",
                             value="eng",
                             type="language",
+                        ),
+                    ),
+                    LabelRelationship(
+                        type="deprecated_category",
+                        value=Label(
+                            id="deprecated_category::Laws and Policies",
+                            value="Laws and Policies",
+                            type="deprecated_category",
                         ),
                     ),
                 ],
@@ -2297,3 +2300,122 @@ def test_author_label_returns_empty_when_no_metadata():
         metadata={},
     )
     assert _author_label(family) == []
+
+
+def test_category_label_returns_law_for_legislative():
+    family = NavigatorFamilyFactory.build(
+        corpus=NavigatorCorpusFactory.build(import_id="CCLW.corpus.i00000001.n0000"),
+        category="LEGISLATIVE",
+    )
+    labels = _category_label(family)
+    assert len(labels) == 1
+    assert labels[0].type == "category"
+    assert labels[0].value.id == "category::Law"
+
+
+def test_category_label_returns_policy_for_executive():
+    family = NavigatorFamilyFactory.build(
+        corpus=NavigatorCorpusFactory.build(import_id="CCLW.corpus.i00000001.n0000"),
+        category="EXECUTIVE",
+    )
+    labels = _category_label(family)
+    assert len(labels) == 1
+    assert labels[0].type == "category"
+    assert labels[0].value.id == "category::Policy"
+
+
+def test_category_label_returns_empty_for_laws_and_policies_with_no_matching_category():
+    family = NavigatorFamilyFactory.build(
+        corpus=NavigatorCorpusFactory.build(import_id="CCLW.corpus.i00000001.n0000"),
+        category="UNFCCC",
+    )
+    assert _category_label(family) == []
+
+
+@pytest.mark.parametrize(
+    "corpus_import_id, expected_category",
+    [
+        ("UNFCCC.corpus.i00000001.n0000", "UN submission"),
+        ("OEP.corpus.i00000001.n0000", "Report"),
+        ("Academic.corpus.Litigation.n0000", "Litigation"),
+        ("CPR.corpus.i00000002.n0000", "Corporate Disclosure"),
+    ],
+)
+def test_category_label_returns_category_for_non_laws_and_policies(
+    corpus_import_id, expected_category
+):
+    family = NavigatorFamilyFactory.build(
+        corpus=NavigatorCorpusFactory.build(import_id=corpus_import_id),
+    )
+    labels = _category_label(family)
+    assert len(labels) == 1
+    assert labels[0].type == "category"
+    assert labels[0].value.id == f"category::{expected_category}"
+
+
+def test_deprecated_category_label_returns_label_for_laws_and_policies_corpus_type():
+    family = NavigatorFamilyFactory.build(
+        corpus=NavigatorCorpusFactory.build(
+            import_id="CCLW.corpus.i00000001.n0000",
+            corpus_type=NavigatorCorpusTypeFactory.build(name="Laws and Policies"),
+        ),
+    )
+    labels = _deprecated_category_label(family)
+    assert len(labels) == 1
+    assert labels[0].type == "deprecated_category"
+    assert labels[0].value.id == "deprecated_category::Laws and Policies"
+
+
+def test_deprecated_category_label_returns_empty_for_non_laws_and_policies_corpus_type():
+    family = NavigatorFamilyFactory.build(
+        corpus=NavigatorCorpusFactory.build(
+            import_id="UNFCCC.corpus.i00000001.n0000",
+            corpus_type=NavigatorCorpusTypeFactory.build(name="UNFCCC"),
+        ),
+    )
+    assert _deprecated_category_label(family) == []
+
+
+@pytest.mark.parametrize(
+    "corpus_import_id",
+    [
+        "MCF.corpus.AF.Guidance",
+        "MCF.corpus.CIF.Guidance",
+        "MCF.corpus.GCF.Guidance",
+        "MCF.corpus.GEF.Guidance",
+    ],
+)
+def test_entity_type_label_returns_guidance_for_mcf_guidance_corpus(corpus_import_id):
+    family = NavigatorFamilyFactory.build(
+        corpus=NavigatorCorpusFactory.build(import_id=corpus_import_id),
+    )
+    labels = _entity_type_label(family)
+    assert len(labels) == 1
+    assert labels[0].type == "entity_type"
+    assert labels[0].value.id == "entity_type::Guidance"
+
+
+@pytest.mark.parametrize(
+    "corpus_import_id",
+    [
+        "MCF.corpus.AF.n0000",
+        "MCF.corpus.CIF.n0000",
+        "MCF.corpus.GCF.n0000",
+        "MCF.corpus.GEF.n0000",
+    ],
+)
+def test_entity_type_label_returns_project_for_mcf_project_corpus(corpus_import_id):
+    family = NavigatorFamilyFactory.build(
+        corpus=NavigatorCorpusFactory.build(import_id=corpus_import_id),
+    )
+    labels = _entity_type_label(family)
+    assert len(labels) == 1
+    assert labels[0].type == "entity_type"
+    assert labels[0].value.id == "entity_type::Project"
+
+
+def test_entity_type_label_returns_empty_for_non_mcf_corpus():
+    family = NavigatorFamilyFactory.build(
+        corpus=NavigatorCorpusFactory.build(import_id="CCLW.corpus.i00000001.n0000"),
+    )
+    assert _entity_type_label(family) == []

--- a/data-in-pipeline/tests/transform/test_navigator_family_GST1.py
+++ b/data-in-pipeline/tests/transform/test_navigator_family_GST1.py
@@ -37,7 +37,7 @@ from tests.transform.assertions import assert_model_list_equality
         #
         # invalid cases - Party
         (
-            "Invalid.corpus.i00000001.n0000",
+            "CCLW.corpus.i00000001.n0000",
             "Party",
             "2023-11-30T00:00:00Z",
             False,
@@ -57,7 +57,7 @@ from tests.transform.assertions import assert_model_list_equality
         #
         # invalid cases - Non-Party
         (
-            "Invalid.corpus.i00000001.n0000",
+            "CCLW.corpus.i00000001.n0000",
             "Non-Party",
             "2023-11-30T00:00:00Z",
             False,
@@ -313,19 +313,19 @@ def test_transform_navigator_family_UNFCCC_party_submission_to_GST1_label():
                             ),
                         ),
                         LabelRelationship(
-                            type="category",
-                            value=Label(
-                                id="category::UN submission",
-                                value="UN submission",
-                                type="category",
-                            ),
-                        ),
-                        LabelRelationship(
                             type="language",
                             value=Label(
                                 id="language::eng",
                                 value="eng",
                                 type="language",
+                            ),
+                        ),
+                        LabelRelationship(
+                            type="category",
+                            value=Label(
+                                id="category::UN submission",
+                                value="UN submission",
+                                type="category",
                             ),
                         ),
                     ],
@@ -411,19 +411,19 @@ def test_transform_navigator_family_UNFCCC_party_submission_to_GST1_label():
                         ),
                     ),
                     LabelRelationship(
-                        type="category",
-                        value=Label(
-                            id="category::UN submission",
-                            value="UN submission",
-                            type="category",
-                        ),
-                    ),
-                    LabelRelationship(
                         type="language",
                         value=Label(
                             id="language::eng",
                             value="eng",
                             type="language",
+                        ),
+                    ),
+                    LabelRelationship(
+                        type="category",
+                        value=Label(
+                            id="category::UN submission",
+                            value="UN submission",
+                            type="category",
                         ),
                     ),
                 ],
@@ -668,19 +668,19 @@ def test_transform_navigator_family_UNFCCC_non_party_submission_to_GST1_label():
                             ),
                         ),
                         LabelRelationship(
-                            type="category",
-                            value=Label(
-                                id="category::UN submission",
-                                value="UN submission",
-                                type="category",
-                            ),
-                        ),
-                        LabelRelationship(
                             type="language",
                             value=Label(
                                 id="language::eng",
                                 value="eng",
                                 type="language",
+                            ),
+                        ),
+                        LabelRelationship(
+                            type="category",
+                            value=Label(
+                                id="category::UN submission",
+                                value="UN submission",
+                                type="category",
                             ),
                         ),
                     ],
@@ -766,19 +766,19 @@ def test_transform_navigator_family_UNFCCC_non_party_submission_to_GST1_label():
                         ),
                     ),
                     LabelRelationship(
-                        type="category",
-                        value=Label(
-                            id="category::UN submission",
-                            value="UN submission",
-                            type="category",
-                        ),
-                    ),
-                    LabelRelationship(
                         type="language",
                         value=Label(
                             id="language::eng",
                             value="eng",
                             type="language",
+                        ),
+                    ),
+                    LabelRelationship(
+                        type="category",
+                        value=Label(
+                            id="category::UN submission",
+                            value="UN submission",
+                            type="category",
                         ),
                     ),
                 ],

--- a/data-in-pipeline/tests/transform/test_navigator_family_litigation.py
+++ b/data-in-pipeline/tests/transform/test_navigator_family_litigation.py
@@ -354,20 +354,20 @@ def test_transform_navigator_family_with_litigation_corpus_type(
                 ),
             ),
             LabelRelationship(
-                type="category",
-                value=Label(
-                    id="category::Litigation",
-                    value="Litigation",
-                    type="category",
-                ),
-            ),
-            LabelRelationship(
                 type="activity_status",
                 timestamp=datetime.datetime(2020, 1, 1),
                 value=Label(
                     type="activity_status",
                     id="activity_status::Filed",
                     value="Filed",
+                ),
+            ),
+            LabelRelationship(
+                type="category",
+                value=Label(
+                    id="category::Litigation",
+                    value="Litigation",
+                    type="category",
                 ),
             ),
         ],
@@ -660,14 +660,6 @@ def test_transform_navigator_family_with_litigation_corpus_type_and_litigation_c
                 ),
             ),
             LabelRelationship(
-                type="category",
-                value=Label(
-                    id="category::Litigation",
-                    value="Litigation",
-                    type="category",
-                ),
-            ),
-            LabelRelationship(
                 type="legal_concept",
                 value=LabelWithoutDocumentRelationships(
                     id="jurisdiction::High Court of Justice",
@@ -712,6 +704,14 @@ def test_transform_navigator_family_with_litigation_corpus_type_and_litigation_c
                     labels=[],
                     type="jurisdiction",
                     value="England and Wales",
+                ),
+            ),
+            LabelRelationship(
+                type="category",
+                value=Label(
+                    id="category::Litigation",
+                    value="Litigation",
+                    type="category",
                 ),
             ),
         ],

--- a/data-in-pipeline/tests/transform/test_navigator_family_mcf.py
+++ b/data-in-pipeline/tests/transform/test_navigator_family_mcf.py
@@ -275,14 +275,6 @@ def test_transform_navigator_family_with_multilateral_climate_fund_project(
                 ),
             ),
             LabelRelationship(
-                type="category",
-                value=Label(
-                    id="category::Multilateral Climate Fund project",
-                    value="Multilateral Climate Fund project",
-                    type="category",
-                ),
-            ),
-            LabelRelationship(
                 type="sector",
                 value=Label(
                     id="sector::Public Sector",
@@ -304,6 +296,14 @@ def test_transform_navigator_family_with_multilateral_climate_fund_project(
                     id="implementing_agency::International Bank for Reconstruction",
                     type="implementing_agency",
                     value="International Bank for Reconstruction",
+                ),
+            ),
+            LabelRelationship(
+                type="category",
+                value=Label(
+                    id="category::Multilateral Climate Fund project",
+                    value="Multilateral Climate Fund project",
+                    type="category",
                 ),
             ),
             LabelRelationship(
@@ -336,27 +336,19 @@ def test_transform_navigator_family_with_multilateral_climate_fund_project(
                             ),
                         ),
                         LabelRelationship(
-                            type="category",
-                            value=Label(
-                                id="category::Multilateral Climate Fund project",
-                                value="Multilateral Climate Fund project",
-                                type="category",
-                            ),
-                        ),
-                        LabelRelationship(
-                            type="entity_type",
-                            value=Label(
-                                id="entity_type::Project",
-                                value="Project",
-                                type="entity_type",
-                            ),
-                        ),
-                        LabelRelationship(
                             type="language",
                             value=Label(
                                 id="language::eng",
                                 value="eng",
                                 type="language",
+                            ),
+                        ),
+                        LabelRelationship(
+                            type="category",
+                            value=Label(
+                                id="category::Multilateral Climate Fund project",
+                                value="Multilateral Climate Fund project",
+                                type="category",
                             ),
                         ),
                     ],
@@ -388,22 +380,6 @@ def test_transform_navigator_family_with_multilateral_climate_fund_project(
                             ),
                         ),
                         LabelRelationship(
-                            type="category",
-                            value=Label(
-                                id="category::Multilateral Climate Fund project",
-                                value="Multilateral Climate Fund project",
-                                type="category",
-                            ),
-                        ),
-                        LabelRelationship(
-                            type="entity_type",
-                            value=Label(
-                                id="entity_type::Project",
-                                value="Project",
-                                type="entity_type",
-                            ),
-                        ),
-                        LabelRelationship(
                             type="language",
                             value=Label(
                                 id="language::eng",
@@ -417,6 +393,14 @@ def test_transform_navigator_family_with_multilateral_climate_fund_project(
                                 id="status::Merged",
                                 value="Merged",
                                 type="status",
+                            ),
+                        ),
+                        LabelRelationship(
+                            type="category",
+                            value=Label(
+                                id="category::Multilateral Climate Fund project",
+                                value="Multilateral Climate Fund project",
+                                type="category",
                             ),
                         ),
                     ],
@@ -461,27 +445,19 @@ def test_transform_navigator_family_with_multilateral_climate_fund_project(
                         ),
                     ),
                     LabelRelationship(
-                        type="category",
-                        value=Label(
-                            id="category::Multilateral Climate Fund project",
-                            value="Multilateral Climate Fund project",
-                            type="category",
-                        ),
-                    ),
-                    LabelRelationship(
-                        type="entity_type",
-                        value=Label(
-                            id="entity_type::Project",
-                            value="Project",
-                            type="entity_type",
-                        ),
-                    ),
-                    LabelRelationship(
                         type="language",
                         value=Label(
                             id="language::eng",
                             value="eng",
                             type="language",
+                        ),
+                    ),
+                    LabelRelationship(
+                        type="category",
+                        value=Label(
+                            id="category::Multilateral Climate Fund project",
+                            value="Multilateral Climate Fund project",
+                            type="category",
                         ),
                     ),
                 ],
@@ -518,22 +494,6 @@ def test_transform_navigator_family_with_multilateral_climate_fund_project(
                         ),
                     ),
                     LabelRelationship(
-                        type="category",
-                        value=Label(
-                            id="category::Multilateral Climate Fund project",
-                            value="Multilateral Climate Fund project",
-                            type="category",
-                        ),
-                    ),
-                    LabelRelationship(
-                        type="entity_type",
-                        value=Label(
-                            id="entity_type::Project",
-                            value="Project",
-                            type="entity_type",
-                        ),
-                    ),
-                    LabelRelationship(
                         type="language",
                         value=Label(
                             id="language::eng",
@@ -547,6 +507,14 @@ def test_transform_navigator_family_with_multilateral_climate_fund_project(
                             id="status::Merged",
                             value="Merged",
                             type="status",
+                        ),
+                    ),
+                    LabelRelationship(
+                        type="category",
+                        value=Label(
+                            id="category::Multilateral Climate Fund project",
+                            value="Multilateral Climate Fund project",
+                            type="category",
                         ),
                     ),
                 ],


### PR DESCRIPTION
# What does this do?

- moves `category`, `deprecated_category` and partial `entity_type` to the clearer label transformers
- adds `subconcept_of` to MCFs for `Project` & `Guidance` labels 
- removes `Project` & `Guidance` from non-Principal documents (this was a mistake)
- adds `subconcept_of` to `author` for `Corporate Disclosure`
- adds more granular label type tests


## Why is it needed?

- to start 

## How was it tested?

- pytest

The tests are mostly reordering of the labels

---

part of https://linear.app/climate-policy-radar/issue/APP-2084/extend-labels-to-support-current-search-filters

part of https://linear.app/climate-policy-radar/issue/APP-2088/move-transformnavigator-family-1-transformer-label-pattern
