### PR TITLE
feat: add ecs service to concepts api

### DIFF
--- a/concepts-api/infra/__main__.py
+++ b/concepts-api/infra/__main__.py
@@ -1,7 +1,18 @@
 import pulumi
 import pulumi_aws as aws
+from pulumi_aws.ecs.express_gateway_service import (
+    ExpressGatewayService,
+    ExpressGatewayServiceNetworkConfigurationArgs,
+    ExpressGatewayServicePrimaryContainerArgs,
+    ExpressGatewayServicePrimaryContainerEnvironmentArgs,
+    ExpressGatewayServiceScalingTargetArgs,
+)
 
 account_id = aws.get_caller_identity().account_id
+
+config = pulumi.Config()
+stack = pulumi.get_stack()
+NAME_PREFIX = "concepts-api"
 
 
 # TODO: https://linear.app/climate-policy-radar/issue/APP-584/standardise-naming-in-infra
@@ -9,7 +20,17 @@ def generate_secret_key(project: str, aws_service: str, name: str):
     return f"/{project}/{aws_service}/{name}"
 
 
-# This stuff is being encapsulated in navigator-infra and we should use that once it is ready
+########################################################################
+# Reference to shared API services infra
+########################################################################
+
+ecs_infra = pulumi.StackReference(f"climatepolicyradar/ecs-infra/{stack}")
+aws_env_stack = pulumi.StackReference(f"climatepolicyradar/aws_env/{stack}")
+eu_west_1a_public_subnet_id = aws_env_stack.get_output("eu_west_1a_public_subnet_id")
+eu_west_1b_public_subnet_id = aws_env_stack.get_output("eu_west_1b_public_subnet_id")
+eu_west_1c_public_subnet_id = aws_env_stack.get_output("eu_west_1c_public_subnet_id")
+
+
 # IAM role trusted by App Runner
 concepts_api_role = aws.iam.Role(
     "concepts-api-role",
@@ -29,7 +50,6 @@ concepts_api_role = aws.iam.Role(
     ).json,
 )
 
-# Attach ECR access policy to the role
 concepts_api_role_policy = aws.iam.RolePolicy(
     "concepts-api-role-ecr-policy",
     role=concepts_api_role.id,
@@ -68,7 +88,6 @@ concepts_api_instance_role = aws.iam.Role(
     ).json,
 )
 
-# Allow access to specific SSM Parameter Store secrets
 concepts_api_ssm_policy = aws.iam.RolePolicy(
     "concepts-api-instance-role-ssm-policy",
     role=concepts_api_instance_role.id,
@@ -85,7 +104,6 @@ concepts_api_ssm_policy = aws.iam.RolePolicy(
     ).json,
 )
 
-
 concepts_api_ecr_repository = aws.ecr.Repository(
     "concepts-api-ecr-repository",
     encryption_configurations=[
@@ -100,7 +118,6 @@ concepts_api_ecr_repository = aws.ecr.Repository(
     name="concepts-api",
     opts=pulumi.ResourceOptions(protect=True),
 )
-
 
 concepts_api_apprunner_service = aws.apprunner.Service(
     "concepts-api-apprunner-service",
@@ -137,6 +154,99 @@ concepts_api_apprunner_service = aws.apprunner.Service(
         ),
     ),
     opts=pulumi.ResourceOptions(protect=True),
+)
+
+
+########################################################################
+# ECS Express Gateway service
+########################################################################
+
+# Task role: the IAM role the *running container* assumes.
+ecs_task_role = aws.iam.Role(
+    f"{NAME_PREFIX}-ecs-task-role",
+    name=f"{NAME_PREFIX}-ecs-task-role",
+    assume_role_policy=aws.iam.get_policy_document(
+        statements=[
+            aws.iam.GetPolicyDocumentStatementArgs(
+                effect="Allow",
+                principals=[
+                    aws.iam.GetPolicyDocumentStatementPrincipalArgs(
+                        type="Service",
+                        identifiers=["ecs-tasks.amazonaws.com"],
+                    )
+                ],
+                actions=["sts:AssumeRole"],
+            )
+        ]
+    ).json,
+)
+
+# SSM access for any secrets the container reads at runtime.
+aws.iam.RolePolicy(
+    f"{NAME_PREFIX}-ecs-task-role-ssm-policy",
+    role=ecs_task_role.id,
+    policy=aws.iam.get_policy_document(
+        statements=[
+            aws.iam.GetPolicyDocumentStatementArgs(
+                effect="Allow",
+                actions=["ssm:GetParameters"],
+                resources=[
+                    f"arn:aws:ssm:eu-west-1:{account_id}:parameter/concepts-api/*"
+                ],
+            )
+        ]
+    ).json,
+)
+
+# Container config
+primary_container = ExpressGatewayServicePrimaryContainerArgs(
+    image=concepts_api_ecr_repository.repository_url.apply(lambda url: f"{url}:latest"),
+    container_port=8080,  # @related: PORT_NUMBER
+    environments=[
+        ExpressGatewayServicePrimaryContainerEnvironmentArgs(
+            name="Environment",
+            value=pulumi.get_stack(),
+        ),
+    ],
+)
+
+ecs_express_service = ExpressGatewayService(
+    f"{NAME_PREFIX}-ecs-express-service",
+    service_name=NAME_PREFIX,
+    cluster=ecs_infra.get_output("cluster_arn"),
+    execution_role_arn=ecs_infra.get_output("task_execution_role_arn"),
+    infrastructure_role_arn=ecs_infra.get_output("infrastructure_role_arn"),
+    task_role_arn=ecs_task_role.arn,  # service-specific
+    primary_container=primary_container,
+    health_check_path="/health",
+    cpu="1024",
+    memory="2048",
+    scaling_targets=[
+        ExpressGatewayServiceScalingTargetArgs(
+            auto_scaling_metric="AVERAGE_CPU",
+            auto_scaling_target_value=70,
+            min_task_count=1,
+            max_task_count=4,
+        ),
+    ],
+    network_configurations=[
+        ExpressGatewayServiceNetworkConfigurationArgs(
+            security_groups=[ecs_infra.get_output("alb_security_group_id")],
+            subnets=[
+                eu_west_1a_public_subnet_id,
+                eu_west_1b_public_subnet_id,
+                eu_west_1c_public_subnet_id,
+            ],
+        ),
+    ],
+)
+
+
+pulumi.export(
+    "ecs_express_service_url",
+    ecs_express_service.ingress_paths.apply(
+        lambda paths: paths[0].endpoint.removeprefix("https://") if paths else None
+    ),
 )
 
 pulumi.export("apprunner_service_url", concepts_api_apprunner_service.service_url)


### PR DESCRIPTION
## Add ECS Express Gateway service to concepts API

Mirrors the ECS setup introduced for the geographies API, giving the concepts API a second compute backend alongside the existing App Runner service.

### Changes
- Added `ExpressGatewayService` resource using the shared cluster, task execution role, and infrastructure role pulled from the `ecs-infra` stack reference
- Added stack references to `aws_env` for subnet IDs across all three AZs
- Created a dedicated ECS task role (`concepts-api-{stack}-ecs-task-role`) with SSM access scoped to `concepts-api/*`
- Exported `ecs_express_service_url` alongside the existing `apprunner_service_url`

### Notes
- All existing App Runner resources are unchanged
- No S3 policy attached to the task role — concepts API has no bucket dependency (unlike geographies)
- CPU/memory set to `1024`/`2048` to match geographies defaults

## Why is it needed?
[Ongoing ECS Migration ](https://www.notion.so/climatepolicyradar/Service-Migration-from-AppRunner-to-ECS-Express-SMD-3599109609a4801a8546daa6cc41a766?source=copy_link)
## How was it tested?
Testing that the staging urls are up and we can see the openapi spec