### PR TITLE
fix: add entity_type labels for reports

### DIFF
--- a/data-in-pipeline/app/transform/navigator_family.py
+++ b/data-in-pipeline/app/transform/navigator_family.py
@@ -142,7 +142,7 @@ report = Label(type="category", id="category::Report", value="Report")
 climate_council_report = Label(
     id="report_type::Climate council report",
     value="Climate council report",
-    type="agent",
+    type="report_type",
     labels=[
         LabelRelationship(
             type="subconcept_of",
@@ -164,6 +164,26 @@ assessment_report = Label(
     type="entity_type",
     labels=[LabelRelationship(type="subconcept_of", value=climate_council_report)],
 )
+industry_report = Label(
+    id="report_type::Industry report",
+    value="Industry report",
+    type="report_type",
+    labels=[
+        LabelRelationship(
+            type="subconcept_of",
+            value=report,
+        )
+    ],
+)
+offshore_wind_report = Label(
+    id="entity_type::Offshore wind report",
+    value="Offshore wind report",
+    type="entity_type",
+    labels=[
+        LabelRelationship(type="subconcept_of", value=industry_report),
+    ],
+)
+
 
 _eu_and_international_region_ids = {c.id: c for c in custom_countries}
 
@@ -1653,17 +1673,17 @@ def _deprecated_category_label(
 
 #  region entity_type label
 # The capitalisation of these keys is irregular as it is irregular in the source data
-_document_type_to_entity_type_map = {
-    "Corporate voluntary report": corporate_voluntary_report,
-    "Corporate regulatory filing": corporate_voluntary_filing,
-    "Assessment Report": assessment_report,
-    "Annual Report": annual_report,
-    "Annual Performance Report": annual_performance_report,
-    "Approved funding proposal": approved_funding_proposal,
-    "Final independent evaluation report": final_independent_evaluation_report,
-    "Gender action plan": multilateral_climate_fund_project_gender_action_plan,
-    "Gender assessment": gender_assessment,
-    "Project completion report": project_completion_report,
+_document_type_to_entity_type_map: dict[str, list[Label]] = {
+    "Corporate voluntary report": [corporate_voluntary_report],
+    "Corporate regulatory filing": [corporate_voluntary_filing],
+    "Assessment Report": [climate_council_report, assessment_report],
+    "Annual Report": [climate_council_report, annual_report],
+    "Annual Performance Report": [annual_performance_report],
+    "Approved funding proposal": [approved_funding_proposal],
+    "Final independent evaluation report": [final_independent_evaluation_report],
+    "Gender action plan": [multilateral_climate_fund_project_gender_action_plan],
+    "Gender assessment": [gender_assessment],
+    "Project completion report": [project_completion_report],
 }
 
 
@@ -1699,14 +1719,25 @@ def _entity_type_label(
                 )
             )
 
-    for document_type, entity_type_label in _document_type_to_entity_type_map.items():
+    for document_type, entity_type_labels in _document_type_to_entity_type_map.items():
         if _has_document_of_type(navigator_family, document_type):
-            labels.append(
+            for entity_type_label in entity_type_labels:
+                labels.append(
+                    LabelRelationship(
+                        type="entity_type",
+                        value=entity_type_label,
+                    )
+                )
+    if navigator_family.corpus.import_id == "OEP.corpus.i00000001.n0000":
+        labels.extend(
+            [
                 LabelRelationship(
                     type="entity_type",
-                    value=entity_type_label,
-                )
-            )
+                    value=industry_report,
+                ),
+                LabelRelationship(type="entity_type", value=offshore_wind_report),
+            ]
+        )
 
     return labels
 

--- a/data-in-pipeline/app/transform/navigator_family.py
+++ b/data-in-pipeline/app/transform/navigator_family.py
@@ -85,6 +85,55 @@ multilateral_climate_fund_project_project = Label(
         LabelRelationship(type="subconcept_of", value=multilateral_climate_fund_project)
     ],
 )
+annual_performance_report = Label(
+    id="entity_type::Annual performance report",
+    value="Annual Performance Report",
+    type="entity_type",
+    labels=[
+        LabelRelationship(type="subconcept_of", value=multilateral_climate_fund_project)
+    ],
+)
+approved_funding_proposal = Label(
+    id="entity_type::Approved funding proposal",
+    value="Approved funding proposal",
+    type="entity_type",
+    labels=[
+        LabelRelationship(type="subconcept_of", value=multilateral_climate_fund_project)
+    ],
+)
+final_independent_evaluation_report = Label(
+    id="entity_type::Final independent evaluation report",
+    value="Final independent evaluation report",
+    type="entity_type",
+    labels=[
+        LabelRelationship(type="subconcept_of", value=multilateral_climate_fund_project)
+    ],
+)
+multilateral_climate_fund_project_gender_action_plan = Label(
+    id="entity_type::Gender action plan",
+    value="Gender action plan",
+    type="entity_type",
+    labels=[
+        LabelRelationship(type="subconcept_of", value=multilateral_climate_fund_project)
+    ],
+)
+gender_assessment = Label(
+    id="entity_type::Gender assessment",
+    value="Gender assessment",
+    type="entity_type",
+    labels=[
+        LabelRelationship(type="subconcept_of", value=multilateral_climate_fund_project)
+    ],
+)
+project_completion_report = Label(
+    id="entity_type::Project completion report",
+    value="Project completion report",
+    type="entity_type",
+    labels=[
+        LabelRelationship(type="subconcept_of", value=multilateral_climate_fund_project)
+    ],
+)
+
 
 law = Label(type="category", id="category::Law", value="Law")
 policy = Label(type="category", id="category::Policy", value="Policy")
@@ -1609,6 +1658,12 @@ _document_type_to_entity_type_map = {
     "Corporate regulatory filing": corporate_voluntary_filing,
     "Assessment Report": assessment_report,
     "Annual Report": annual_report,
+    "Annual Performance Report": annual_performance_report,
+    "Approved funding proposal": approved_funding_proposal,
+    "Final independent evaluation report": final_independent_evaluation_report,
+    "Gender action plan": multilateral_climate_fund_project_gender_action_plan,
+    "Gender assessment": gender_assessment,
+    "Project completion report": project_completion_report,
 }
 
 
@@ -1868,6 +1923,14 @@ def _implementing_agency_label(
 
 
 # region multilateral_climate_fund label
+_corpus_import_id_to_multilateral_climate_fund = {
+    "MCF.corpus.AF.n0000": "Adaptation Fund",
+    "MCF.corpus.CIF.n0000": "Climate Investment Funds",
+    "MCF.corpus.GCF.n0000": "Global Environment Facility",
+    "MCF.corpus.GEF.n0000": "Green Climate Fund",
+}
+
+
 def _multilateral_climate_fund_label(
     navigator_family: NavigatorFamily,
 ) -> list[LabelRelationship]:
@@ -1951,12 +2014,3 @@ def _un_convention_label(
         )
 
     return labels
-
-
-# region multilateral_climate_fund label
-_corpus_import_id_to_multilateral_climate_fund = {
-    "MCF.corpus.AF.n0000": "Adaptation Fund",
-    "MCF.corpus.CIF.n0000": "Climate Investment Funds",
-    "MCF.corpus.GCF.n0000": "Global Environment Facility",
-    "MCF.corpus.GEF.n0000": "Green Climate Fund",
-}

--- a/data-in-pipeline/app/transform/navigator_family.py
+++ b/data-in-pipeline/app/transform/navigator_family.py
@@ -47,6 +47,22 @@ from app.transform.models import (
 corporate_discloser = Label(
     type="category", id="category::Corporate Disclosures", value="Corporate Disclosures"
 )
+corporate_voluntary_report = Label(
+    id="entity_type::Corporate voluntary report",
+    value="Corporate voluntary report",
+    type="entity_type",
+    labels=[
+        LabelRelationship(type="subconcept_of", value=corporate_discloser),
+    ],
+)
+corporate_voluntary_filing = Label(
+    id="entity_type::Corporate voluntary filing",
+    value="Corporate voluntary report",
+    type="entity_type",
+    labels=[
+        LabelRelationship(type="subconcept_of", value=corporate_discloser),
+    ],
+)
 
 multilateral_climate_fund_project = Label(
     type="category",
@@ -72,8 +88,33 @@ multilateral_climate_fund_project_project = Label(
 
 law = Label(type="category", id="category::Law", value="Law")
 policy = Label(type="category", id="category::Policy", value="Policy")
-report = Label(type="category", id="category::Report", value="Report")
 
+report = Label(type="category", id="category::Report", value="Report")
+climate_council_report = Label(
+    id="report_type::Climate council report",
+    value="Climate council report",
+    type="agent",
+    labels=[
+        LabelRelationship(
+            type="subconcept_of",
+            value=report,
+        )
+    ],
+)
+annual_report = Label(
+    id="entity_type::Annual report",
+    value="Annual report",
+    type="entity_type",
+    labels=[
+        LabelRelationship(type="subconcept_of", value=climate_council_report),
+    ],
+)
+assessment_report = Label(
+    id="entity_type::Assessment report",
+    value="Assessment report",
+    type="entity_type",
+    labels=[LabelRelationship(type="subconcept_of", value=climate_council_report)],
+)
 
 _eu_and_international_region_ids = {c.id: c for c in custom_countries}
 
@@ -1562,6 +1603,25 @@ def _deprecated_category_label(
 
 
 #  region entity_type label
+# The capitalisation of these keys is irregular as it is irregular in the source data
+_document_type_to_entity_type_map = {
+    "Corporate voluntary report": corporate_voluntary_report,
+    "Corporate regulatory filing": corporate_voluntary_filing,
+    "Assessment Report": assessment_report,
+    "Annual Report": annual_report,
+}
+
+
+def _has_document_of_type(
+    navigator_family: NavigatorFamily, document_type: str
+) -> bool:
+    return any(
+        document
+        for document in navigator_family.documents
+        if document.valid_metadata.get("type") == [document_type]
+    )
+
+
 def _entity_type_label(
     navigator_family: NavigatorFamily,
 ) -> list[LabelRelationship]:
@@ -1581,6 +1641,15 @@ def _entity_type_label(
                 LabelRelationship(
                     type="entity_type",
                     value=multilateral_climate_fund_project_project,
+                )
+            )
+
+    for document_type, entity_type_label in _document_type_to_entity_type_map.items():
+        if _has_document_of_type(navigator_family, document_type):
+            labels.append(
+                LabelRelationship(
+                    type="entity_type",
+                    value=entity_type_label,
                 )
             )
 

--- a/data-in-pipeline/app/transform/navigator_family.py
+++ b/data-in-pipeline/app/transform/navigator_family.py
@@ -57,7 +57,7 @@ corporate_voluntary_report = Label(
 )
 corporate_voluntary_filing = Label(
     id="entity_type::Corporate voluntary filing",
-    value="Corporate voluntary report",
+    value="Corporate voluntary filing",
     type="entity_type",
     labels=[
         LabelRelationship(type="subconcept_of", value=corporate_discloser),

--- a/data-in-pipeline/app/transform/navigator_family.py
+++ b/data-in-pipeline/app/transform/navigator_family.py
@@ -183,6 +183,70 @@ offshore_wind_report = Label(
         LabelRelationship(type="subconcept_of", value=industry_report),
     ],
 )
+individual = Label(
+    id="author_type::Individual",
+    value="Individual",
+    type="author_type",
+    labels=[LabelRelationship(type="subconcept_of", value=report)],
+)
+academic_research = Label(
+    id="author_type::Academic/Research",
+    value="Academic/Research",
+    type="author_type",
+    labels=[LabelRelationship(type="subconcept_of", value=report)],
+)
+national_body = Label(
+    id="author_type::National Body",
+    value="National Body",
+    type="author_type",
+    labels=[LabelRelationship(type="subconcept_of", value=report)],
+)
+intergovernmental_organization = Label(
+    id="author_type::Intergovernmental Organization",
+    value="Intergovernmental Organization",
+    type="author_type",
+    labels=[LabelRelationship(type="subconcept_of", value=report)],
+)
+corporate = Label(
+    id="author_type::Corporate",
+    value="Corporate",
+    type="author_type",
+    labels=[LabelRelationship(type="subconcept_of", value=report)],
+)
+industry_body = Label(
+    id="author_type::Industry Body",
+    value="Industry Body",
+    type="author_type",
+    labels=[LabelRelationship(type="subconcept_of", value=report)],
+)
+ngo_civil_society = Label(
+    id="author_type::NGO/Civil Society",
+    value="NGO/Civil Society",
+    type="author_type",
+    labels=[LabelRelationship(type="subconcept_of", value=report)],
+)
+other = Label(
+    id="author_type::Other",
+    value="Other",
+    type="author_type",
+    labels=[LabelRelationship(type="subconcept_of", value=report)],
+)
+
+un_submission = Label(
+    type="category", id="category::UN submission", value="UN submission"
+)
+party = Label(
+    id="author_type::Party",
+    value="Party",
+    type="author_type",
+    labels=[LabelRelationship(type="subconcept_of", value=un_submission)],
+)
+non_party = Label(
+    id="author_type::Non-Party",
+    value="Non-Party",
+    type="author_type",
+    labels=[LabelRelationship(type="subconcept_of", value=un_submission)],
+)
 
 
 _eu_and_international_region_ids = {c.id: c for c in custom_countries}
@@ -301,7 +365,7 @@ def transform_navigator_family(
 def _transform_litigation_events(data: NavigatorFamily) -> list[Document]:
     documents = []
     labels = []
-    attributes = {}
+    attributes: dict[str, str | float | bool] = {}
     navigator_family_events = data.events
     navigator_document_event_ids = {
         doc.events[0].import_id for doc in data.documents if doc.events
@@ -1612,22 +1676,14 @@ def _category_label(
             labels.append(
                 LabelRelationship(
                     type="category",
-                    value=Label(
-                        id="category::Law",
-                        value="Law",
-                        type="category",
-                    ),
+                    value=law,
                 )
             )
         if navigator_family.category == "EXECUTIVE":
             labels.append(
                 LabelRelationship(
                     type="category",
-                    value=Label(
-                        id="category::Policy",
-                        value="Policy",
-                        type="category",
-                    ),
+                    value=policy,
                 )
             )
     else:
@@ -1775,22 +1831,22 @@ def _author_label(
 # region author_type label
 
 # These are controlled vocabularies
-_author_types = [
+_author_types = {
     # Intl. Agreements
     # @see: https://github.com/climatepolicyradar/data-migrations/blob/main/taxonomies/Intl.%20agreements.json#L145-L149
-    "Party",
-    "Non-Party",
+    "Party": party,
+    "Non-Party": non_party,
     # Reports
     # https://github.com/climatepolicyradar/data-migrations/blob/main/taxonomies/Reports.json#L32-L41
-    "Individual",
-    "Academic/Research",
-    "National Body",
-    "Intergovernmental Organization",
-    "Corporate",
-    "Industry Body",
-    "NGO/Civil Society",
-    "Other",
-]
+    "Individual": individual,
+    "Academic/Research": academic_research,
+    "National Body": national_body,
+    "Intergovernmental Organization": intergovernmental_organization,
+    "Corporate": corporate,
+    "Industry Body": industry_body,
+    "NGO/Civil Society": ngo_civil_society,
+    "Other": other,
+}
 
 
 def _author_type_label(
@@ -1798,18 +1854,8 @@ def _author_type_label(
 ) -> list[LabelRelationship]:
     labels: list[LabelRelationship] = []
     author_type_values = navigator_family.metadata.get("author_type")
-    if author_type_values and author_type_values[0] in _author_types:
-        author_type = author_type_values[0]
-        labels.append(
-            LabelRelationship(
-                type="author_type",
-                value=Label(
-                    id=f"author_type::{author_type}",
-                    value=author_type,
-                    type="author_type",
-                ),
-            )
-        )
+    if author_type_values and (label := _author_types.get(author_type_values[0])):
+        labels.append(LabelRelationship(type="author_type", value=label))
     return labels
 
 

--- a/data-in-pipeline/app/transform/navigator_family.py
+++ b/data-in-pipeline/app/transform/navigator_family.py
@@ -196,14 +196,14 @@ academic_research = Label(
     labels=[LabelRelationship(type="subconcept_of", value=report)],
 )
 national_body = Label(
-    id="author_type::National Body",
-    value="National Body",
+    id="author_type::National body",
+    value="National body",
     type="author_type",
     labels=[LabelRelationship(type="subconcept_of", value=report)],
 )
 intergovernmental_organization = Label(
-    id="author_type::Intergovernmental Organization",
-    value="Intergovernmental Organization",
+    id="author_type::Intergovernmental organization",
+    value="Intergovernmental organization",
     type="author_type",
     labels=[LabelRelationship(type="subconcept_of", value=report)],
 )
@@ -214,14 +214,14 @@ corporate = Label(
     labels=[LabelRelationship(type="subconcept_of", value=report)],
 )
 industry_body = Label(
-    id="author_type::Industry Body",
-    value="Industry Body",
+    id="author_type::Industry body",
+    value="Industry body",
     type="author_type",
     labels=[LabelRelationship(type="subconcept_of", value=report)],
 )
 ngo_civil_society = Label(
-    id="author_type::NGO/Civil Society",
-    value="NGO/Civil Society",
+    id="author_type::NGO/Civil society",
+    value="NGO/Civil society",
     type="author_type",
     labels=[LabelRelationship(type="subconcept_of", value=report)],
 )

--- a/data-in-pipeline/app/transform/navigator_family.py
+++ b/data-in-pipeline/app/transform/navigator_family.py
@@ -87,7 +87,7 @@ multilateral_climate_fund_project_project = Label(
 )
 annual_performance_report = Label(
     id="entity_type::Annual performance report",
-    value="Annual Performance Report",
+    value="Annual performance report",
     type="entity_type",
     labels=[
         LabelRelationship(type="subconcept_of", value=multilateral_climate_fund_project)

--- a/data-in-pipeline/tests/transform/test_navigator_family.py
+++ b/data-in-pipeline/tests/transform/test_navigator_family.py
@@ -2240,7 +2240,7 @@ def test_author_type_label_returns_label_for_non_stakeholder():
     labels = _author_type_label(family)
     assert len(labels) == 1
     assert labels[0].type == "author_type"
-    assert labels[0].value.id == "author_type::Intergovernmental Organization"
+    assert labels[0].value.id == "author_type::Intergovernmental organization"
 
 
 def test_author_type_label_returns_empty_when_no_metadata():

--- a/data-in-pipeline/tests/transform/test_navigator_family.py
+++ b/data-in-pipeline/tests/transform/test_navigator_family.py
@@ -2449,11 +2449,20 @@ def test_entity_type_label_returns_empty_for_non_mcf_corpus():
     [
         ("Corporate voluntary report", ["entity_type::Corporate voluntary report"]),
         ("Corporate regulatory filing", ["entity_type::Corporate voluntary filing"]),
-        ("Assessment Report", ["report_type::Climate council report", "entity_type::Assessment report"]),
-        ("Annual Report", ["report_type::Climate council report", "entity_type::Annual report"]),
+        (
+            "Assessment Report",
+            ["report_type::Climate council report", "entity_type::Assessment report"],
+        ),
+        (
+            "Annual Report",
+            ["report_type::Climate council report", "entity_type::Annual report"],
+        ),
         ("Annual Performance Report", ["entity_type::Annual performance report"]),
         ("Approved funding proposal", ["entity_type::Approved funding proposal"]),
-        ("Final independent evaluation report", ["entity_type::Final independent evaluation report"]),
+        (
+            "Final independent evaluation report",
+            ["entity_type::Final independent evaluation report"],
+        ),
         ("Gender action plan", ["entity_type::Gender action plan"]),
         ("Gender assessment", ["entity_type::Gender assessment"]),
         ("Project completion report", ["entity_type::Project completion report"]),
@@ -2495,7 +2504,7 @@ def test_entity_type_label_returns_both_labels_for_oep_corpus():
     label_ids = [label.value.id for label in labels]
     assert "report_type::Industry report" in label_ids
     assert "entity_type::Offshore wind report" in label_ids
-    assert len(labels) == 2
+    assert len(labels) == 2  # noqa: PLR2004
 
 
 def test_entity_type_label_oep_always_applies_regardless_of_document_type():

--- a/data-in-pipeline/tests/transform/test_navigator_family.py
+++ b/data-in-pipeline/tests/transform/test_navigator_family.py
@@ -2445,6 +2445,47 @@ def test_entity_type_label_returns_empty_for_non_mcf_corpus():
 
 
 @pytest.mark.parametrize(
+    "document_type,expected_entity_type_id",
+    [
+        ("Corporate voluntary report", "entity_type::Corporate voluntary report"),
+        ("Corporate regulatory filing", "entity_type::Corporate voluntary filing"),
+        ("Assessment Report", "entity_type::Assessment report"),
+        ("Annual Report", "entity_type::Annual report"),
+    ],
+)
+def test_entity_type_label_returns_label_for_document_type(
+    document_type, expected_entity_type_id
+):
+    family = NavigatorFamilyFactory.build(
+        corpus=NavigatorCorpusFactory.build(import_id="CCLW.corpus.i00000001.n0000"),
+        documents=[
+            NavigatorDocumentFactory.build(
+                valid_metadata={"type": [document_type]},
+            )
+        ],
+    )
+    labels = _entity_type_label(family)
+    entity_type_labels = [
+        label for label in labels if label.value.id == expected_entity_type_id
+    ]
+    assert len(entity_type_labels) == 1
+    assert entity_type_labels[0].type == "entity_type"
+    assert entity_type_labels[0].value.type == "entity_type"
+
+
+def test_entity_type_label_returns_empty_for_non_matching_document_type():
+    family = NavigatorFamilyFactory.build(
+        corpus=NavigatorCorpusFactory.build(import_id="CCLW.corpus.i00000001.n0000"),
+        documents=[
+            NavigatorDocumentFactory.build(
+                valid_metadata={"type": ["Some other document type"]},
+            )
+        ],
+    )
+    assert _entity_type_label(family) == []
+
+
+@pytest.mark.parametrize(
     "topic",
     ["Mitigation", "Adaptation", "Loss and Damage"],
 )

--- a/data-in-pipeline/tests/transform/test_navigator_family.py
+++ b/data-in-pipeline/tests/transform/test_navigator_family.py
@@ -2451,6 +2451,12 @@ def test_entity_type_label_returns_empty_for_non_mcf_corpus():
         ("Corporate regulatory filing", "entity_type::Corporate voluntary filing"),
         ("Assessment Report", "entity_type::Assessment report"),
         ("Annual Report", "entity_type::Annual report"),
+        ("Annual Performance Report", "entity_type::Annual performance report"),
+        ("Approved funding proposal", "entity_type::Approved funding proposal"),
+        ("Final independent evaluation report", "entity_type::Final independent evaluation report"),
+        ("Gender action plan", "entity_type::Gender action plan"),
+        ("Gender assessment", "entity_type::Gender assessment"),
+        ("Project completion report", "entity_type::Project completion report"),
     ],
 )
 def test_entity_type_label_returns_label_for_document_type(

--- a/data-in-pipeline/tests/transform/test_navigator_family.py
+++ b/data-in-pipeline/tests/transform/test_navigator_family.py
@@ -2445,22 +2445,22 @@ def test_entity_type_label_returns_empty_for_non_mcf_corpus():
 
 
 @pytest.mark.parametrize(
-    "document_type,expected_entity_type_id",
+    "document_type,expected_entity_type_ids",
     [
-        ("Corporate voluntary report", "entity_type::Corporate voluntary report"),
-        ("Corporate regulatory filing", "entity_type::Corporate voluntary filing"),
-        ("Assessment Report", "entity_type::Assessment report"),
-        ("Annual Report", "entity_type::Annual report"),
-        ("Annual Performance Report", "entity_type::Annual performance report"),
-        ("Approved funding proposal", "entity_type::Approved funding proposal"),
-        ("Final independent evaluation report", "entity_type::Final independent evaluation report"),
-        ("Gender action plan", "entity_type::Gender action plan"),
-        ("Gender assessment", "entity_type::Gender assessment"),
-        ("Project completion report", "entity_type::Project completion report"),
+        ("Corporate voluntary report", ["entity_type::Corporate voluntary report"]),
+        ("Corporate regulatory filing", ["entity_type::Corporate voluntary filing"]),
+        ("Assessment Report", ["report_type::Climate council report", "entity_type::Assessment report"]),
+        ("Annual Report", ["report_type::Climate council report", "entity_type::Annual report"]),
+        ("Annual Performance Report", ["entity_type::Annual performance report"]),
+        ("Approved funding proposal", ["entity_type::Approved funding proposal"]),
+        ("Final independent evaluation report", ["entity_type::Final independent evaluation report"]),
+        ("Gender action plan", ["entity_type::Gender action plan"]),
+        ("Gender assessment", ["entity_type::Gender assessment"]),
+        ("Project completion report", ["entity_type::Project completion report"]),
     ],
 )
 def test_entity_type_label_returns_label_for_document_type(
-    document_type, expected_entity_type_id
+    document_type, expected_entity_type_ids
 ):
     family = NavigatorFamilyFactory.build(
         corpus=NavigatorCorpusFactory.build(import_id="CCLW.corpus.i00000001.n0000"),
@@ -2471,12 +2471,8 @@ def test_entity_type_label_returns_label_for_document_type(
         ],
     )
     labels = _entity_type_label(family)
-    entity_type_labels = [
-        label for label in labels if label.value.id == expected_entity_type_id
-    ]
-    assert len(entity_type_labels) == 1
-    assert entity_type_labels[0].type == "entity_type"
-    assert entity_type_labels[0].value.type == "entity_type"
+    assert [label.value.id for label in labels] == expected_entity_type_ids
+    assert all(label.type == "entity_type" for label in labels)
 
 
 def test_entity_type_label_returns_empty_for_non_matching_document_type():
@@ -2489,6 +2485,30 @@ def test_entity_type_label_returns_empty_for_non_matching_document_type():
         ],
     )
     assert _entity_type_label(family) == []
+
+
+def test_entity_type_label_returns_both_labels_for_oep_corpus():
+    family = NavigatorFamilyFactory.build(
+        corpus=NavigatorCorpusFactory.build(import_id="OEP.corpus.i00000001.n0000"),
+    )
+    labels = _entity_type_label(family)
+    label_ids = [label.value.id for label in labels]
+    assert "report_type::Industry report" in label_ids
+    assert "entity_type::Offshore wind report" in label_ids
+    assert len(labels) == 2
+
+
+def test_entity_type_label_oep_always_applies_regardless_of_document_type():
+    family = NavigatorFamilyFactory.build(
+        corpus=NavigatorCorpusFactory.build(import_id="OEP.corpus.i00000001.n0000"),
+        documents=[
+            NavigatorDocumentFactory.build(valid_metadata={"type": ["Some other type"]})
+        ],
+    )
+    labels = _entity_type_label(family)
+    label_ids = [label.value.id for label in labels]
+    assert "report_type::Industry report" in label_ids
+    assert "entity_type::Offshore wind report" in label_ids
 
 
 @pytest.mark.parametrize(

--- a/data-in-pipeline/tests/transform/test_navigator_family_GST1.py
+++ b/data-in-pipeline/tests/transform/test_navigator_family_GST1.py
@@ -247,6 +247,16 @@ def test_transform_navigator_family_UNFCCC_party_submission_to_GST1_label():
                     id="author_type::Party",
                     value="Party",
                     type="author_type",
+                    labels=[
+                        LabelRelationship(
+                            type="subconcept_of",
+                            value=Label(
+                                id="category::UN submission",
+                                value="UN submission",
+                                type="category",
+                            ),
+                        )
+                    ],
                 ),
             ),
             LabelRelationship(
@@ -602,6 +612,16 @@ def test_transform_navigator_family_UNFCCC_non_party_submission_to_GST1_label():
                     id="author_type::Non-Party",
                     value="Non-Party",
                     type="author_type",
+                    labels=[
+                        LabelRelationship(
+                            type="subconcept_of",
+                            value=Label(
+                                id="category::UN submission",
+                                value="UN submission",
+                                type="category",
+                            ),
+                        )
+                    ],
                 ),
             ),
             LabelRelationship(


### PR DESCRIPTION
# What does this do?

Copies specific `NavigatorFamily.documents[].valid_metadata.type` => `Principal.labels[].entity_type`

---

part of https://linear.app/climate-policy-radar/issue/APP-2084/extend-labels-to-support-current-search-filters

part of https://linear.app/climate-policy-radar/issue/APP-2088/move-transformnavigator-family-1-transformer-label-pattern