### PR TITLE
Fix create dedicated transformation warning for missing region mapping

### DIFF
--- a/data-in-pipeline/app/transform/models.py
+++ b/data-in-pipeline/app/transform/models.py
@@ -51,9 +51,17 @@ class UnknownGeography(BaseModel):
     geography_id: str
 
 
+class MissingRegionMapping(BaseModel):
+    """A known country could not be mapped to a region."""
+
+    kind: Literal["missing_region_mapping"] = "missing_region_mapping"
+    family_import_id: str
+    geography_id: str
+
+
 # Discriminated union — `kind` is the discriminator field.
 # @see: https://docs.pydantic.dev/latest/concepts/unions/#discriminated-unions
 type TransformWarning = Annotated[
-    UnknownParentLabel | UnknownGeography,
+    UnknownParentLabel | UnknownGeography | MissingRegionMapping,
     Field(discriminator="kind"),
 ]

--- a/data-in-pipeline/app/transform/navigator_family.py
+++ b/data-in-pipeline/app/transform/navigator_family.py
@@ -31,6 +31,7 @@ from app.geographies import (
 from app.models import Identified, NavigatorConcept
 from app.transform.models import (
     CouldNotTransform,
+    MissingRegionMapping,
     TransformWarning,
     UnknownGeography,
     UnknownParentLabel,
@@ -629,7 +630,7 @@ def _transform_geographies(
                 )
             elif geography.id not in _eu_and_international_region_ids:
                 warnings.append(
-                    UnknownGeography(
+                    MissingRegionMapping(
                         family_import_id=navigator_family.import_id,
                         geography_id=geography.id,
                     )

--- a/data-in-pipeline/app/transform/navigator_family.py
+++ b/data-in-pipeline/app/transform/navigator_family.py
@@ -40,7 +40,7 @@ from app.transform.models import (
 # Constants
 # ---------------------------------------------------------------------------
 
-_custom_countries_by_id = {c.id: c for c in custom_countries}
+_eu_and_international_region_ids = {c.id: c for c in custom_countries}
 
 _corpus_to_provider_map = {
     "CCLW.corpus.i00000001.n0000": "Grantham Research Institute",
@@ -627,7 +627,7 @@ def _transform_geographies(
                         value=region_label,
                     )
                 )
-            elif geography.id not in _custom_countries_by_id:
+            elif geography.id not in _eu_and_international_region_ids:
                 warnings.append(
                     UnknownGeography(
                         family_import_id=navigator_family.import_id,

--- a/data-in-pipeline/app/transform/navigator_family.py
+++ b/data-in-pipeline/app/transform/navigator_family.py
@@ -24,6 +24,7 @@ from app.geographies import (
     Country,
     Subdivision,
     countries_by_alpha_2,
+    custom_countries,
     geographies_lookup,
     regions_lookup,
 )
@@ -38,6 +39,8 @@ from app.transform.models import (
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
+
+_custom_countries_by_id = {c.id: c for c in custom_countries}
 
 _corpus_to_provider_map = {
     "CCLW.corpus.i00000001.n0000": "Grantham Research Institute",
@@ -624,7 +627,7 @@ def _transform_geographies(
                         value=region_label,
                     )
                 )
-            else:
+            elif geography.id not in _custom_countries_by_id:
                 warnings.append(
                     UnknownGeography(
                         family_import_id=navigator_family.import_id,

--- a/data-in-pipeline/tests/factories.py
+++ b/data-in-pipeline/tests/factories.py
@@ -4,7 +4,7 @@ Use ModelFactory.build(...) with overrides for specific test data; factories
 fill the rest with sensible defaults.
 """
 
-from data_in_models.models import DocumentWithoutRelationships
+from data_in_models.models import Document, DocumentWithoutRelationships
 from polyfactory.factories.pydantic_factory import ModelFactory
 
 from app.extract.connectors import (
@@ -58,3 +58,7 @@ class ExtractedMetadataFactory(ModelFactory[ExtractedMetadata]):
 
 class DocumentWithoutRelationshipsFactory(ModelFactory[DocumentWithoutRelationships]):
     """Factory for DocumentWithoutRelationships. Override id, title, labels, items."""
+
+
+class DocumentFactory(ModelFactory[Document]):
+    """Factory for Document. Override id, title, labels, items."""


### PR DESCRIPTION
The errors for unknown geographies and missing region mappings are being conflated and becoming semantically incorrect.

It will be able to tell what the geography warning is showing up for.

```
"kind='unknown_geography' family_import_id='Sabin.family.88912.0' geography_id='VAT'",
"kind='unknown_geography' family_import_id='Sabin.family.88912.0' geography_id='VAT'",
"kind='unknown_geography' family_import_id='CCLW.family.i00004374.n0000' geography_id='TWN'",
"kind='unknown_geography' family_import_id='CCLW.family.i00004407.n0000' geography_id='TWN'",
```