### PR TITLE
chore: grant GitHub Actions role permissions for families-api IAM and…

### DIFF
--- a/api/infra/__main__.py
+++ b/api/infra/__main__.py
@@ -370,6 +370,7 @@ navigator_backend_github_actions_deploy = aws.iam.Role(
                         resources=[
                             f"arn:aws:ssm:*:{account_id}:parameter/data-in-pipeline/*",
                             f"arn:aws:ssm:*:{account_id}:parameter/data-in-api/*",
+                            f"arn:aws:ssm:*:{account_id}:parameter/families-api/*",
                         ],
                     ),
                     aws.iam.GetPolicyDocumentStatementArgs(
@@ -407,9 +408,13 @@ navigator_backend_github_actions_deploy = aws.iam.Role(
                     aws.iam.GetPolicyDocumentStatementArgs(
                         actions=[
                             "iam:PassRole",
+                            "iam:CreateRole",
+                            "iam:DeleteRole",
                             "iam:DeleteRolePolicy",
                             "iam:GetRole",
                             "iam:ListRolePolicies",
+                            "iam:ListRoleTags",
+                            "iam:TagRole",
                             "iam:GetRolePolicy",
                             "iam:PutRolePolicy",
                             "iam:ListAttachedRolePolicies",
@@ -418,6 +423,7 @@ navigator_backend_github_actions_deploy = aws.iam.Role(
                         resources=[
                             f"arn:aws:iam::{account_id}:role/data-in-pipeline-*",
                             f"arn:aws:iam::{account_id}:role/data-in-api-*",
+                            f"arn:aws:iam::{account_id}:role/families-api-*",
                         ],
                     ),
                     aws.iam.GetPolicyDocumentStatementArgs(
@@ -427,6 +433,8 @@ navigator_backend_github_actions_deploy = aws.iam.Role(
                         effect="Allow",
                         resources=[
                             f"arn:aws:ssm:*:{account_id}:parameter/data-in-pipeline/*",
+                            f"arn:aws:ssm:*:{account_id}:parameter/data-in-api/*",
+                            f"arn:aws:ssm:*:{account_id}:parameter/families-api/*",
                         ],
                     ),
                 ]

--- a/api/infra/__main__.py
+++ b/api/infra/__main__.py
@@ -371,6 +371,8 @@ navigator_backend_github_actions_deploy = aws.iam.Role(
                             f"arn:aws:ssm:*:{account_id}:parameter/data-in-pipeline/*",
                             f"arn:aws:ssm:*:{account_id}:parameter/data-in-api/*",
                             f"arn:aws:ssm:*:{account_id}:parameter/families-api/*",
+                            f"arn:aws:ssm:*:{account_id}:parameter/concepts-api/*",
+                            f"arn:aws:ssm:*:{account_id}:parameter/geographies-api/*",
                         ],
                     ),
                     aws.iam.GetPolicyDocumentStatementArgs(
@@ -424,6 +426,8 @@ navigator_backend_github_actions_deploy = aws.iam.Role(
                             f"arn:aws:iam::{account_id}:role/data-in-pipeline-*",
                             f"arn:aws:iam::{account_id}:role/data-in-api-*",
                             f"arn:aws:iam::{account_id}:role/families-api-*",
+                            f"arn:aws:iam::{account_id}:role/concepts-api-*",
+                            f"arn:aws:iam::{account_id}:role/geographies-api-*",
                         ],
                     ),
                     aws.iam.GetPolicyDocumentStatementArgs(
@@ -435,6 +439,8 @@ navigator_backend_github_actions_deploy = aws.iam.Role(
                             f"arn:aws:ssm:*:{account_id}:parameter/data-in-pipeline/*",
                             f"arn:aws:ssm:*:{account_id}:parameter/data-in-api/*",
                             f"arn:aws:ssm:*:{account_id}:parameter/families-api/*",
+                            f"arn:aws:ssm:*:{account_id}:parameter/concepts-api/*",
+                            f"arn:aws:ssm:*:{account_id}:parameter/geographies-api/*",
                         ],
                     ),
                 ]


### PR DESCRIPTION


# What does this do?

Grants the navigator-backend-github-actions-deploy role the additional IAM and SSM permissions required to deploy the families-api stack. & concepts-api stack. This unblocks creation of the new families-api-production-ecs-task-role and allows Pulumi to read/write the existing App Runner IAM roles and SSM parameters under /families-api/*.

Have added in the other resources for good measure. 

## Why is it needed?
[failing ci runs](https://github.com/climatepolicyradar/navigator-backend/actions/runs/27131772669/job/80074244278) when trying to deploy

```
aws:iam:Role (families-api-instance-role):
    error:   sdk-v2/provider2.go:572: sdk.helper_schema: reading IAM Role (families-api-instance-role-88146e1): operation error IAM: GetRole, https response error StatusCode: 403, RequestID: bf77a8cd-3f47-4a52-8d35-fd4d0ed4176a, api error AccessDenied: User: arn:aws:sts::***:assumed-role/navigator-backend-github-actions-deploy/GitHub_to_AWS_via_FederatedOIDC_production is not authorized to perform: iam:GetRole on resource: role families-api-instance-role-88146e1 because no identity-based policy allows the iam:GetRole action: provider=aws@7.29.0
    error:   sdk-v2/provider2.go:572: sdk.helper_schema: listing tags for IAM (Identity & Access Management) Role (families-api-instance-role-88146e1): listing tags for resource (families-api-instance-role-88146e1): operation error IAM: ListRoleTags, https response error StatusCode: 403, RequestID: a4174511-1526-470a-a03a-72800a44237a, api error AccessDenied: User: arn:aws:sts::***:assumed-role/navigator-backend-github-actions-deploy/GitHub_to_AWS_via_FederatedOIDC_production is not authorized to perform: iam:ListRoleTags on resource: role families-api-instance-role-88146e1 because no identity-based policy allows the iam:ListRoleTags action: provider=aws@7.29.0
    error: 1 error occurred:
    	* updating urn:pulumi:production::families-api::aws:iam/role:Role::families-api-instance-role: 2 errors occurred:
    	* reading IAM Role (families-api-instance-role-88146e1): operation error IAM: GetRole, https response error StatusCode: 403, RequestID: bf77a8cd-3f47-4a52-8d35-fd4d0ed4176a, api error AccessDenied: User: arn:aws:sts::***:assumed-role/navigator-backend-github-actions-deploy/GitHub_to_AWS_via_FederatedOIDC_production is not authorized to perform: iam:GetRole on resource: role families-api-instance-role-88146e1 because no identity-based policy allows the iam:GetRole action
    	* listing tags for IAM (Identity & Access Management) Role (families-api-instance-role-88146e1): listing tags for resource (families-api-instance-role-88146e1): operation error IAM: ListRoleTags, https response error StatusCode: 403, RequestID: a4174511-1526-470a-a03a-72800a44237a, api error AccessDenied: User: arn:aws:sts::***:assumed-role/navigator-backend-github-actions-deploy/GitHub_to_AWS_via_FederatedOIDC_production is not authorized to perform: iam:ListRoleTags on resource: role families-api-instance-role-88146e1 because no identity-based policy allows the iam:ListRoleTags action

  aws:ssm:Parameter (families-api-apprunner-cdn-url):
    error:   sdk-v2/provider2.go:572: sdk.helper_schema: updating SSM Parameter (/families-api/apprunner/CDN_URL): operation error SSM: PutParameter, https response error StatusCode: 400, RequestID: f3b32d02-0ccf-41c9-bb56-0e6ed7244085, api error AccessDeniedException: User: arn:aws:sts::***:assumed-role/navigator-backend-github-actions-deploy/GitHub_to_AWS_via_FederatedOIDC_production is not authorized to perform: ssm:PutParameter on resource: arn:aws:ssm:eu-west-1:***:parameter/families-api/apprunner/CDN_URL because no identity-based policy allows the ssm:PutParameter action: provider=aws@7.29.0
    error:   sdk-v2/provider2.go:572: sdk.helper_schema: listing tags for SSM (Systems Manager) Parameter (/families-api/apprunner/CDN_URL): operation error SSM: ListTagsForResource, https response error StatusCode: 400, RequestID: 92931814-d2d2-4f91-aeee-17bc62dd09cf, api error AccessDeniedException: User: arn:aws:sts::***:assumed-role/navigator-backend-github-actions-deploy/GitHub_to_AWS_via_FederatedOIDC_production is not authorized to perform: ssm:ListTagsForResource on resource: arn:aws:ssm:eu-west-1:***:parameter/families-api/apprunner/CDN_URL because no identity-based policy allows the ssm:ListTagsForResource action: provider=aws@7.29.0
    error: 1 error occurred:
    	* updating urn:pulumi:production::families-api::aws:ssm/parameter:Parameter::families-api-apprunner-cdn-url: 2 errors occurred:
    	* updating SSM Parameter (/families-api/apprunner/CDN_URL): operation error SSM: PutParameter, https response error StatusCode: 400, RequestID: f3b32d02-0ccf-41c9-bb56-0e6ed7244085, api error AccessDeniedException: User: arn:aws:sts::***:assumed-role/navigator-backend-github-actions-deploy/GitHub_to_AWS_via_FederatedOIDC_production is not authorized to perform: ssm:PutParameter on resource: arn:aws:ssm:eu-west-1:***:parameter/families-api/apprunner/CDN_URL because no identity-based policy allows the ssm:PutParameter action
    	* listing tags for SSM (Systems Manager) Parameter (/families-api/apprunner/CDN_URL): operation error SSM: ListTagsForResource, https response error StatusCode: 400, RequestID: 92931814-d2d2-4f91-aeee-17bc62dd09cf, api error AccessDeniedException: User: arn:aws:sts::***:assumed-role/navigator-backend-github-actions-deploy/GitHub_to_AWS_via_FederatedOIDC_production is not authorized to perform: ssm:ListTagsForResource on resource: arn:aws:ssm:eu-west-1:***:parameter/families-api/apprunner/CDN_URL because no identity-based policy allows the ssm:ListTagsForResource action

  aws:ssm:Parameter (families-api-apprunner-navigator-database-url):
    error:   sdk-v2/provider2.go:572: sdk.helper_schema: updating SSM Parameter (/families-api/apprunner/NAVIGATOR_DATABASE_URL): operation error SSM: PutParameter, https response error StatusCode: 400, RequestID: b41344a9-a5c8-40f1-a9e9-0471b3bba8fc, api error AccessDeniedException: User: arn:aws:sts::***:assumed-role/navigator-backend-github-actions-deploy/GitHub_to_AWS_via_FederatedOIDC_production is not authorized to perform: ssm:PutParameter on resource: arn:aws:ssm:eu-west-1:***:parameter/families-api/apprunner/NAVIGATOR_DATABASE_URL because no identity-based policy allows the ssm:PutParameter action: provider=aws@7.29.0
    error:   sdk-v2/provider2.go:572: sdk.helper_schema: listing tags for SSM (Systems Manager) Parameter (/families-api/apprunner/NAVIGATOR_DATABASE_URL): operation error SSM: ListTagsForResource, https response error StatusCode: 400, RequestID: 712d6833-b08f-413d-aa40-af010170b232, api error AccessDeniedException: User: arn:aws:sts::***:assumed-role/navigator-backend-github-actions-deploy/GitHub_to_AWS_via_FederatedOIDC_production is not authorized to perform: ssm:ListTagsForResource on resource: arn:aws:ssm:eu-west-1:***:parameter/families-api/apprunner/NAVIGATOR_DATABASE_URL because no identity-based policy allows the ssm:ListTagsForResource action: provider=aws@7.29.0
    error: 1 error occurred:
    	* updating urn:pulumi:production::families-api::aws:ssm/parameter:Parameter::families-api-apprunner-navigator-database-url: 2 errors occurred:
    	* updating SSM Parameter (/families-api/apprunner/NAVIGATOR_DATABASE_URL): operation error SSM: PutParameter, https response error StatusCode: 400, RequestID: b41344a9-a5c8-40f1-a9e9-0471b3bba8fc, api error AccessDeniedException: User: arn:aws:sts::***:assumed-role/navigator-backend-github-actions-deploy/GitHub_to_AWS_via_FederatedOIDC_production is not authorized to perform: ssm:PutParameter on resource: arn:aws:ssm:eu-west-1:***:parameter/families-api/apprunner/NAVIGATOR_DATABASE_URL because no identity-based policy allows the ssm:PutParameter action
    	* listing tags for SSM (Systems Manager) Parameter (/families-api/apprunner/NAVIGATOR_DATABASE_URL): operation error SSM: ListTagsForResource, https response error StatusCode: 400, RequestID: 712d6833-b08f-413d-aa40-af010170b232, api error AccessDeniedException: User: arn:aws:sts::***:assumed-role/navigator-backend-github-actions-deploy/GitHub_to_AWS_via_FederatedOIDC_production is not authorized to perform: ssm:ListTagsForResource on resource: arn:aws:ssm:eu-west-1:***:parameter/families-api/apprunner/NAVIGATOR_DATABASE_URL because no identity-based policy allows the ssm:ListTagsForResource action
```


## How was it tested?
