### PR TITLE
Rename services to differentiate the new ecs service metrics source

### DIFF
--- a/concepts-api/service-manifest.json
+++ b/concepts-api/service-manifest.json
@@ -1,9 +1,12 @@
 {
-  "service.name": "concepts-api",
+  "service.name": "concepts-api-ecs",
   "service.namespace": "data-fetching",
   "team": "application",
   "inputs": [
-    { "type": "s3", "name": "cpr-production-document-cache/concepts" }
+    {
+      "type": "s3",
+      "name": "cpr-production-document-cache/concepts"
+    }
   ],
   "outputs": [],
   "repos": ["https://github.com/climatepolicyradar/navigator-backend"]

--- a/families-api/service-manifest.json
+++ b/families-api/service-manifest.json
@@ -1,8 +1,13 @@
 {
-  "service.name": "families-api",
+  "service.name": "families-api-ecs",
   "service.namespace": "data-fetching",
   "team": "application",
-  "inputs": [{ "type": "aws", "name": "navigator-infra" }],
+  "inputs": [
+    {
+      "type": "aws",
+      "name": "navigator-infra"
+    }
+  ],
   "outputs": [],
   "repos": ["https://github.com/climatepolicyradar/navigator-backend"]
 }

--- a/geographies-api/service-manifest.json
+++ b/geographies-api/service-manifest.json
@@ -1,5 +1,5 @@
 {
-  "service.name": "geographies-api",
+  "service.name": "geographies-api-ecs",
   "service.namespace": "data-fetching",
   "team": "application",
   "inputs": [],


### PR DESCRIPTION
# What does this do?

As above, adds `-ecs` to the end of each of the service names (`families-api`, `geographies-api`, `concepts-api`) in the service-manifest.json for the services that have been migrated to ECS Express and have OpenTelemetry enabled.

## Why is it needed?

To differentiate which services the metrics are coming from as we migrate from AppRunner to ECS Express and the new and old services run in parallel
