### PR TITLE
Feature/enri 1522 remove the concepts api app runner service from our iac

### DIFF
--- a/api/infra/__main__.py
+++ b/api/infra/__main__.py
@@ -148,16 +148,6 @@ api_cloudfront_distribution = aws.cloudfront.Distribution(
             ),
         ),
         aws.cloudfront.DistributionOriginArgs(
-            domain_name=concepts_api_stack.get_output("apprunner_service_url"),
-            origin_id="concepts-api-apprunner",
-            custom_origin_config=aws.cloudfront.DistributionOriginCustomOriginConfigArgs(
-                http_port=80,
-                https_port=443,
-                origin_protocol_policy="https-only",
-                origin_ssl_protocols=["TLSv1.2"],
-            ),
-        ),
-        aws.cloudfront.DistributionOriginArgs(
             domain_name=concepts_api_stack.get_output("ecs_express_service_url"),
             origin_id="concepts-api-ecs-express",
             custom_origin_config=aws.cloudfront.DistributionOriginCustomOriginConfigArgs(
@@ -223,7 +213,7 @@ api_cloudfront_distribution = aws.cloudfront.Distribution(
             "GET",
             "OPTIONS",
         ],
-        "target_origin_id": "concepts-api-apprunner",
+        "target_origin_id": "concepts-api-ecs-express",
         "viewer_protocol_policy": "redirect-to-https",
         "cache_policy_id": api_cache_policy.id,
     },

--- a/concepts-api/infra/__main__.py
+++ b/concepts-api/infra/__main__.py
@@ -31,79 +31,6 @@ eu_west_1b_public_subnet_id = aws_env_stack.get_output("eu_west_1b_public_subnet
 eu_west_1c_public_subnet_id = aws_env_stack.get_output("eu_west_1c_public_subnet_id")
 
 
-# IAM role trusted by App Runner
-concepts_api_role = aws.iam.Role(
-    "concepts-api-role",
-    assume_role_policy=aws.iam.get_policy_document(
-        statements=[
-            aws.iam.GetPolicyDocumentStatementArgs(
-                effect="Allow",
-                principals=[
-                    aws.iam.GetPolicyDocumentStatementPrincipalArgs(
-                        type="Service",
-                        identifiers=["build.apprunner.amazonaws.com"],
-                    )
-                ],
-                actions=["sts:AssumeRole"],
-            )
-        ]
-    ).json,
-)
-
-concepts_api_role_policy = aws.iam.RolePolicy(
-    "concepts-api-role-ecr-policy",
-    role=concepts_api_role.id,
-    policy=aws.iam.get_policy_document(
-        statements=[
-            aws.iam.GetPolicyDocumentStatementArgs(
-                effect="Allow",
-                actions=[
-                    "ecr:GetDownloadUrlForLayer",
-                    "ecr:BatchGetImage",
-                    "ecr:DescribeImages",
-                    "ecr:GetAuthorizationToken",
-                    "ecr:BatchCheckLayerAvailability",
-                ],
-                resources=["*"],
-            )
-        ]
-    ).json,
-)
-
-concepts_api_instance_role = aws.iam.Role(
-    "concepts-api-instance-role",
-    assume_role_policy=aws.iam.get_policy_document(
-        statements=[
-            aws.iam.GetPolicyDocumentStatementArgs(
-                effect="Allow",
-                principals=[
-                    aws.iam.GetPolicyDocumentStatementPrincipalArgs(
-                        type="Service",
-                        identifiers=["tasks.apprunner.amazonaws.com"],
-                    )
-                ],
-                actions=["sts:AssumeRole"],
-            )
-        ]
-    ).json,
-)
-
-concepts_api_ssm_policy = aws.iam.RolePolicy(
-    "concepts-api-instance-role-ssm-policy",
-    role=concepts_api_instance_role.id,
-    policy=aws.iam.get_policy_document(
-        statements=[
-            aws.iam.GetPolicyDocumentStatementArgs(
-                effect="Allow",
-                actions=["ssm:GetParameters"],
-                resources=[
-                    f"arn:aws:ssm:eu-west-1:{account_id}:parameter/concepts-api/apprunner/*"
-                ],
-            )
-        ]
-    ).json,
-)
-
 concepts_api_ecr_repository = aws.ecr.Repository(
     "concepts-api-ecr-repository",
     encryption_configurations=[
@@ -118,44 +45,6 @@ concepts_api_ecr_repository = aws.ecr.Repository(
     name="concepts-api",
     opts=pulumi.ResourceOptions(protect=True),
 )
-
-concepts_api_apprunner_service = aws.apprunner.Service(
-    "concepts-api-apprunner-service",
-    auto_scaling_configuration_arn=f"arn:aws:apprunner:eu-west-1:{account_id}:autoscalingconfiguration/DefaultConfiguration/1/00000000000000000000000000000001",
-    health_check_configuration=aws.apprunner.ServiceHealthCheckConfigurationArgs(
-        interval=10,
-        protocol="TCP",
-        timeout=5,
-    ),
-    instance_configuration=aws.apprunner.ServiceInstanceConfigurationArgs(
-        instance_role_arn=concepts_api_instance_role.arn,
-    ),
-    network_configuration=aws.apprunner.ServiceNetworkConfigurationArgs(
-        ingress_configuration=aws.apprunner.ServiceNetworkConfigurationIngressConfigurationArgs(
-            is_publicly_accessible=True,
-        ),
-        ip_address_type="IPV4",
-    ),
-    observability_configuration=aws.apprunner.ServiceObservabilityConfigurationArgs(
-        observability_enabled=False,
-    ),
-    service_name="concepts-api",
-    source_configuration=aws.apprunner.ServiceSourceConfigurationArgs(
-        authentication_configuration=aws.apprunner.ServiceSourceConfigurationAuthenticationConfigurationArgs(
-            access_role_arn=concepts_api_role.arn,
-        ),
-        image_repository=aws.apprunner.ServiceSourceConfigurationImageRepositoryArgs(
-            image_configuration=aws.apprunner.ServiceSourceConfigurationImageRepositoryImageConfigurationArgs(
-                port="8080",
-                runtime_environment_variables={"Environment": pulumi.get_stack()},
-            ),
-            image_identifier=f"{account_id}.dkr.ecr.eu-west-1.amazonaws.com/concepts-api:latest",
-            image_repository_type="ECR",
-        ),
-    ),
-    opts=pulumi.ResourceOptions(protect=False),
-)
-
 
 ########################################################################
 # ECS Express Gateway service
@@ -248,5 +137,3 @@ pulumi.export(
         lambda paths: paths[0].endpoint.removeprefix("https://") if paths else None
     ),
 )
-
-pulumi.export("apprunner_service_url", concepts_api_apprunner_service.service_url)


### PR DESCRIPTION
# What does this do?
Removes the app runner service from our eco system. 

This is clean up from the ecs migration. 

## Why is it needed?

Whilst it does not cost much, there is a running cost to just leaving this in our estate.

## How was it tested?

Tested on staging. 