### PR TITLE
Feature/app 2183 trigger ecs deploy on merge to main data-in-pipeline-load-api

### DIFF
--- a/.github/workflows/deploy-load-api.yml
+++ b/.github/workflows/deploy-load-api.yml
@@ -25,6 +25,21 @@ jobs:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/navigator-backend-github-actions-deploy
           role-session-name: GitHub_to_AWS_via_FederatedOIDC_${{ matrix.environment }}
           aws-region: eu-west-1
+
+      - name: Require existing service
+        env:
+          CLUSTER: data-in-pipeline-load-api-${{ matrix.environment }}
+          SERVICE_NAME: data-in-pipeline-load-api-${{ matrix.environment }}
+        run: |
+          set -euo pipefail
+          STATUS=$(aws ecs describe-services \
+            --cluster "${CLUSTER}" --services "${SERVICE_NAME}" \
+            --query 'services[0].status' --output text 2>/dev/null || echo "MISSING")
+          if [[ "${STATUS}" != "ACTIVE" ]]; then
+            echo "::error::Service ${SERVICE_NAME} not ACTIVE in ${CLUSTER} (got: ${STATUS}); refusing to create."
+            exit 1
+          fi
+
       - uses: aws-actions/amazon-ecr-login@v2
       - uses: astral-sh/setup-uv@v7
       - run: uv sync --all-packages

--- a/.github/workflows/deploy-load-api.yml
+++ b/.github/workflows/deploy-load-api.yml
@@ -1,0 +1,70 @@
+name: Deploy Load API
+on:
+  workflow_call:
+    inputs:
+      environment:
+        required: true
+        type: string
+permissions:
+  id-token: write
+  contents: read
+jobs:
+  deploy-load-api:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        environment: ${{ fromJSON(inputs.environment) }}
+    environment: ${{ matrix.environment }}
+    env:
+      SERVICE: data-in-pipeline-load-api
+    steps:
+      - uses: actions/checkout@v6
+      - uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/navigator-backend-github-actions-deploy
+          role-session-name: GitHub_to_AWS_via_FederatedOIDC_${{ matrix.environment }}
+          aws-region: eu-west-1
+      - uses: aws-actions/amazon-ecr-login@v2
+      - uses: astral-sh/setup-uv@v7
+      - run: uv sync --all-packages
+      - uses: extractions/setup-just@v4
+
+      - name: Build and push image
+        run: |
+          REGISTRY="${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.eu-west-1.amazonaws.com"
+          just build "${SERVICE}" "${{ matrix.environment }}" "${{ github.sha }}"
+          docker tag "${SERVICE}:${{ github.sha }}" "${REGISTRY}/${SERVICE}:${{ github.sha }}"
+          docker tag "${SERVICE}:${{ github.sha }}" "${REGISTRY}/${SERVICE}:latest"
+          docker push "${REGISTRY}/${SERVICE}:${{ github.sha }}"
+          docker push "${REGISTRY}/${SERVICE}:latest"
+
+      - id: deploy
+        uses: aws-actions/amazon-ecs-deploy-express-service@v1
+        with:
+          cluster: data-in-pipeline-load-api-${{ matrix.environment }}
+          service-name: data-in-pipeline-load-api-${{ matrix.environment }}
+          image: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.eu-west-1.amazonaws.com/data-in-pipeline-load-api:${{ github.sha }}
+          execution-role-arn: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/data-in-pipeline-load-api-${{ matrix.environment }}-ecs-execution-role
+          infrastructure-role-arn: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/data-in-pipeline-load-api-${{ matrix.environment }}-ecs-infrastructure-role
+
+      - name: Verify deployment outcome
+        env:
+          SERVICE_ARN: ${{ steps.deploy.outputs.service-arn }}
+          CLUSTER: data-in-pipeline-load-api-${{ matrix.environment }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${SERVICE_ARN}" ]]; then
+            echo "::error::deploy step did not emit a service-arn output"; exit 1
+          fi
+          DEPLOY_ARN=$(aws ecs list-service-deployments \
+            --cluster "${CLUSTER}" --service "${SERVICE_ARN}" \
+            --query 'serviceDeployments[0].serviceDeploymentArn' --output text)
+          if [[ -z "${DEPLOY_ARN}" || "${DEPLOY_ARN}" == "None" ]]; then
+            echo "::error::Could not find a service deployment for ${SERVICE_ARN}"; exit 1
+          fi
+          STATUS=$(aws ecs describe-service-deployments \
+            --service-deployment-arns "${DEPLOY_ARN}" \
+            --query 'serviceDeployments[0].status' --output text)
+          echo "Deployment ${DEPLOY_ARN} final status: ${STATUS}"
+          [[ "${STATUS}" == "SUCCESSFUL" ]] || { echo "::error::status=${STATUS}"; exit 1; }

--- a/.github/workflows/merge-to-main.yml
+++ b/.github/workflows/merge-to-main.yml
@@ -18,6 +18,7 @@ jobs:
       services: ${{ steps.parse.outputs.services }}
       infra_services: ${{ steps.parse.outputs.infra_services }}
       ecs_services: ${{ steps.parse.outputs.ecs_services }}
+      deploy_load_api_ecs: ${{ steps.parse.outputs.deploy_load_api }}
 
     steps:
       - uses: actions/checkout@v6
@@ -86,7 +87,8 @@ jobs:
           CHANGES='${{ steps.filter.outputs.changes }}'
           echo "services=$(echo "$CHANGES" | jq -c '[.[] | select(contains("/infra") | not)]')" >> $GITHUB_OUTPUT
           echo "infra_services=$(echo "$CHANGES" | jq -c '[.[] | select(contains("/infra"))]')" >> $GITHUB_OUTPUT
-          echo "ecs_services=$(echo "$CHANGES" | jq -c '[.[] | select(contains("/infra") | not) | select(. == "geographies-api" or . == "families-api" or . == "data-in-pipeline-load-api" or . == "concepts-api" or . == "data-in-api")]')" >> $GITHUB_OUTPUT
+          echo "deploy_load_api_ecs=$(echo "$CHANGES" | jq -c 'any(.[]; . == "data-in-pipeline-load-api")')" >> $GITHUB_OUTPUT
+          echo "ecs_services=$(echo "$CHANGES" | jq -c '[.[] | select(contains("/infra") | not) | select(. == "geographies-api" or . == "families-api"  or . == "concepts-api" or . == "data-in-api")]')" >> $GITHUB_OUTPUT
 
   test:
     needs: changes
@@ -219,4 +221,15 @@ jobs:
     if: (needs.test.result == 'success' || needs.test.result == 'skipped') && needs.changes.result == 'success' && needs.changes.outputs.ecs_services != '[]'
     with:
       ecs_services: ${{ needs.changes.outputs.ecs_services }}
+      environment: '["staging", "production"]'
+
+  deploy-load-api:
+    uses: ./.github/workflows/deploy-load-api.yml
+    secrets: inherit
+    needs: [changes, test]
+    if: >-
+      (needs.test.result == 'success' || needs.test.result == 'skipped')
+      && needs.changes.result == 'success'
+      && needs.changes.outputs.deploy_load_api_ecs == 'true'
+    with:
       environment: '["staging", "production"]'

--- a/.github/workflows/merge-to-main.yml
+++ b/.github/workflows/merge-to-main.yml
@@ -86,7 +86,7 @@ jobs:
           CHANGES='${{ steps.filter.outputs.changes }}'
           echo "services=$(echo "$CHANGES" | jq -c '[.[] | select(contains("/infra") | not)]')" >> $GITHUB_OUTPUT
           echo "infra_services=$(echo "$CHANGES" | jq -c '[.[] | select(contains("/infra"))]')" >> $GITHUB_OUTPUT
-          echo "ecs_services=$(echo "$CHANGES" | jq -c '[.[] | select(contains("/infra") | not) | select(. == "geographies-api" or . == "families-api" or . == "concepts-api" or . == "data-in-api")]')" >> $GITHUB_OUTPUT
+          echo "ecs_services=$(echo "$CHANGES" | jq -c '[.[] | select(contains("/infra") | not) | select(. == "geographies-api" or . == "families-api" or . == "data-in-pipeline-load-api" or . == "concepts-api" or . == "data-in-api")]')" >> $GITHUB_OUTPUT
 
   test:
     needs: changes

--- a/data-in-pipeline-load-api/app/main.py
+++ b/data-in-pipeline-load-api/app/main.py
@@ -23,7 +23,7 @@ root_dir = Path(__file__).parent.parent
 
 _LOGGER.debug("🚀 Starting FastAPI application")
 
-# Configure Open Telemetry.
+# Configure Open Telemetry
 ENV = os.getenv("ENV", "development")
 os.environ["OTEL_PYTHON_LOG_CORRELATION"] = "True"
 try:
@@ -39,7 +39,7 @@ except Exception as _:
         environment=ENV,
     )
 
-# Configure FastAPI and SQLAlchemy telemetry for the service.
+# Configure FastAPI and SQLAlchemy telemetry for the service
 telemetry = FastAPITelemetry(otel_config)
 tracer = telemetry.get_tracer()
 sqlalchemy_telemetry = SQLAlchemyTelemetry(tracer)

--- a/data-in-pipeline-load-api/app/settings.py
+++ b/data-in-pipeline-load-api/app/settings.py
@@ -37,13 +37,13 @@ class Settings(BaseSettings):
     # Valid values: disable, allow, prefer, require, verify-ca, verify-full
     # 'prefer' tries SSL but falls back to non-SSL for local dev (validates
     # certs if SSL is used). For production RDS without cert validation,
-    # set db_sslmode=require via environment variable.
+    # set db_sslmode=require via environment variable
     db_sslmode: str = "prefer"
 
 
 # Pydantic settings are set from the env variables passed in via
 # docker / apprunner. Missing required fields will raise a
-# ValidationError on import.
+# ValidationError on import
 # pyright: reportCallIssue=false
 # Pyright doesn't recognize that BaseSettings loads from environment variables, so it
 # flags required fields as missing constructor arguments. This is a false positive.


### PR DESCRIPTION
# What does this do?
adds a fix to the previous change made where we tried to deploy `data-in-pipeline-load-api` to ecs but in the shares api cluster, which meant that we ended up creating a dead service. 

This is because `data-in-pipeline-load-api` has its own service and cluster so have updated the flow to reflect that. 

## Why is it needed?

Part of the ECS Migration. 

## How was it tested?

NA