### PR TITLE
fix: add kosovo

### DIFF
--- a/geographies-api/app/data/cpr_custom_geographies.py
+++ b/geographies-api/app/data/cpr_custom_geographies.py
@@ -23,4 +23,12 @@ countries = {
         "numeric": "",
         "flag": "🇪🇺",
     },
+    "XKX": {
+        "alpha_2": "XK",
+        "alpha_3": "XKX",
+        "name": "Kosovo",
+        "official_name": "Republic of Kosovo",
+        "numeric": "",
+        "flag": "🇽🇰",
+    },
 }


### PR DESCRIPTION
# What does this do?

As Kosovo isn't in the ISO-3166 standard, [it has a commonly used user assigned value](https://en.wikipedia.org/wiki/XK_(user_assigned_code)).

`XKX` is used in our DB - [which you can see applied to this family](https://api.climatepolicyradar.org/families/CCLW.family.i00000218.n0000). 

This adds it to our list of custom countries.
