### PR TITLE
fix: add health endpoint to app root for ALB health checks

### DIFF
--- a/concepts-api/app/main.py
+++ b/concepts-api/app/main.py
@@ -303,7 +303,7 @@ async def get_concept(concept_id: str):
     return {"concept": concept, "related_concepts": related, "subconcepts": subconcepts}
 
 
-@router.get("/health")
+@router.get("/db-health")
 async def health_check():
     db = get_db()
 

--- a/concepts-api/app/main.py
+++ b/concepts-api/app/main.py
@@ -89,17 +89,10 @@ app = FastAPI(
 
 @app.get("/health")
 async def service_health_check():
-    db = get_db()
-    try:
-        db.execute("SELECT 1").fetchone()
-        return {
-            "status": "ok",
-            "version": settings.github_sha,
-        }
-    except Exception:
-        raise HTTPException(
-            status_code=500, detail="Database connection failed"
-        ) from Exception
+    return {
+        "status": "ok",
+        "version": settings.github_sha,
+    }
 
 
 @router.get("/search")

--- a/concepts-api/app/main.py
+++ b/concepts-api/app/main.py
@@ -136,9 +136,10 @@ async def search_concepts(
                 """,
                 [limit],
             )
-    elif has_classifier:
-        result = db.execute(
-            """
+    else:
+        if has_classifier:
+            result = db.execute(
+                """
                 SELECT
                     wikibase_id,
                     preferred_label,
@@ -153,11 +154,11 @@ async def search_concepts(
                 AND has_classifier = ?
                 LIMIT ?
                 """,
-            [f"{q}%", has_classifier, limit],
-        )
-    else:
-        result = db.execute(
-            """
+                [f"{q}%", has_classifier, limit],
+            )
+        else:
+            result = db.execute(
+                """
                 SELECT
                     wikibase_id,
                     preferred_label,
@@ -171,8 +172,8 @@ async def search_concepts(
                 WHERE preferred_label ILIKE ?
                 LIMIT ?
                 """,
-            [f"{q}%", limit],
-        )
+                [f"{q}%", limit],
+            )
 
     if result.description is not None and (rows := result.fetchall()):
         columns = [desc[0] for desc in result.description]

--- a/concepts-api/app/main.py
+++ b/concepts-api/app/main.py
@@ -27,7 +27,7 @@ try:
         ServiceManifest.from_file(f"{root_dir}/service-manifest.json"), ENV, "0.1.0"
     )
 except Exception as _:
-    _LOGGER.error("Failed to load service manifest, using defaults")
+    _LOGGER.exception("Failed to load service manifest, using defaults")
     otel_config = TelemetryConfig(
         service_name="navigator-backend",
         namespace_name="navigator",
@@ -53,13 +53,12 @@ async def lifespan(app: FastAPI):
     # Startup
     global conn
     try:
-
         db_path = root_dir / "initial-data" / "concepts.db"
         conn = duckdb.connect(db_path, read_only=True)
         _LOGGER.info("🔌 Database connection established")
         yield
     except Exception as e:
-        _LOGGER.error(f"❌ Database connection failed: {e}")
+        _LOGGER.exception(f"❌ Database connection failed: {e}")
         raise
     finally:
         # Shutdown
@@ -86,6 +85,21 @@ app = FastAPI(
     redoc_url="/concepts/redoc",
     openapi_url="/concepts/openapi.json",
 )
+
+
+@app.get("/health")
+async def service_health_check():
+    db = get_db()
+    try:
+        db.execute("SELECT 1").fetchone()
+        return {
+            "status": "ok",
+            "version": settings.github_sha,
+        }
+    except Exception:
+        raise HTTPException(
+            status_code=500, detail="Database connection failed"
+        ) from Exception
 
 
 @router.get("/search")
@@ -129,10 +143,9 @@ async def search_concepts(
                 """,
                 [limit],
             )
-    else:
-        if has_classifier:
-            result = db.execute(
-                """
+    elif has_classifier:
+        result = db.execute(
+            """
                 SELECT
                     wikibase_id,
                     preferred_label,
@@ -147,11 +160,11 @@ async def search_concepts(
                 AND has_classifier = ?
                 LIMIT ?
                 """,
-                [f"{q}%", has_classifier, limit],
-            )
-        else:
-            result = db.execute(
-                """
+            [f"{q}%", has_classifier, limit],
+        )
+    else:
+        result = db.execute(
+            """
                 SELECT
                     wikibase_id,
                     preferred_label,
@@ -165,8 +178,8 @@ async def search_concepts(
                 WHERE preferred_label ILIKE ?
                 LIMIT ?
                 """,
-                [f"{q}%", limit],
-            )
+            [f"{q}%", limit],
+        )
 
     if result.description is not None and (rows := result.fetchall()):
         columns = [desc[0] for desc in result.description]


### PR DESCRIPTION
# What does this do?

our ECS container won't start up because it can't reach the health endpoint, the actual route defintion is /concepts/health but as you can see by Amazon Q's diagnosis this causes an issue if you set that endpoint as the health check

```
Based on my comprehensive investigation, I can now provide you with a complete analysis of the ECS service deployment issue.
ROOT CAUSE ANALYSIS
Primary Root Cause: Health Check Endpoint Mismatch
The deployment is failing due to inconsistent health check endpoint configurations between the two target groups:

Target Group 1 (ecs-gateway-tg-9ad4e83c5e4f66ac6): Health check path = /concepts/health
Target Group 2 (ecs-gateway-tg-bb115eb70d0af98fc): Health check path =
/health
Current State Analysis:
Task Status:

Task 1 (af82e5a8ec55...): Running task definition revision 2, IP 10.0.20.109
Container status: RUNNING
Health status: UNKNOWN (no container-level health checks configured)
Registered to target group expecting /concepts/health endpoint
Target group reports: UNHEALTHY - 404 errors
Task 2 (60e7eb7c18c2...): Running task definition revision 1, IP 10.0.15.220
 
Container status: RUNNING
Health status: UNKNOWN
No targets registered in its target group Secondary Issues:

Rollback Failure: The "ROLLBACK_FAILED" status with "No rollback candidate was found" indicates that both deployments have failed, leaving no healthy deployment to roll back to.
Circuit Breaker Activation: Both deployments show "ECS deployment circuit breaker: tasks failed to start" due to repeated health check failures.
Application Health Check Implementation: The 404 responses suggest the application either:
Doesn't implement the /concepts/health endpoint
Has a routing issue preventing access to the health endpoint
Is not fully initialized when health checks begin RESOLUTION RECOMMENDATIONS Immediate Actions:

```

so i have added an app level health endpoint, which replicates the concept/health
