### PR TITLE
Feature/app 2240 test 5xx grafana dashboard and alert

### DIFF
--- a/data-in-api/app/main.py
+++ b/data-in-api/app/main.py
@@ -182,13 +182,4 @@ def read_label(label_id: str, db=Depends(get_db)):
         )
 
 
-@app.get("/test-5xx")
-@router.get("/test-5xx")
-def test_5xx():
-    raise HTTPException(
-        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-        detail="Testing 5xx errors for Grafana",
-    )
-
-
 app.include_router(router)

--- a/data-in-api/app/main.py
+++ b/data-in-api/app/main.py
@@ -182,4 +182,13 @@ def read_label(label_id: str, db=Depends(get_db)):
         )
 
 
+@app.get("/test-5xx")
+@router.get("/test-5xx")
+def test_5xx():
+    raise HTTPException(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        detail="Testing 5xx errors for Grafana",
+    )
+
+
 app.include_router(router)

--- a/geographies-api/app/router.py
+++ b/geographies-api/app/router.py
@@ -265,3 +265,11 @@ async def read_geography(slug: str):
     return APIItemResponse(
         data=result,
     )
+
+
+@router.get("/test-5xx")
+def test_5xx():
+    raise HTTPException(
+        status_code=500,
+        detail="Testing 5xx errors for Grafana",
+    )


### PR DESCRIPTION
# What does this do?

Moves the temporary 5xx Testing endpoint to the geographies API

## Why is it needed?

We need to test our 5xx Error Rate Grafana dashboard and Slack alert so using this endpoint to generate some errors. Initially added to the data-in-api but that is currently unavailable on ECS.


