### PR TITLE
chore: Increase min task count to 2 across ECS express services

### DIFF
--- a/concepts-api/infra/__main__.py
+++ b/concepts-api/infra/__main__.py
@@ -225,7 +225,7 @@ ecs_express_service = ExpressGatewayService(
         ExpressGatewayServiceScalingTargetArgs(
             auto_scaling_metric="AVERAGE_CPU",
             auto_scaling_target_value=70,
-            min_task_count=1,
+            min_task_count=2,
             max_task_count=4,
         ),
     ],

--- a/data-in-api/infra/__main__.py
+++ b/data-in-api/infra/__main__.py
@@ -355,23 +355,25 @@ aws.iam.RolePolicy(
         aurora_read_replica_db_name_parameter=aurora_read_replica_db_name_parameter.arn,
         aurora_read_replica_db_username_parameter=aurora_read_replica_db_username_parameter.arn,
     ).apply(
-        lambda args: aws.iam.get_policy_document(
-            statements=[
-                aws.iam.GetPolicyDocumentStatementArgs(
-                    effect="Allow",
-                    actions=[
-                        "ssm:GetParameter",
-                        "ssm:GetParameters",
-                        "ssm:DescribeParameters",
-                    ],
-                    resources=[
-                        args["aurora_read_replica_db_url_parameter"],
-                        args["aurora_read_replica_db_name_parameter"],
-                        args["aurora_read_replica_db_username_parameter"],
-                    ],
-                ),
-            ]
-        ).json
+        lambda args: (
+            aws.iam.get_policy_document(
+                statements=[
+                    aws.iam.GetPolicyDocumentStatementArgs(
+                        effect="Allow",
+                        actions=[
+                            "ssm:GetParameter",
+                            "ssm:GetParameters",
+                            "ssm:DescribeParameters",
+                        ],
+                        resources=[
+                            args["aurora_read_replica_db_url_parameter"],
+                            args["aurora_read_replica_db_name_parameter"],
+                            args["aurora_read_replica_db_username_parameter"],
+                        ],
+                    ),
+                ]
+            ).json
+        )
     ),
 )
 
@@ -482,7 +484,7 @@ ecs_express_service = ExpressGatewayService(
         ExpressGatewayServiceScalingTargetArgs(
             auto_scaling_metric="AVERAGE_CPU",
             auto_scaling_target_value=70,
-            min_task_count=1,
+            min_task_count=2,
             max_task_count=4,
         ),
     ],

--- a/families-api/infra/__main__.py
+++ b/families-api/infra/__main__.py
@@ -325,7 +325,7 @@ ecs_express_service = ExpressGatewayService(
         ExpressGatewayServiceScalingTargetArgs(
             auto_scaling_metric="AVERAGE_CPU",
             auto_scaling_target_value=70,
-            min_task_count=1,
+            min_task_count=2,
             max_task_count=4,
         ),
     ],

--- a/geographies-api/infra/__main__.py
+++ b/geographies-api/infra/__main__.py
@@ -284,7 +284,7 @@ ecs_express_service = ExpressGatewayService(
         ExpressGatewayServiceScalingTargetArgs(
             auto_scaling_metric="AVERAGE_CPU",
             auto_scaling_target_value=70,
-            min_task_count=1,
+            min_task_count=2,
             max_task_count=4,
         ),
     ],


### PR DESCRIPTION
## What
Increases the minimum task count from 1 to 2 on ECS express services.

## Why
A single container getting saturated by request spikes (e.g. from data-in hitting families-api) causes ALB health checks to fail, ECS to kill the task, and a latency gap while a replacement spins up. Running a minimum of 2 containers ensures the ALB can load balance across tasks and maintain availability while ECS replaces any unhealthy container.