### PR TITLE
Feature/app 2240 test 5xx grafana dashboard and alert

### DIFF
--- a/data-in-api/app/main.py
+++ b/data-in-api/app/main.py
@@ -182,13 +182,4 @@ def read_label(label_id: str, db=Depends(get_db)):
         )
 
 
-@app.get("/test-5xx")
-@router.get("/test-5xx")
-def test_5xx():
-    raise HTTPException(
-        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-        detail="Testing 5xx errors for Grafana",
-    )
-
-
 app.include_router(router)

--- a/data-in-api/app/main.py
+++ b/data-in-api/app/main.py
@@ -182,4 +182,13 @@ def read_label(label_id: str, db=Depends(get_db)):
         )
 
 
+@app.get("/test-5xx")
+@router.get("/test-5xx")
+def test_5xx():
+    raise HTTPException(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        detail="Testing 5xx errors for Grafana",
+    )
+
+
 app.include_router(router)

--- a/geographies-api/app/router.py
+++ b/geographies-api/app/router.py
@@ -37,6 +37,14 @@ APIDataType = TypeVar("APIDataType")
 router = APIRouter()
 
 
+@router.get("/test-5xx")
+def test_5xx():
+    raise HTTPException(
+        status_code=500,
+        detail="Testing 5xx errors for Grafana",
+    )
+
+
 @router.get("/regions", response_model=list[RegionResponse])
 async def list_all_regions() -> list[RegionResponse]:
     """
@@ -264,12 +272,4 @@ async def read_geography(slug: str):
 
     return APIItemResponse(
         data=result,
-    )
-
-
-@router.get("/test-5xx")
-def test_5xx():
-    raise HTTPException(
-        status_code=500,
-        detail="Testing 5xx errors for Grafana",
     )

--- a/geographies-api/app/router.py
+++ b/geographies-api/app/router.py
@@ -273,11 +273,3 @@ async def read_geography(slug: str):
     return APIItemResponse(
         data=result,
     )
-
-
-@router.get("/test-5xx")
-def test_5xx():
-    raise HTTPException(
-        status_code=500,
-        detail="Testing 5xx errors for Grafana",
-    )

--- a/geographies-api/app/router.py
+++ b/geographies-api/app/router.py
@@ -265,3 +265,11 @@ async def read_geography(slug: str):
     return APIItemResponse(
         data=result,
     )
+
+
+@router.get("/test-5xx")
+def test_5xx():
+    raise HTTPException(
+        status_code=500,
+        detail="Testing 5xx errors for Grafana",
+    )


### PR DESCRIPTION
# What does this do?

- Moves the 5xx testing route to the top of geographies router file so it is not ignored

