### PR TITLE
Update service names to match AWS naming

### DIFF
--- a/backend-api/service-manifest.json
+++ b/backend-api/service-manifest.json
@@ -1,14 +1,32 @@
 {
-  "service.name": "navigator-backend",
+  "service.name": "backend",
   "service.namespace": "data-fetching",
   "team": "application",
   "inputs": [
-    { "type": "service", "name": "db-client" },
-    { "type": "service", "name": "rds" },
-    { "type": "service", "name": "search" },
-    { "type": "s3", "name": "cpr-production-document-cache" },
-    { "type": "s3", "name": "cpr-prod-data-pipeline-cache" },
-    { "type": "service", "name": "navigator-infra" }
+    {
+      "type": "service",
+      "name": "db-client"
+    },
+    {
+      "type": "service",
+      "name": "rds"
+    },
+    {
+      "type": "service",
+      "name": "search"
+    },
+    {
+      "type": "s3",
+      "name": "cpr-production-document-cache"
+    },
+    {
+      "type": "s3",
+      "name": "cpr-prod-data-pipeline-cache"
+    },
+    {
+      "type": "service",
+      "name": "navigator-infra"
+    }
   ],
   "outputs": [],
   "repos": ["https://github.com/climatepolicyradar/navigator-backend"]

--- a/concepts-api/service-manifest.json
+++ b/concepts-api/service-manifest.json
@@ -1,5 +1,5 @@
 {
-  "service.name": "concepts-api-ecs",
+  "service.name": "concepts-api",
   "service.namespace": "data-fetching",
   "team": "application",
   "inputs": [

--- a/families-api/service-manifest.json
+++ b/families-api/service-manifest.json
@@ -1,5 +1,5 @@
 {
-  "service.name": "families-api-ecs",
+  "service.name": "families-api",
   "service.namespace": "data-fetching",
   "team": "application",
   "inputs": [

--- a/geographies-api/service-manifest.json
+++ b/geographies-api/service-manifest.json
@@ -1,5 +1,5 @@
 {
-  "service.name": "geographies-api-ecs",
+  "service.name": "geographies-api",
   "service.namespace": "data-fetching",
   "team": "application",
   "inputs": [],


### PR DESCRIPTION
# What does this do?

We want the service names for OTel to match the naming convention we are using for our AWS services.

## Why is it needed?

To keep things consistent and allow us to combine both OTel and Cloudwatch data in a single dashboard.


