### PR TITLE
fix: use litigation for root subconcept of litigation concepts

### DIFF
--- a/data-in-pipeline/app/transform/navigator_family.py
+++ b/data-in-pipeline/app/transform/navigator_family.py
@@ -363,6 +363,9 @@ national_drought_plan = Label(
     labels=[LabelRelationship(type="subconcept_of", value=unccd)],
 )
 
+# region Litigation
+litigation = Label(type="category", id="category::Litigation", value="Litigation")
+
 
 _eu_and_international_region_ids = {c.id: c for c in custom_countries}
 
@@ -1066,21 +1069,27 @@ def _transform_litigation_concepts_to_label_relationships(
     # Wire up parent-child relationships
     for concept in concepts:
         child = label_map[(concept.relation, concept.id)]
-        for parent_name in concept.subconcept_of_labels:
-            parent = label_by_name.get((concept.relation, parent_name))
-            if parent is None:
-                warnings.append(
-                    UnknownParentLabel(
-                        family_import_id=family_import_id,
-                        relation=concept.relation,
-                        parent_name=parent_name,
-                    )
-                )
-                continue
-            parent_ref = _shallow_label(parent)
+
+        if not concept.subconcept_of_labels:
             child.labels.append(
-                LabelRelationship(type="subconcept_of", value=parent_ref)
+                LabelRelationship(type="subconcept_of", value=litigation)
             )
+        else:
+            for parent_name in concept.subconcept_of_labels:
+                parent = label_by_name.get((concept.relation, parent_name))
+                if parent is None:
+                    warnings.append(
+                        UnknownParentLabel(
+                            family_import_id=family_import_id,
+                            relation=concept.relation,
+                            parent_name=parent_name,
+                        )
+                    )
+                    continue
+                parent_ref = _shallow_label(parent)
+                child.labels.append(
+                    LabelRelationship(type="subconcept_of", value=parent_ref)
+                )
 
     labels = [
         # we use legal_concept over concept as `concept` is reserved for our knowledge graph labels

--- a/data-in-pipeline/tests/transform/test_navigator_family_litigation.py
+++ b/data-in-pipeline/tests/transform/test_navigator_family_litigation.py
@@ -729,7 +729,16 @@ def test_transform_navigator_family_with_litigation_corpus_type_and_litigation_c
                 type="legal_concept",
                 value=LabelWithoutDocumentRelationships(
                     id="jurisdiction::England and Wales",
-                    labels=[],
+                    labels=[
+                        LabelRelationship(
+                            type="subconcept_of",
+                            value=Label(
+                                id="category::Litigation",
+                                value="Litigation",
+                                type="category",
+                            ),
+                        )
+                    ],
                     type="jurisdiction",
                     value="England and Wales",
                 ),


### PR DESCRIPTION
- uses `category::Litigation` for concepts from Sabin that have no `subconcept_of` from the source data

---

part of https://linear.app/climate-policy-radar/issue/APP-2084/extend-labels-to-support-current-search-filters

part of https://linear.app/climate-policy-radar/issue/APP-2088/move-transformnavigator-family-1-transformer-label-pattern