### PR TITLE
fix: trailing slash causing errors when hitting related endpoints

### DIFF
--- a/data-in-pipeline/infra/__main__.py
+++ b/data-in-pipeline/infra/__main__.py
@@ -942,7 +942,7 @@ ecs_express_service = ExpressGatewayService(
 )
 
 load_api_base_url = ecs_express_service.ingress_paths.apply(
-    lambda paths: f"{paths[0].endpoint.rstrip('/')}/"
+    lambda paths: f"{paths[0].endpoint.rstrip('/')}"
 )
 
 ########################################################################


### PR DESCRIPTION
# What does this do?
per title - removes trailing slash.
## Why is it needed?
Error when hitting load api endpoints..

```
Task run failed with exception: HTTPError('500 Server Error: Internal Server Error for url: https://da-9f758dc9847148f1b8df15150d4488fa.ecs.eu-west-1.on.aws//load/run-migrations')
Traceback (most recent call last):
```
