### PR TITLE
chore: add backend api to deploy to ecs workflow

### DIFF
--- a/.github/workflows/merge-to-main.yml
+++ b/.github/workflows/merge-to-main.yml
@@ -88,7 +88,7 @@ jobs:
           echo "services=$(echo "$CHANGES" | jq -c '[.[] | select(contains("/infra") | not)]')" >> $GITHUB_OUTPUT
           echo "infra_services=$(echo "$CHANGES" | jq -c '[.[] | select(contains("/infra"))]')" >> $GITHUB_OUTPUT
           echo "deploy_load_api_ecs=$(echo "$CHANGES" | jq -c 'any(.[]; . == "data-in-pipeline-load-api")')" >> $GITHUB_OUTPUT
-          echo "ecs_services=$(echo "$CHANGES" | jq -c '[.[] | select(contains("/infra") | not) | select(. == "geographies-api" or . == "families-api"  or . == "concepts-api" or . == "data-in-api")]')" >> $GITHUB_OUTPUT
+          echo "ecs_services=$(echo "$CHANGES" | jq -c '[.[] | select(contains("/infra") | not) | select(. == "geographies-api" or . == "families-api" or . == "backend-api"  or . == "concepts-api" or . == "data-in-api")]')" >> $GITHUB_OUTPUT
 
   test:
     needs: changes

--- a/backend-api/app/main.py
+++ b/backend-api/app/main.py
@@ -56,7 +56,7 @@ try:
         ServiceManifest.from_file("service-manifest.json"), config.ENV, "0.1.0"
     )
 except Exception as _:
-    _LOGGER.error("Failed to load service manifest, using defaults")
+    _LOGGER.exception("Failed to load service manifest, using defaults")
     otel_config = TelemetryConfig(
         service_name="navigator-backend",
         namespace_name="navigator",
@@ -82,7 +82,7 @@ _docs_url = "/api/docs" if ENABLE_API_DOCS else None
 _openapi_url = "/api" if ENABLE_API_DOCS else None
 
 
-# Lifespan context manager for startup/shutdown events
+# Lifespan context manager for startup/shutdown events.
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     # Startup
@@ -121,7 +121,7 @@ _ALLOW_ORIGIN_REGEX = (
     r"https://.+\.climatecasechart\.com"
 )
 
-# Add CORS middleware to allow cross origin requests from any port
+# Add CORS middleware to allow cross origin requests from any port.
 app.add_middleware(
     CORSMiddleware,
     allow_origin_regex=_ALLOW_ORIGIN_REGEX,


### PR DESCRIPTION
# What does this do?
deploy backend api to ecs on merge to main

## Why is it needed?
Part of ECS migration

