### PR TITLE
Add temprorary 5xx error testing endpoint

### DIFF
--- a/data-in-api/app/main.py
+++ b/data-in-api/app/main.py
@@ -182,4 +182,13 @@ def read_label(label_id: str, db=Depends(get_db)):
         )
 
 
+@app.get("/test-5xx")
+@router.get("/test-5xx")
+def test_5xx():
+    raise HTTPException(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        detail="Testing 5xx errors for Grafana",
+    )
+
+
 app.include_router(router)


### PR DESCRIPTION
# What does this do?

- Add a test endpoint to one of the services that will throw a 500 error when hit (`data-in-api` - as it is currently only used behind a feature flag on the FE).

## Why is it needed?

- For Grafana testing - will allow us to simulate enough 500 errors for that service to see some meaningful data on the dashboard panel and trigger an alert to check they have been set up correctly.

- Will be removed once testing is completed


