### PR TITLE
Remove test endpoint

### DIFF
--- a/geographies-api/app/router.py
+++ b/geographies-api/app/router.py
@@ -37,14 +37,6 @@ APIDataType = TypeVar("APIDataType")
 router = APIRouter()
 
 
-@router.get("/test-5xx")
-def test_5xx():
-    raise HTTPException(
-        status_code=500,
-        detail="Testing 5xx errors for Grafana",
-    )
-
-
 @router.get("/regions", response_model=list[RegionResponse])
 async def list_all_regions() -> list[RegionResponse]:
     """


### PR DESCRIPTION
# What does this do?

- Removes temporary 5xx testing endpoint from the `geographies-api`

## Why is it needed?

- Grafana testing was completed so the endpoint is no longer needed


