### PR TITLE
fix: remove plural from Corporate Disclosure

### DIFF
--- a/data-in-pipeline/app/transform/navigator_family.py
+++ b/data-in-pipeline/app/transform/navigator_family.py
@@ -43,9 +43,9 @@ from app.transform.models import (
 # Constants
 # ---------------------------------------------------------------------------
 
-# region Corporate disclosures
+# region Corporate disclosure
 corporate_discloser = Label(
-    type="category", id="category::Corporate Disclosures", value="Corporate Disclosures"
+    type="category", id="category::Corporate Disclosure", value="Corporate Disclosure"
 )
 corporate_voluntary_report = Label(
     id="entity_type::Corporate voluntary report",


### PR DESCRIPTION
# What does this do?

removes the `s` from `Corporate Disclosure`

There is a longer term fix here where we shouldn't be using free text - but it's a larger refactor that I cannot prioritise right now.