### PR TITLE
Bugfix: Correct production aws env to prod for prefect variable load 

### DIFF
--- a/data-in-pipeline/app/deploy.py
+++ b/data-in-pipeline/app/deploy.py
@@ -265,7 +265,10 @@ async def create_deployment(flow: Flow) -> None:
         docker_registry,
     )
 
-    default_variables_name = f"ecs-default-job-variables-prefect-mvp-{aws_env}"
+    # In prefect the Variable is saved with the shortened prod suffix for the
+    # environment, so we need to adjust the suffix accordingly when loading the block.
+    aws_env_short: str = "prod" if aws_env == "production" else aws_env
+    default_variables_name = f"ecs-default-job-variables-prefect-mvp-{aws_env_short}"
     default_job_variables: Any = await Variable.aget(default_variables_name)
     if default_job_variables is None:
         raise ValueError(f"Variable '{default_variables_name}' not found in Prefect")


### PR DESCRIPTION

# What does this do?
Fixes a failing CI deploy due to the disparity between the aws_env used in this module and in the `Variable` name. 

The variable name in prefect: 
<img width="329" height="46" alt="image" src="https://github.com/user-attachments/assets/7b586316-a2ad-460f-8cf9-9ca8e45be704" />


## Why is it needed?
CI was failing. 

## How was it tested?
Existing unit tests. 
