### PR TITLE
fix: add law and MCF label types

### DIFF
--- a/data-in-pipeline/app/transform/navigator_family.py
+++ b/data-in-pipeline/app/transform/navigator_family.py
@@ -47,6 +47,7 @@ from app.transform.models import (
 corporate_discloser = Label(
     type="category", id="category::Corporate Disclosures", value="Corporate Disclosures"
 )
+
 multilateral_climate_fund_project = Label(
     type="category",
     id="category::Multilateral Climate Fund project",
@@ -68,6 +69,8 @@ multilateral_climate_fund_project_project = Label(
         LabelRelationship(type="subconcept_of", value=multilateral_climate_fund_project)
     ],
 )
+
+law = Label(type="category", id="category::Law", value="Law")
 
 
 _eu_and_international_region_ids = {c.id: c for c in custom_countries}
@@ -1138,6 +1141,10 @@ def _transform_navigator_family(
         + _entity_type_label(navigator_family)
         + _author_label(navigator_family)
         + _author_type_label(navigator_family)
+        + _topic_label(navigator_family)
+        + _law_type_label(navigator_family)
+        + _status_label(navigator_family)
+        + _implementing_agency_label(navigator_family)
         + _un_convention_label(navigator_family)
         + _multilateral_climate_fund_label(navigator_family)
     )
@@ -1648,6 +1655,172 @@ def _author_type_label(
     return labels
 
 
+# region topic label
+# This is also known as "response area" in the UI
+def _topic_label(
+    navigator_family: NavigatorFamily,
+) -> list[LabelRelationship]:
+    labels: list[LabelRelationship] = []
+
+    # These are controlled vocabularies
+    # @see: https://github.com/climatepolicyradar/data-migrations/blob/main/taxonomies/Laws%20and%20Policies.json#L15-L18
+    topic_values = navigator_family.metadata.get("topic")
+    if topic_values and topic_values[0]:
+        topic = topic_values[0]
+        labels.append(
+            LabelRelationship(
+                type="topic",
+                value=Label(
+                    id=f"topic::{topic}",
+                    value=topic,
+                    type="topic",
+                    labels=[LabelRelationship(type="subconcept_of", value=law)],
+                ),
+            )
+        )
+
+    # These are controlled vocabularies
+    # @see: https://github.com/climatepolicyradar/data-migrations/blob/main/taxonomies/Laws%20and%20Policies.json#L496-L498
+    framework_values = navigator_family.metadata.get("framework")
+
+    # Only Mitigation makes this a Framework law
+    if framework_values and framework_values[0] in ["Mitigation"]:
+        topic = framework_values[0]
+        labels.append(
+            LabelRelationship(
+                type="law_type",
+                value=Label(
+                    id=f"law_type::{topic}",
+                    value="Framework law",
+                    type="law_type",
+                    labels=[LabelRelationship(type="subconcept_of", value=law)],
+                ),
+            )
+        )
+    return labels
+
+
+# region law_type label
+def _law_type_label(
+    navigator_family: NavigatorFamily,
+) -> list[LabelRelationship]:
+    labels: list[LabelRelationship] = []
+
+    # These are controlled vocabularies
+    # @see: https://github.com/climatepolicyradar/data-migrations/blob/main/taxonomies/Laws%20and%20Policies.json#L490-L494
+    framework_values = navigator_family.metadata.get("framework")
+
+    # Only Mitigation makes this a Framework law
+    if framework_values and framework_values[0] in [
+        "Adaptation",
+        "Mitigation",
+        "Drm/Drr",
+    ]:
+        topic = framework_values[0]
+        labels.append(
+            LabelRelationship(
+                type="law_type",
+                value=Label(
+                    id=f"law_type::{topic}",
+                    value="Framework law",
+                    type="law_type",
+                    labels=[LabelRelationship(type="subconcept_of", value=law)],
+                ),
+            )
+        )
+    return labels
+
+
+# region status label
+def _status_label(
+    navigator_family: NavigatorFamily,
+) -> list[LabelRelationship]:
+    labels: list[LabelRelationship] = []
+
+    # These are controlled vocabularies
+    # @see: https://github.com/climatepolicyradar/data-migrations/blob/main/taxonomies/GCF.json#L44-L48
+    status_values = navigator_family.metadata.get("status")
+    if status_values and status_values[0]:
+        status = status_values[0]
+        labels.append(
+            LabelRelationship(
+                type="status",
+                value=Label(
+                    id=f"status::{status}",
+                    value=status,
+                    type="status",
+                    labels=[
+                        LabelRelationship(
+                            type="subconcept_of",
+                            value=multilateral_climate_fund_project_project,
+                        )
+                    ],
+                ),
+            )
+        )
+    return labels
+
+
+# region implementing_agency label
+def _implementing_agency_label(
+    navigator_family: NavigatorFamily,
+) -> list[LabelRelationship]:
+    labels: list[LabelRelationship] = []
+
+    # These are controlled vocabularies
+    # @see: https://github.com/climatepolicyradar/data-migrations/blob/main/taxonomies/GCF.json#L44-L48
+    status_values = navigator_family.metadata.get("implementing_agency")
+    if status_values and status_values[0]:
+        status = status_values[0]
+        labels.append(
+            LabelRelationship(
+                type="implementing_agency",
+                value=Label(
+                    id=f"agent::{status}",
+                    value=status,
+                    type="agent",
+                    labels=[
+                        LabelRelationship(
+                            type="subconcept_of",
+                            value=multilateral_climate_fund_project_project,
+                        )
+                    ],
+                ),
+            )
+        )
+    return labels
+
+
+# region multilateral_climate_fund label
+def _multilateral_climate_fund_label(
+    navigator_family: NavigatorFamily,
+) -> list[LabelRelationship]:
+    labels: list[LabelRelationship] = []
+    if navigator_family.corpus.import_id in MCF_CORPORA:
+        multilateral_climate_fund = _corpus_import_id_to_multilateral_climate_fund.get(
+            navigator_family.corpus.import_id
+        )
+        if multilateral_climate_fund:
+            labels.append(
+                LabelRelationship(
+                    type="multilateral_climate_fund",
+                    value=Label(
+                        id=f"agent::{multilateral_climate_fund}",
+                        value=multilateral_climate_fund,
+                        type="agent",
+                        labels=[
+                            LabelRelationship(
+                                type="subconcept_of",
+                                value=multilateral_climate_fund_project,
+                            )
+                        ],
+                    ),
+                )
+            )
+
+    return labels
+
+
 # region un_convention label
 _corpus_import_id_to_un_convention = {
     "UNFCCC.corpus.i00000001.n0000": "UNFCCC",
@@ -1685,26 +1858,3 @@ _corpus_import_id_to_multilateral_climate_fund = {
     "MCF.corpus.GCF.n0000": "Global Environment Facility",
     "MCF.corpus.GEF.n0000": "Green Climate Fund",
 }
-
-
-def _multilateral_climate_fund_label(
-    navigator_family: NavigatorFamily,
-) -> list[LabelRelationship]:
-    labels: list[LabelRelationship] = []
-    if navigator_family.corpus.import_id in MCF_CORPORA:
-        multilateral_climate_fund = _corpus_import_id_to_multilateral_climate_fund.get(
-            navigator_family.corpus.import_id
-        )
-        if multilateral_climate_fund:
-            labels.append(
-                LabelRelationship(
-                    type="multilateral_climate_fund",
-                    value=Label(
-                        id=f"multilateral_climate_fund::{multilateral_climate_fund}",
-                        value=multilateral_climate_fund,
-                        type="multilateral_climate_fund",
-                    ),
-                )
-            )
-
-    return labels

--- a/data-in-pipeline/tests/transform/test_navigator_family.py
+++ b/data-in-pipeline/tests/transform/test_navigator_family.py
@@ -2013,9 +2013,9 @@ def test_transform_to_category_corpus_ids(corpus_id: str, expected_category: str
     family_doc = result[0]
 
     category_labels = [label for label in family_doc.labels if label.type == "category"]
-    assert any(label.value.id == expected_category for label in category_labels), (
-        f"Expected category '{expected_category}' not found in labels for corpus '{corpus_id}'"
-    )
+    assert any(
+        label.value.id == expected_category for label in category_labels
+    ), f"Expected category '{expected_category}' not found in labels for corpus '{corpus_id}'"
 
 
 def test_transform_navigator_family_and_document_with_domain_metadata(

--- a/data-in-pipeline/tests/transform/test_navigator_family.py
+++ b/data-in-pipeline/tests/transform/test_navigator_family.py
@@ -20,7 +20,11 @@ from app.transform.navigator_family import (
     _category_label,
     _deprecated_category_label,
     _entity_type_label,
+    _implementing_agency_label,
+    _law_type_label,
     _multilateral_climate_fund_label,
+    _status_label,
+    _topic_label,
     _un_convention_label,
     transform_navigator_family,
 )
@@ -1078,6 +1082,24 @@ def test_transform_navigator_family_with_laws_and_policies_corpus_type(
                     type="deprecated_category",
                 ),
             ),
+            LabelRelationship(
+                type="law_type",
+                value=Label(
+                    id="law_type::Mitigation",
+                    value="Framework law",
+                    type="law_type",
+                    labels=[
+                        LabelRelationship(
+                            type="subconcept_of",
+                            value=Label(
+                                id="category::Law",
+                                value="Law",
+                                type="category",
+                            ),
+                        )
+                    ],
+                ),
+            ),
         ],
         documents=[],
         attributes={
@@ -1991,9 +2013,9 @@ def test_transform_to_category_corpus_ids(corpus_id: str, expected_category: str
     family_doc = result[0]
 
     category_labels = [label for label in family_doc.labels if label.type == "category"]
-    assert any(
-        label.value.id == expected_category for label in category_labels
-    ), f"Expected category '{expected_category}' not found in labels for corpus '{corpus_id}'"
+    assert any(label.value.id == expected_category for label in category_labels), (
+        f"Expected category '{expected_category}' not found in labels for corpus '{corpus_id}'"
+    )
 
 
 def test_transform_navigator_family_and_document_with_domain_metadata(
@@ -2272,7 +2294,7 @@ def test_multilateral_climate_fund_label_returns_label(corpus_import_id, expecte
     labels = _multilateral_climate_fund_label(family)
     assert len(labels) == 1
     assert labels[0].type == "multilateral_climate_fund"
-    assert labels[0].value.id == f"multilateral_climate_fund::{expected_fund}"
+    assert labels[0].value.id == f"agent::{expected_fund}"
 
 
 def test_multilateral_climate_fund_label_returns_empty_for_non_mcf_corpus():
@@ -2419,3 +2441,230 @@ def test_entity_type_label_returns_empty_for_non_mcf_corpus():
         corpus=NavigatorCorpusFactory.build(import_id="CCLW.corpus.i00000001.n0000"),
     )
     assert _entity_type_label(family) == []
+
+
+@pytest.mark.parametrize(
+    "topic",
+    ["Mitigation", "Adaptation", "Loss and Damage"],
+)
+def test_topic_label_returns_label_for_topic_metadata(topic):
+    family = NavigatorFamilyFactory.build(
+        corpus=NavigatorCorpusFactory.build(import_id="CCLW.corpus.i00000001.n0000"),
+        metadata={"topic": [topic]},
+    )
+    labels = _topic_label(family)
+    assert len(labels) == 1
+    assert labels[0].type == "topic"
+    assert labels[0].value.id == f"topic::{topic}"
+    assert labels[0].value.value == topic
+    assert labels[0].value.type == "topic"
+
+
+def test_topic_label_includes_subconcept_of_law():
+    family = NavigatorFamilyFactory.build(
+        corpus=NavigatorCorpusFactory.build(import_id="CCLW.corpus.i00000001.n0000"),
+        metadata={"topic": ["Mitigation"]},
+    )
+    labels = _topic_label(family)
+    assert len(labels) == 1
+    subconcept_labels = labels[0].value.labels
+    assert len(subconcept_labels) == 1
+    assert subconcept_labels[0].type == "subconcept_of"
+    assert subconcept_labels[0].value.id == "category::Law"
+    assert subconcept_labels[0].value.type == "category"
+    assert subconcept_labels[0].value.value == "Law"
+
+
+def test_topic_label_returns_empty_when_no_topic_key():
+    family = NavigatorFamilyFactory.build(
+        corpus=NavigatorCorpusFactory.build(import_id="CCLW.corpus.i00000001.n0000"),
+        metadata={},
+    )
+    assert _topic_label(family) == []
+
+
+def test_topic_label_returns_empty_when_topic_is_empty_list():
+    family = NavigatorFamilyFactory.build(
+        corpus=NavigatorCorpusFactory.build(import_id="CCLW.corpus.i00000001.n0000"),
+        metadata={"topic": []},
+    )
+    assert _topic_label(family) == []
+
+
+def test_topic_label_returns_empty_when_topic_first_value_is_empty_string():
+    family = NavigatorFamilyFactory.build(
+        corpus=NavigatorCorpusFactory.build(import_id="CCLW.corpus.i00000001.n0000"),
+        metadata={"topic": [""]},
+    )
+    assert _topic_label(family) == []
+
+
+def test_topic_label_returns_law_type_label_for_mitigation_framework():
+    family = NavigatorFamilyFactory.build(
+        corpus=NavigatorCorpusFactory.build(import_id="CCLW.corpus.i00000001.n0000"),
+        metadata={"framework": ["Mitigation"]},
+    )
+    labels = _topic_label(family)
+    assert len(labels) == 1
+    assert labels[0].type == "law_type"
+    assert labels[0].value.id == "law_type::Mitigation"
+    assert labels[0].value.value == "Framework law"
+
+
+def test_topic_label_ignores_non_mitigation_framework_metadata():
+    family = NavigatorFamilyFactory.build(
+        corpus=NavigatorCorpusFactory.build(import_id="CCLW.corpus.i00000001.n0000"),
+        metadata={"framework": ["Adaptation"]},
+    )
+    assert _topic_label(family) == []
+
+
+@pytest.mark.parametrize("framework", ["Adaptation", "Mitigation", "Drm/Drr"])
+def test_law_type_label_returns_label_for_framework_values(framework):
+    family = NavigatorFamilyFactory.build(
+        corpus=NavigatorCorpusFactory.build(import_id="CCLW.corpus.i00000001.n0000"),
+        metadata={"framework": [framework]},
+    )
+    labels = _law_type_label(family)
+    assert len(labels) == 1
+    assert labels[0].type == "law_type"
+    assert labels[0].value.id == f"law_type::{framework}"
+    assert labels[0].value.value == "Framework law"
+    assert labels[0].value.type == "law_type"
+
+
+def test_law_type_label_includes_subconcept_of_law():
+    family = NavigatorFamilyFactory.build(
+        corpus=NavigatorCorpusFactory.build(import_id="CCLW.corpus.i00000001.n0000"),
+        metadata={"framework": ["Adaptation"]},
+    )
+    labels = _law_type_label(family)
+    subconcept_labels = labels[0].value.labels
+    assert len(subconcept_labels) == 1
+    assert subconcept_labels[0].type == "subconcept_of"
+    assert subconcept_labels[0].value.id == "category::Law"
+    assert subconcept_labels[0].value.type == "category"
+
+
+def test_law_type_label_returns_empty_when_no_framework_key():
+    family = NavigatorFamilyFactory.build(
+        corpus=NavigatorCorpusFactory.build(import_id="CCLW.corpus.i00000001.n0000"),
+        metadata={},
+    )
+    assert _law_type_label(family) == []
+
+
+def test_law_type_label_returns_empty_for_non_matching_framework():
+    family = NavigatorFamilyFactory.build(
+        corpus=NavigatorCorpusFactory.build(import_id="CCLW.corpus.i00000001.n0000"),
+        metadata={"framework": ["Other"]},
+    )
+    assert _law_type_label(family) == []
+
+
+def test_law_type_label_returns_empty_when_framework_is_empty_list():
+    family = NavigatorFamilyFactory.build(
+        corpus=NavigatorCorpusFactory.build(import_id="CCLW.corpus.i00000001.n0000"),
+        metadata={"framework": []},
+    )
+    assert _law_type_label(family) == []
+
+
+def test_status_label_returns_label_for_status_metadata():
+    family = NavigatorFamilyFactory.build(
+        corpus=NavigatorCorpusFactory.build(import_id="MCF.corpus.AF.n0000"),
+        metadata={"status": ["Under Implementation"]},
+    )
+    labels = _status_label(family)
+    assert len(labels) == 1
+    assert labels[0].type == "status"
+    assert labels[0].value.id == "status::Under Implementation"
+    assert labels[0].value.value == "Under Implementation"
+    assert labels[0].value.type == "status"
+
+
+def test_status_label_includes_subconcept_of_mcf_project():
+    family = NavigatorFamilyFactory.build(
+        corpus=NavigatorCorpusFactory.build(import_id="MCF.corpus.AF.n0000"),
+        metadata={"status": ["Under Implementation"]},
+    )
+    labels = _status_label(family)
+    subconcept_labels = labels[0].value.labels
+    assert len(subconcept_labels) == 1
+    assert subconcept_labels[0].type == "subconcept_of"
+    assert subconcept_labels[0].value.id == "entity_type::Project"
+    assert subconcept_labels[0].value.type == "entity_type"
+
+
+def test_status_label_returns_empty_when_no_status_key():
+    family = NavigatorFamilyFactory.build(
+        corpus=NavigatorCorpusFactory.build(import_id="MCF.corpus.AF.n0000"),
+        metadata={},
+    )
+    assert _status_label(family) == []
+
+
+def test_status_label_returns_empty_when_status_is_empty_list():
+    family = NavigatorFamilyFactory.build(
+        corpus=NavigatorCorpusFactory.build(import_id="MCF.corpus.AF.n0000"),
+        metadata={"status": []},
+    )
+    assert _status_label(family) == []
+
+
+def test_status_label_returns_empty_when_status_first_value_is_empty_string():
+    family = NavigatorFamilyFactory.build(
+        corpus=NavigatorCorpusFactory.build(import_id="MCF.corpus.AF.n0000"),
+        metadata={"status": [""]},
+    )
+    assert _status_label(family) == []
+
+
+def test_implementing_agency_label_returns_label():
+    family = NavigatorFamilyFactory.build(
+        corpus=NavigatorCorpusFactory.build(import_id="MCF.corpus.AF.n0000"),
+        metadata={"implementing_agency": ["World Bank"]},
+    )
+    labels = _implementing_agency_label(family)
+    assert len(labels) == 1
+    assert labels[0].type == "implementing_agency"
+    assert labels[0].value.id == "agent::World Bank"
+    assert labels[0].value.value == "World Bank"
+    assert labels[0].value.type == "agent"
+
+
+def test_implementing_agency_label_includes_subconcept_of_mcf_project():
+    family = NavigatorFamilyFactory.build(
+        corpus=NavigatorCorpusFactory.build(import_id="MCF.corpus.AF.n0000"),
+        metadata={"implementing_agency": ["World Bank"]},
+    )
+    labels = _implementing_agency_label(family)
+    subconcept_labels = labels[0].value.labels
+    assert len(subconcept_labels) == 1
+    assert subconcept_labels[0].type == "subconcept_of"
+    assert subconcept_labels[0].value.id == "entity_type::Project"
+    assert subconcept_labels[0].value.type == "entity_type"
+
+
+def test_implementing_agency_label_returns_empty_when_no_metadata():
+    family = NavigatorFamilyFactory.build(
+        corpus=NavigatorCorpusFactory.build(import_id="MCF.corpus.AF.n0000"),
+        metadata={},
+    )
+    assert _implementing_agency_label(family) == []
+
+
+def test_implementing_agency_label_returns_empty_when_empty_list():
+    family = NavigatorFamilyFactory.build(
+        corpus=NavigatorCorpusFactory.build(import_id="MCF.corpus.AF.n0000"),
+        metadata={"implementing_agency": []},
+    )
+    assert _implementing_agency_label(family) == []
+
+
+def test_implementing_agency_label_returns_empty_when_empty_string():
+    family = NavigatorFamilyFactory.build(
+        corpus=NavigatorCorpusFactory.build(import_id="MCF.corpus.AF.n0000"),
+        metadata={"implementing_agency": [""]},
+    )
+    assert _implementing_agency_label(family) == []

--- a/data-in-pipeline/tests/transform/test_navigator_family_litigation.py
+++ b/data-in-pipeline/tests/transform/test_navigator_family_litigation.py
@@ -370,6 +370,34 @@ def test_transform_navigator_family_with_litigation_corpus_type(
                     type="category",
                 ),
             ),
+            LabelRelationship(
+                type="status",
+                value=Label(
+                    id="status::Decided",
+                    value="Decided",
+                    type="status",
+                    labels=[
+                        LabelRelationship(
+                            type="subconcept_of",
+                            value=Label(
+                                id="entity_type::Project",
+                                value="Project",
+                                type="entity_type",
+                                labels=[
+                                    LabelRelationship(
+                                        type="subconcept_of",
+                                        value=Label(
+                                            id="category::Multilateral Climate Fund project",
+                                            value="Multilateral Climate Fund project",
+                                            type="category",
+                                        ),
+                                    )
+                                ],
+                            ),
+                        )
+                    ],
+                ),
+            ),
         ],
         documents=[
             DocumentRelationship(

--- a/data-in-pipeline/tests/transform/test_navigator_family_mcf.py
+++ b/data-in-pipeline/tests/transform/test_navigator_family_mcf.py
@@ -146,9 +146,9 @@ def navigator_family_multilateral_climate_fund_project() -> Identified[Navigator
 
 
 @pytest.fixture
-def navigator_family_multilateral_climate_fund_guidance() -> (
-    Identified[NavigatorFamily]
-):
+def navigator_family_multilateral_climate_fund_guidance() -> Identified[
+    NavigatorFamily
+]:
     return Identified(
         id="family",
         source="navigator_family",
@@ -307,11 +307,77 @@ def test_transform_navigator_family_with_multilateral_climate_fund_project(
                 ),
             ),
             LabelRelationship(
+                type="status",
+                value=Label(
+                    id="status::Under Implementation",
+                    value="Under Implementation",
+                    type="status",
+                    labels=[
+                        LabelRelationship(
+                            type="subconcept_of",
+                            value=Label(
+                                id="entity_type::Project",
+                                value="Project",
+                                type="entity_type",
+                                labels=[
+                                    LabelRelationship(
+                                        type="subconcept_of",
+                                        value=Label(
+                                            id="category::Multilateral Climate Fund project",
+                                            value="Multilateral Climate Fund project",
+                                            type="category",
+                                        ),
+                                    )
+                                ],
+                            ),
+                        )
+                    ],
+                ),
+            ),
+            LabelRelationship(
+                type="implementing_agency",
+                value=Label(
+                    id="agent::International Bank for Reconstruction",
+                    value="International Bank for Reconstruction",
+                    type="agent",
+                    labels=[
+                        LabelRelationship(
+                            type="subconcept_of",
+                            value=Label(
+                                id="entity_type::Project",
+                                value="Project",
+                                type="entity_type",
+                                labels=[
+                                    LabelRelationship(
+                                        type="subconcept_of",
+                                        value=Label(
+                                            id="category::Multilateral Climate Fund project",
+                                            value="Multilateral Climate Fund project",
+                                            type="category",
+                                        ),
+                                    )
+                                ],
+                            ),
+                        )
+                    ],
+                ),
+            ),
+            LabelRelationship(
                 type="multilateral_climate_fund",
                 value=Label(
-                    id="multilateral_climate_fund::Adaptation Fund",
+                    id="agent::Adaptation Fund",
                     value="Adaptation Fund",
-                    type="multilateral_climate_fund",
+                    type="agent",
+                    labels=[
+                        LabelRelationship(
+                            type="subconcept_of",
+                            value=Label(
+                                id="category::Multilateral Climate Fund project",
+                                value="Multilateral Climate Fund project",
+                                type="category",
+                            ),
+                        )
+                    ],
                 ),
             ),
         ],

--- a/data-in-pipeline/tests/transform/test_navigator_family_mcf.py
+++ b/data-in-pipeline/tests/transform/test_navigator_family_mcf.py
@@ -146,9 +146,9 @@ def navigator_family_multilateral_climate_fund_project() -> Identified[Navigator
 
 
 @pytest.fixture
-def navigator_family_multilateral_climate_fund_guidance() -> Identified[
-    NavigatorFamily
-]:
+def navigator_family_multilateral_climate_fund_guidance() -> (
+    Identified[NavigatorFamily]
+):
     return Identified(
         id="family",
         source="navigator_family",


### PR DESCRIPTION
# What does this do?

- adds labels for laws and MCFs

Follows [this pattern](https://github.com/climatepolicyradar/navigator-backend/pull/1244).

part of https://linear.app/climate-policy-radar/issue/APP-2084/extend-labels-to-support-current-search-filters

part of https://linear.app/climate-policy-radar/issue/APP-2088/move-transformnavigator-family-1-transformer-label-pattern

None of this should break frontend as it is all additive, or no-ops.