### PR TITLE
fix: add report type labels

### DIFF
--- a/data-in-pipeline/app/transform/navigator_family.py
+++ b/data-in-pipeline/app/transform/navigator_family.py
@@ -72,6 +72,7 @@ multilateral_climate_fund_project_project = Label(
 
 law = Label(type="category", id="category::Law", value="Law")
 policy = Label(type="category", id="category::Policy", value="Policy")
+report = Label(type="category", id="category::Report", value="Report")
 
 
 _eu_and_international_region_ids = {c.id: c for c in custom_countries}
@@ -1148,6 +1149,7 @@ def _transform_navigator_family(
         + _implementing_agency_label(navigator_family)
         + _un_convention_label(navigator_family)
         + _multilateral_climate_fund_label(navigator_family)
+        + _report_type_label(navigator_family)
     )
 
     document = Document(
@@ -1822,6 +1824,32 @@ def _multilateral_climate_fund_label(
                     ),
                 )
             )
+
+    return labels
+
+
+# region report_type label
+def _report_type_label(
+    navigator_family: NavigatorFamily,
+) -> list[LabelRelationship]:
+    labels: list[LabelRelationship] = []
+    if navigator_family.corpus.import_id == "ICCN.corpus.i00000001.n0000":
+        labels.append(
+            LabelRelationship(
+                type="report_type",
+                value=Label(
+                    id="report_type::Climate council report",
+                    value="Climate council report",
+                    type="agent",
+                    labels=[
+                        LabelRelationship(
+                            type="subconcept_of",
+                            value=report,
+                        )
+                    ],
+                ),
+            )
+        )
 
     return labels
 

--- a/data-in-pipeline/tests/transform/test_navigator_family.py
+++ b/data-in-pipeline/tests/transform/test_navigator_family.py
@@ -23,6 +23,7 @@ from app.transform.navigator_family import (
     _implementing_agency_label,
     _law_type_label,
     _multilateral_climate_fund_label,
+    _report_type_label,
     _status_label,
     _topic_label,
     _un_convention_label,
@@ -2668,3 +2669,34 @@ def test_implementing_agency_label_returns_empty_when_empty_string():
         metadata={"implementing_agency": [""]},
     )
     assert _implementing_agency_label(family) == []
+
+
+def test_report_type_label_returns_label_for_iccn_corpus():
+    family = NavigatorFamilyFactory.build(
+        corpus=NavigatorCorpusFactory.build(import_id="ICCN.corpus.i00000001.n0000"),
+    )
+    labels = _report_type_label(family)
+    assert len(labels) == 1
+    assert labels[0].type == "report_type"
+    assert labels[0].value.id == "report_type::Climate council report"
+    assert labels[0].value.value == "Climate council report"
+    assert labels[0].value.type == "agent"
+
+
+def test_report_type_label_includes_subconcept_of_report():
+    family = NavigatorFamilyFactory.build(
+        corpus=NavigatorCorpusFactory.build(import_id="ICCN.corpus.i00000001.n0000"),
+    )
+    labels = _report_type_label(family)
+    subconcept_labels = labels[0].value.labels
+    assert len(subconcept_labels) == 1
+    assert subconcept_labels[0].type == "subconcept_of"
+    assert subconcept_labels[0].value.id == "category::Report"
+    assert subconcept_labels[0].value.type == "category"
+
+
+def test_report_type_label_returns_empty_for_non_iccn_corpus():
+    family = NavigatorFamilyFactory.build(
+        corpus=NavigatorCorpusFactory.build(import_id="CCLW.corpus.i00000001.n0000"),
+    )
+    assert _report_type_label(family) == []


### PR DESCRIPTION
# What does this do?
- adds the `report_type` label
- it is a `subconcept_of` the `category::Report`

Follows https://github.com/climatepolicyradar/navigator-backend/pull/1244.

part of https://linear.app/climate-policy-radar/issue/APP-2084/extend-labels-to-support-current-search-filters

part of https://linear.app/climate-policy-radar/issue/APP-2088/move-transformnavigator-family-1-transformer-label-pattern