### PR TITLE
Feature/enri 1518 remove the geographies api app runner service

### DIFF
--- a/api/infra/__main__.py
+++ b/api/infra/__main__.py
@@ -128,16 +128,6 @@ api_cloudfront_distribution = aws.cloudfront.Distribution(
             ),
         ),
         aws.cloudfront.DistributionOriginArgs(
-            domain_name=geographies_api_stack.get_output("apprunner_service_url"),
-            origin_id="geographies-api-apprunner",
-            custom_origin_config=aws.cloudfront.DistributionOriginCustomOriginConfigArgs(
-                http_port=80,
-                https_port=443,
-                origin_protocol_policy="https-only",
-                origin_ssl_protocols=["TLSv1.2"],
-            ),
-        ),
-        aws.cloudfront.DistributionOriginArgs(
             domain_name=geographies_api_stack.get_output("ecs_express_service_url"),
             origin_id="geographies-api-ecs-express",
             custom_origin_config=aws.cloudfront.DistributionOriginCustomOriginConfigArgs(

--- a/geographies-api/infra/__main__.py
+++ b/geographies-api/infra/__main__.py
@@ -26,85 +26,6 @@ NAME_PREFIX = f"geographies-api-{stack}"
 
 ecs_infra = pulumi.StackReference(f"climatepolicyradar/ecs-infra/{stack}")
 
-
-# This stuff is being encapsulated in navigator-infra and we should use that once it is ready
-# IAM role trusted by App Runner
-geographies_api_role = aws.iam.Role(
-    "geographies-api-role",
-    assume_role_policy=aws.iam.get_policy_document(
-        statements=[
-            aws.iam.GetPolicyDocumentStatementArgs(
-                effect="Allow",
-                principals=[
-                    aws.iam.GetPolicyDocumentStatementPrincipalArgs(
-                        type="Service",
-                        identifiers=["build.apprunner.amazonaws.com"],
-                    )
-                ],
-                actions=["sts:AssumeRole"],
-            )
-        ]
-    ).json,
-)
-
-
-# Attach ECR access policy to the role
-geographies_api_role_policy = aws.iam.RolePolicy(
-    "geographies-api-role-ecr-policy",
-    role=geographies_api_role.id,
-    policy=aws.iam.get_policy_document(
-        statements=[
-            aws.iam.GetPolicyDocumentStatementArgs(
-                effect="Allow",
-                actions=[
-                    "ecr:GetDownloadUrlForLayer",
-                    "ecr:BatchGetImage",
-                    "ecr:DescribeImages",
-                    "ecr:GetAuthorizationToken",
-                    "ecr:BatchCheckLayerAvailability",
-                ],
-                resources=["*"],
-            )
-        ]
-    ).json,
-)
-
-geographies_api_instance_role = aws.iam.Role(
-    "geographies-api-instance-role",
-    assume_role_policy=aws.iam.get_policy_document(
-        statements=[
-            aws.iam.GetPolicyDocumentStatementArgs(
-                effect="Allow",
-                principals=[
-                    aws.iam.GetPolicyDocumentStatementPrincipalArgs(
-                        type="Service",
-                        identifiers=["tasks.apprunner.amazonaws.com"],
-                    )
-                ],
-                actions=["sts:AssumeRole"],
-            )
-        ]
-    ).json,
-)
-
-# Allow access to specific SSM Parameter Store secrets
-geographies_api_ssm_policy = aws.iam.RolePolicy(
-    "geographies-api-instance-role-ssm-policy",
-    role=geographies_api_instance_role.id,
-    policy=aws.iam.get_policy_document(
-        statements=[
-            aws.iam.GetPolicyDocumentStatementArgs(
-                effect="Allow",
-                actions=["ssm:GetParameters"],
-                resources=[
-                    f"arn:aws:ssm:eu-west-1:{account_id}:parameter/geographies-api/apprunner/*"
-                ],
-            )
-        ]
-    ).json,
-)
-
-
 geographies_api_ecr_repository = aws.ecr.Repository(
     "geographies-api-ecr-repository",
     encryption_configurations=[
@@ -146,52 +67,6 @@ s3_access_policy = aws.iam.Policy(
     description="Policy to allow geographies API to access S3 bucket",
 )
 
-# Attach the policy to the instance role
-aws.iam.RolePolicyAttachment(
-    "geographies-api-instance-role-s3-policy-attachment",
-    role=geographies_api_instance_role.name,
-    policy_arn=s3_access_policy.arn,
-)
-
-geographies_api_apprunner_service = aws.apprunner.Service(
-    "geographies-api-apprunner-service",
-    auto_scaling_configuration_arn=f"arn:aws:apprunner:eu-west-1:{account_id}:autoscalingconfiguration/DefaultConfiguration/1/00000000000000000000000000000001",
-    health_check_configuration=aws.apprunner.ServiceHealthCheckConfigurationArgs(
-        interval=10,
-        protocol="TCP",
-        timeout=5,
-    ),
-    instance_configuration=aws.apprunner.ServiceInstanceConfigurationArgs(
-        instance_role_arn=geographies_api_instance_role.arn,
-    ),
-    network_configuration=aws.apprunner.ServiceNetworkConfigurationArgs(
-        ingress_configuration=aws.apprunner.ServiceNetworkConfigurationIngressConfigurationArgs(
-            is_publicly_accessible=True,
-        ),
-        ip_address_type="IPV4",
-    ),
-    observability_configuration=aws.apprunner.ServiceObservabilityConfigurationArgs(
-        observability_enabled=False,
-    ),
-    service_name="geographies-api",
-    source_configuration=aws.apprunner.ServiceSourceConfigurationArgs(
-        authentication_configuration=aws.apprunner.ServiceSourceConfigurationAuthenticationConfigurationArgs(
-            access_role_arn=geographies_api_role.arn,
-        ),
-        image_repository=aws.apprunner.ServiceSourceConfigurationImageRepositoryArgs(
-            image_configuration=aws.apprunner.ServiceSourceConfigurationImageRepositoryImageConfigurationArgs(
-                port="8080",  # @related: PORT_NUMBER
-                runtime_environment_variables={
-                    "GEOGRAPHIES_BUCKET": config.require("geographies_bucket"),
-                    "CDN_URL": config.require("cdn_url"),
-                },
-            ),
-            image_identifier=f"{account_id}.dkr.ecr.eu-west-1.amazonaws.com/geographies-api:latest",
-            image_repository_type="ECR",
-        ),
-    ),
-    opts=pulumi.ResourceOptions(protect=False),
-)
 
 ########################################################################
 # ECS Express Gateway service
@@ -306,5 +181,3 @@ pulumi.export(
         lambda paths: paths[0].endpoint.removeprefix("https://") if paths else None
     ),
 )
-
-pulumi.export("apprunner_service_url", geographies_api_apprunner_service.service_url)

--- a/geographies-api/infra/__main__.py
+++ b/geographies-api/infra/__main__.py
@@ -190,7 +190,7 @@ geographies_api_apprunner_service = aws.apprunner.Service(
             image_repository_type="ECR",
         ),
     ),
-    opts=pulumi.ResourceOptions(protect=True),
+    opts=pulumi.ResourceOptions(protect=False),
 )
 
 ########################################################################


### PR DESCRIPTION
# What does this do?
Per title removes the geographies app runner service.

This one has a few stages to it. 

First you unprotect the app runner resource

Then you delete the resource, associated roles and policies

Then you delete the cloudfront distribution from the api stack. 
## Why is it needed?
Clean up work from the ecs migration.
## How was it tested?
Checking that everything is all good in staging.