### PR TITLE
fix: return label => label relationships in data-in-api response

### DIFF
--- a/data-in-api/app/repository.py
+++ b/data-in-api/app/repository.py
@@ -268,7 +268,19 @@ def _map_db_label_to_schema(db_label: DBLabel) -> LabelOutput:
         value=db_label.value,
         type=db_label.type,
         attributes=db_label.attributes or {},
-        # We purposefully do not map relation ships as they are not useful in the response
+        labels=[
+            LabelRelationship(
+                type=label_relationship.type,
+                value=LabelLabelRelationshipOutput(
+                    id=label_relationship.related_label_id,
+                    value=label_relationship.related_label_id,
+                    type=db_label.type,
+                    labels=[],
+                ),
+                timestamp=label_relationship.timestamp,
+            )
+            for label_relationship in db_label.labels
+        ],
     )
 
 

--- a/data-in-api/justfile
+++ b/data-in-api/justfile
@@ -1,0 +1,22 @@
+# Override the root justfile test recipe with extra flags required by this service's
+# IAM-token-based auth setup (see README "Why we freeze time" and docker-compose.yml).
+# Other services don't use this mechanism so they don't need the overhead.
+#
+# --build:
+# Ensures the dev Dockerfile stage is up to date so libfaketime is installed
+# and LD_PRELOAD is set; without it a cached image may lack faketime and
+# generate_db_auth_token() produces a token with the real current time instead
+# of the FAKETIME-frozen 2026-01-01, which won't match POSTGRES_PASSWORD.
+#
+# --force-recreate:
+# ensures the test-db container is replaced even when docker-compose
+# doesn't detect a config change, so a stale container initialised
+# with an old POSTGRES_PASSWORD is never reused.
+#
+# --renew-anon-volumes:
+# wipes the anonymous volume that postgres:17 creates for
+# /var/lib/postgresql/data; without it postgres skips
+# initialisation on restart and retains the old password
+# hash even after the container is recreated.
+test-override:
+    docker compose -f docker-compose.yml --profile test up --build --force-recreate --renew-anon-volumes --abort-on-container-exit --exit-code-from test --remove-orphans

--- a/data-in-api/tests/test_repository.py
+++ b/data-in-api/tests/test_repository.py
@@ -440,6 +440,33 @@ def test_select_label_with_null_attributes(session: Session):
     assert result.attributes == {}
 
 
+def test_select_label_with_label_relationship(session: Session):
+    """A label with a LabelLabelRelationship should expose it in labels."""
+    create_label(session, "child", "Child Label", type_="principal_law")
+    create_label(session, "parent", "Parent Label", type_="principal_law")
+    link_label_to_parent(session, "child", "parent", type="subconcept_of")
+
+    result = select_label(session, "child")
+
+    assert result is not None
+    assert len(result.labels) == 1
+    rel = result.labels[0]
+    assert rel.type == "subconcept_of"
+    assert rel.value.id == "parent"
+    assert rel.value.type == "principal_law"
+    assert rel.value.labels == []
+
+
+def test_select_label_without_label_relationship(session: Session):
+    """A label with no LabelLabelRelationship should have an empty labels list."""
+    create_label(session, "standalone", "Standalone", type_="entity_type")
+
+    result = select_label(session, "standalone")
+
+    assert result is not None
+    assert result.labels == []
+
+
 def test_document_labels_include_attributes(session_with_documents: Session):
     """Test that label attributes appear in top-level document labels."""
     # Create a label with attributes and link to doc1

--- a/data-in-api/tests/test_routes.py
+++ b/data-in-api/tests/test_routes.py
@@ -2,6 +2,8 @@ from http import HTTPStatus
 from unittest.mock import Mock
 
 import pytest
+from data_in_models.db_models import Label as DBLabel
+from data_in_models.db_models import LabelLabelRelationship as DBLabelLabelRelationship
 from data_in_models.models import Document as DocumentOutput
 from fastapi.testclient import TestClient
 from sqlmodel import Session
@@ -145,3 +147,40 @@ def test_list_documents_returns_empty_list(client, monkeypatch):
     data = response.json()
     assert data["total"] == 0
     assert data["data"] == []
+
+
+def test_get_label_response_includes_label_relationships(session: Session):
+    """GET /labels/{id} should return label relationships in the labels field."""
+    child = DBLabel(
+        id="child", value="Child Label", type="principal_law", attributes={}
+    )
+    parent = DBLabel(
+        id="parent", value="Parent Label", type="principal_law", attributes={}
+    )
+    session.add(child)
+    session.add(parent)
+    session.commit()
+
+    link = DBLabelLabelRelationship(
+        label_id="child", related_label_id="parent", type="subconcept_of"
+    )
+    session.add(link)
+    session.commit()
+
+    def get_db_override():
+        yield session
+
+    app.dependency_overrides[get_db] = get_db_override
+    client = TestClient(app)
+
+    try:
+        response = client.get("/data-in/labels/child")
+        assert response.status_code == HTTPStatus.OK
+        data = response.json()["data"]
+        assert data["id"] == "child"
+        assert len(data["labels"]) == 1
+        rel = data["labels"][0]
+        assert rel["type"] == "subconcept_of"
+        assert rel["value"]["id"] == "parent"
+    finally:
+        app.dependency_overrides.clear()

--- a/data-in-models/src/data_in_models/db_models.py
+++ b/data-in-models/src/data_in_models/db_models.py
@@ -63,6 +63,12 @@ class Label(WithDbDatetimeFields, table=True):
     )
 
     documents: list["DocumentLabelRelationship"] = Relationship(back_populates="label")
+    labels: list["LabelLabelRelationship"] = Relationship(
+        back_populates="label",
+        sa_relationship_kwargs={
+            "foreign_keys": "[LabelLabelRelationship.label_id]",
+        },
+    )
 
 
 class DocumentLabelRelationship(WithDbDatetimeFields, table=True):
@@ -106,6 +112,13 @@ class LabelLabelRelationship(WithDbDatetimeFields, table=True):
     related_label_id: str = Field(
         foreign_key="label.id",
         primary_key=True,
+    )
+
+    label: Label = Relationship(
+        back_populates="labels",
+        sa_relationship_kwargs={
+            "foreign_keys": "[LabelLabelRelationship.label_id]",
+        },
     )
 
 


### PR DESCRIPTION
# What does this do?
- fetches the label relationships in the `repository`
- renders those in the API response
- fixes a problem with Docker containers becoming stale locally to re-enable local testing for `data-in-api` (this has to do with the AWS authentication)

---

part of https://linear.app/climate-policy-radar/issue/APP-2084/extend-labels-to-support-current-search-filters