### PR TITLE
chore: bump cpu and memory for families api ecs task

### DIFF
--- a/families-api/infra/__main__.py
+++ b/families-api/infra/__main__.py
@@ -319,8 +319,8 @@ ecs_express_service = ExpressGatewayService(
     task_role_arn=ecs_task_role.arn,
     primary_container=primary_container,
     health_check_path="/health",
-    cpu="1024",
-    memory="2048",
+    cpu="2048",
+    memory="4096",
     scaling_targets=[
         ExpressGatewayServiceScalingTargetArgs(
             auto_scaling_metric="AVERAGE_CPU",


### PR DESCRIPTION
# What does this do?
per title

We tend to hit the ceiling of the task/container resources every day when we run the DIP pipeline. 


