### PR TITLE
Feature: Pla 1383 - Backend Api Exact Match Only

### DIFF
--- a/backend-api/app/models/search.py
+++ b/backend-api/app/models/search.py
@@ -67,6 +67,18 @@ class SearchRequestBody(CprSdkSearchParameters):
     For example: 'Adaptation strategy'"
     """
 
+    exact_match: bool = Field(
+        default=True,
+        description=(
+            "Whether to only return results that exactly match the query string. "
+            "This defaults to True as semantic search is deprecated in the backend."
+        ),
+    )
+    """
+    Indicate if the `query_string` should be treated as an exact match when
+    the search is performed.
+    """
+
     # We need to add `keyword_filters` here because the items received from the frontend
     # need processing to be ready for vespa (key name change & geo slugs to geo codes)
     keyword_filters: BackendKeywordFilter = None
@@ -120,6 +132,16 @@ class SearchRequestBody(CprSdkSearchParameters):
                 f"page_size: {page_size}, limit: {limit}"
             )
         return page_size
+
+    @field_validator("exact_match", mode="before")
+    @classmethod
+    def force_exact_match(cls, v):
+        """
+        Ensure we always set exact_match to True.
+
+        This is as semantic search is deprecated in the backend.
+        """
+        return True
 
     @classmethod
     def __get_pydantic_json_schema__(

--- a/backend-api/app/service/search.py
+++ b/backend-api/app/service/search.py
@@ -1,6 +1,5 @@
 import logging
 import re
-from enum import Enum
 from typing import Mapping, Optional, Sequence, Tuple
 
 from cpr_sdk.exceptions import QueryError
@@ -43,12 +42,6 @@ from app.service.util import to_cdn_url
 from app.telemetry import observe
 
 _LOGGER = logging.getLogger(__name__)
-
-
-class SearchType(str, Enum):
-    standard = "standard"
-    browse = "browse"
-    browse_with_concepts = "browse_with_concepts"
 
 
 def _parse_text_block_id(text_block_id: Optional[str]) -> Tuple[Optional[int], int]:
@@ -463,34 +456,6 @@ def create_vespa_search_params(
     return search_body
 
 
-@observe("identify_search_type")
-def identify_search_type(search_body: SearchRequestBody) -> str:
-    """Identify the search type from parameters"""
-    if not search_body.query_string and not search_body.concept_filters:
-        return SearchType.browse
-    elif not search_body.query_string and search_body.concept_filters:
-        return SearchType.browse_with_concepts
-    else:
-        return SearchType.standard
-
-
-@observe("mutate_search_body_for_search_type")
-def mutate_search_body_for_search_type(
-    search_body: SearchRequestBody,
-) -> SearchRequestBody:
-    """Mutate the search body in line with the search params"""
-    search_type = identify_search_type(search_body=search_body)
-    if search_type == SearchType.browse:
-        search_body.all_results = True
-        search_body.documents_only = True
-        search_body.exact_match = False
-    elif search_type == SearchType.browse_with_concepts:
-        search_body.all_results = True
-        search_body.documents_only = False
-        search_body.exact_match = False
-    return search_body
-
-
 @observe("make_search_request")
 def make_search_request(
     db: Session,
@@ -500,7 +465,6 @@ def make_search_request(
     """Perform a search request against the Vespa search engine"""
 
     try:
-        search_body = mutate_search_body_for_search_type(search_body=search_body)
         cpr_sdk_search_params = create_vespa_search_params(db, search_body)
         cpr_sdk_search_response = observe("vespa_search")(vespa_search_adapter.search)(
             parameters=cpr_sdk_search_params

--- a/backend-api/docs/api/search.md
+++ b/backend-api/docs/api/search.md
@@ -78,6 +78,9 @@ strategy”
 Boolean value to indicate if the `query_string`should be treated as an exact
 match when the search is performed.
 
+> **Warning**: `exact_match` will be overidden to `True`. This is because
+> embeddings have been deprecated in the backend system.
+
 ##### max_passages_per_doc (optional, default is 10)
 
 The maximum number of matched passages to be returned for a single document.

--- a/backend-api/tests/search/test_search.py
+++ b/backend-api/tests/search/test_search.py
@@ -350,7 +350,8 @@ def test_create_vespa_search_params(
     assert produced_search_parameters.continuation_tokens == continuation_tokens
     assert produced_search_parameters.year_range == year_range
     assert produced_search_parameters.query_string == query_string
-    assert produced_search_parameters.exact_match == exact_match
+    # We've deprecated embeddings in the backend system, thus this should always be True
+    assert produced_search_parameters.exact_match
 
     # Test converted data
     if keyword_filters:


### PR DESCRIPTION
# What does this do?
Limits the backend api to only running `exact_match=True` searches even if the frontend requests otherwise. This is as we've taken the decision to deprecate embeddings in the backend as outlined in this [notion](https://www.notion.so/climatepolicyradar/RFC-Embeddings-Deprecation-from-Platform-3599109609a4801fad2cc8caef57a09d?d=4dd9109609a4834988a6835c7f57e605) document. 

We're not doing a wholesale removal of embeddings from the backend api and query layer (including the cpr_sdk) because we're about to migrate to the search / data-in api and schema. 

#### Solution 
- Override the default field value to `True`. 
- Adds a validator to ensure the value is set to `True` incase a `False` value was passed in. 
- Removal of the browse capabilities that utilise semantic search.

## Why is it needed?
Embeddings are being removed from vespa, the pipeline will no longer produce them, thus we need to remove the ability to query on that path. 

## How was it tested?
- Updated the `test_create_vespa_search_params` test. 