### PR TITLE
Update title for documents mapped from litigation events

### DIFF
--- a/data-in-pipeline/app/transform/navigator_family.py
+++ b/data-in-pipeline/app/transform/navigator_family.py
@@ -535,7 +535,11 @@ def _transform_litigation_events(data: NavigatorFamily) -> list[Document]:
         documents.append(
             Document(
                 id=event.import_id,
-                title=event.title,
+                # Event title not to be used here - it stores Sabin's original event type value
+                # which we ignore and map to a standardised value for even type in the
+                # litigation data mapper. Instead, we are constructing the title using
+                # the case title and event type to match how document titles are constructed
+                title=f"{data.title} - {event.event_type.lower()}",
                 description=event.metadata["description"][0],
                 labels=labels,
                 items=[],

--- a/data-in-pipeline/tests/transform/test_navigator_documents.py
+++ b/data-in-pipeline/tests/transform/test_navigator_documents.py
@@ -184,7 +184,7 @@ def test_transform_navigator_documents_litigation_events_without_documents():
         [
             Document(
                 id="123",
-                title="decision",
+                title="Litigation family - decision",
                 description="Summary of the filed document",
                 labels=[
                     LabelRelationship(


### PR DESCRIPTION
# What does this do?

Update what title is mapped for documents mapped from litigation events. Instead of using the `event.title` we should be following the document title naming convention (i.e. <case_title> - <event_type>).

## Why is it needed?

We were surfacing an original Sabin event type in the title - which is not a value we want exposed. We have a standardised list of event types these get mapped to. Event title was never used before and only serves to capture that original value.


