### PR TITLE
fix: wait for service_healthy on data-in-load-api docker-compose

### DIFF
--- a/data-in-pipeline-load-api/docker-compose.yml
+++ b/data-in-pipeline-load-api/docker-compose.yml
@@ -89,8 +89,6 @@ services:
       context: ..
       target: dev
       dockerfile: data-in-pipeline-load-api/Dockerfile
-    ports:
-      - 8080:8080
     volumes:
       - ..:/app
     working_dir: /app
@@ -119,6 +117,7 @@ services:
         -vvv,
       ]
     depends_on:
-      - test-db
+      test-db:
+        condition: service_healthy
 volumes:
   data-in-pipeline-load-api-postgres-data: {}


### PR DESCRIPTION
## Fix flaky test container startup

Two issues were causing just test data-in-pipeline-load-api to fail:

- Race condition: the test container was starting before the DB was ready to accept connections, causing DNS/connection errors. Fixed by adding condition: service_healthy to depends_on so Docker waits for the Postgres healthcheck to pass first.
- Port conflict: the test service was trying to bind port 8080 on the host, which fails if anything else is using it (e.g. Docker Desktop). Pytest doesn't need an exposed port, so the mapping is removed.