### PR TITLE
fix: add relationship.type to primary key when storing document => label relationships

### DIFF
--- a/data-in-models/src/data_in_models/db_models.py
+++ b/data-in-models/src/data_in_models/db_models.py
@@ -72,7 +72,7 @@ class Label(WithDbDatetimeFields, table=True):
 
 
 class DocumentLabelRelationship(WithDbDatetimeFields, table=True):
-    type: str
+    type: str = Field(primary_key=True)
     timestamp: datetime | None = None
     document_id: str = Field(
         foreign_key="document.id",

--- a/data-in-pipeline-load-api/app/alembic/migrations/versions/0009_add_type_to_document_label_relationship_pk.py
+++ b/data-in-pipeline-load-api/app/alembic/migrations/versions/0009_add_type_to_document_label_relationship_pk.py
@@ -29,8 +29,14 @@ def upgrade() -> None:
             "WHERE table_name = 'documentlabelrelationship' AND constraint_type = 'PRIMARY KEY'"
         )
     ).fetchone()
+    if row is None:
+        raise RuntimeError(
+            "No primary key constraint found on documentlabelrelationship"
+        )
     pk_name = row[0]
-    conn.execute(text(f"ALTER TABLE documentlabelrelationship DROP CONSTRAINT {pk_name}"))
+    conn.execute(
+        text(f"ALTER TABLE documentlabelrelationship DROP CONSTRAINT {pk_name}")
+    )
     conn.execute(
         text(
             "ALTER TABLE documentlabelrelationship "
@@ -48,8 +54,14 @@ def downgrade() -> None:
             "WHERE table_name = 'documentlabelrelationship' AND constraint_type = 'PRIMARY KEY'"
         )
     ).fetchone()
+    if row is None:
+        raise RuntimeError(
+            "No primary key constraint found on documentlabelrelationship"
+        )
     pk_name = row[0]
-    conn.execute(text(f"ALTER TABLE documentlabelrelationship DROP CONSTRAINT {pk_name}"))
+    conn.execute(
+        text(f"ALTER TABLE documentlabelrelationship DROP CONSTRAINT {pk_name}")
+    )
     conn.execute(
         text(
             "ALTER TABLE documentlabelrelationship "

--- a/data-in-pipeline-load-api/app/alembic/migrations/versions/0009_add_type_to_document_label_relationship_pk.py
+++ b/data-in-pipeline-load-api/app/alembic/migrations/versions/0009_add_type_to_document_label_relationship_pk.py
@@ -1,0 +1,58 @@
+"""Add type to documentlabelrelationship primary key
+
+Revision ID: 0009
+Revises: 0008
+Create Date: 2026-06-30
+
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+from sqlalchemy import text
+
+# revision identifiers, used by Alembic.
+revision: str = "0009"
+down_revision: str | Sequence[str] | None = "0008"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    conn = op.get_bind()
+    # Discover the actual PK constraint name (varies depending on whether the
+    # table was created via Alembic migrations or SQLModel.metadata.create_all)
+    row = conn.execute(
+        text(
+            "SELECT constraint_name FROM information_schema.table_constraints "
+            "WHERE table_name = 'documentlabelrelationship' AND constraint_type = 'PRIMARY KEY'"
+        )
+    ).fetchone()
+    pk_name = row[0]
+    conn.execute(text(f"ALTER TABLE documentlabelrelationship DROP CONSTRAINT {pk_name}"))
+    conn.execute(
+        text(
+            "ALTER TABLE documentlabelrelationship "
+            f"ADD CONSTRAINT {pk_name} PRIMARY KEY (document_id, label_id, type)"
+        )
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    conn = op.get_bind()
+    row = conn.execute(
+        text(
+            "SELECT constraint_name FROM information_schema.table_constraints "
+            "WHERE table_name = 'documentlabelrelationship' AND constraint_type = 'PRIMARY KEY'"
+        )
+    ).fetchone()
+    pk_name = row[0]
+    conn.execute(text(f"ALTER TABLE documentlabelrelationship DROP CONSTRAINT {pk_name}"))
+    conn.execute(
+        text(
+            "ALTER TABLE documentlabelrelationship "
+            f"ADD CONSTRAINT {pk_name} PRIMARY KEY (document_id, label_id)"
+        )
+    )

--- a/data-in-pipeline-load-api/app/repository.py
+++ b/data-in-pipeline-load-api/app/repository.py
@@ -230,7 +230,7 @@ def _upsert_labels_and_relationships(
         )
         return
 
-    unique_rels = {rel.value.id: rel for rel in label_relationships}
+    unique_rels = {(rel.value.id, rel.type): rel for rel in label_relationships}
 
     rows = [
         {
@@ -246,20 +246,21 @@ def _upsert_labels_and_relationships(
 
     stmt = insert(DBDocumentLabelLink).values(rows)
     stmt = stmt.on_conflict_do_update(
-        index_elements=["document_id", "label_id"],
+        index_elements=["document_id", "label_id", "type"],
         set_={
-            "type": stmt.excluded.type,
             "timestamp": stmt.excluded.timestamp,
             "updated_at": now,
         },
-        where=(DBDocumentLabelLink.type != stmt.excluded.type),
+        where=(DBDocumentLabelLink.timestamp != stmt.excluded.timestamp),
     )
     db.exec(stmt)
 
     db.exec(
         delete(DBDocumentLabelLink).where(
             DBDocumentLabelLink.document_id == document_id,
-            ~DBDocumentLabelLink.label_id.in_(unique_rels.keys()),  # type: ignore[attr-defined]
+            ~tuple_(DBDocumentLabelLink.label_id, DBDocumentLabelLink.type).in_(  # type: ignore[attr-defined]
+                list(unique_rels.keys())
+            ),
         )
     )
 

--- a/data-in-pipeline-load-api/tests/test_upsert_documents.py
+++ b/data-in-pipeline-load-api/tests/test_upsert_documents.py
@@ -126,7 +126,7 @@ def test_upsert_creates_document_with_labels_and_items(session):
     assert label_entity is not None
     assert label_entity.value == "Important"
 
-    link = session.get(DocumentLabelRelationship, ("test-doc-2", "label_1"))
+    link = session.get(DocumentLabelRelationship, ("tag", "test-doc-2", "label_1"))
     assert link is not None
     assert link.type == "tag"
 
@@ -266,7 +266,7 @@ def test_create_document_success(session):
     assert label_entity is not None
     assert label_entity.value == "Important"
 
-    link = session.get(DocumentLabelRelationship, ("test-doc-2", "label_1"))
+    link = session.get(DocumentLabelRelationship, ("tag", "test-doc-2", "label_1"))
     assert link is not None
     assert link.type == "tag"
 


### PR DESCRIPTION
# What does this do?

Adds `relationship.type` to the primary key of `Document` => `Label` relationships in the DB.

This allows us to store a `Label` twice against Document, but with a different relationship 

e.g. 
```
Document -- provider --> Global Environment Facility
Document -- part_of --> Global Environment Facility
``` 

Supports https://github.com/climatepolicyradar/navigator-backend/pull/1291