### PR TITLE
Feature/enri 1524 remove the families api app runner service

### DIFF
--- a/api/infra/__main__.py
+++ b/api/infra/__main__.py
@@ -108,16 +108,6 @@ api_cloudfront_distribution = aws.cloudfront.Distribution(
     comment="API",
     origins=[
         aws.cloudfront.DistributionOriginArgs(
-            domain_name=families_api_stack.get_output("apprunner_service_url"),
-            origin_id="families-api-apprunner",
-            custom_origin_config=aws.cloudfront.DistributionOriginCustomOriginConfigArgs(
-                http_port=80,
-                https_port=443,
-                origin_protocol_policy="https-only",
-                origin_ssl_protocols=["TLSv1.2"],
-            ),
-        ),
-        aws.cloudfront.DistributionOriginArgs(
             domain_name=families_api_stack.get_output("ecs_express_service_url"),
             origin_id="families-api-ecs-express",
             custom_origin_config=aws.cloudfront.DistributionOriginCustomOriginConfigArgs(

--- a/families-api/infra/__main__.py
+++ b/families-api/infra/__main__.py
@@ -39,82 +39,6 @@ rds_vpc_security_group_id = aws_env_stack.get_output("rds_security_group_id")
 ecs_shared_task_execution_role_name = ecs_infra.get_output("task_execution_role_name")
 
 
-# This stuff is being encapsulated in navigator-infra and we should use that once it is ready
-# IAM role trusted by App Runner
-families_api_role = aws.iam.Role(
-    "families-api-role",
-    assume_role_policy=aws.iam.get_policy_document(
-        statements=[
-            aws.iam.GetPolicyDocumentStatementArgs(
-                effect="Allow",
-                principals=[
-                    aws.iam.GetPolicyDocumentStatementPrincipalArgs(
-                        type="Service",
-                        identifiers=["build.apprunner.amazonaws.com"],
-                    )
-                ],
-                actions=["sts:AssumeRole"],
-            )
-        ]
-    ).json,
-)
-
-# Attach ECR access policy to the role
-families_api_role_policy = aws.iam.RolePolicy(
-    "families-api-role-ecr-policy",
-    role=families_api_role.id,
-    policy=aws.iam.get_policy_document(
-        statements=[
-            aws.iam.GetPolicyDocumentStatementArgs(
-                effect="Allow",
-                actions=[
-                    "ecr:GetDownloadUrlForLayer",
-                    "ecr:BatchGetImage",
-                    "ecr:DescribeImages",
-                    "ecr:GetAuthorizationToken",
-                    "ecr:BatchCheckLayerAvailability",
-                ],
-                resources=["*"],
-            )
-        ]
-    ).json,
-)
-
-families_api_instance_role = aws.iam.Role(
-    "families-api-instance-role",
-    assume_role_policy=aws.iam.get_policy_document(
-        statements=[
-            aws.iam.GetPolicyDocumentStatementArgs(
-                effect="Allow",
-                principals=[
-                    aws.iam.GetPolicyDocumentStatementPrincipalArgs(
-                        type="Service",
-                        identifiers=["tasks.apprunner.amazonaws.com"],
-                    )
-                ],
-                actions=["sts:AssumeRole"],
-            )
-        ]
-    ).json,
-)
-
-# Allow access to specific SSM Parameter Store secrets
-families_api_ssm_policy = aws.iam.RolePolicy(
-    "families-api-instance-role-ssm-policy",
-    role=families_api_instance_role.id,
-    policy=aws.iam.get_policy_document(
-        statements=[
-            aws.iam.GetPolicyDocumentStatementArgs(
-                effect="Allow",
-                actions=["ssm:GetParameters"],
-                resources=[
-                    f"arn:aws:ssm:eu-west-1:{account_id}:parameter/families-api/apprunner/*"
-                ],
-            )
-        ]
-    ).json,
-)
-
 families_api_apprunner_navigator_database_url = aws.ssm.Parameter(
     "families-api-apprunner-navigator-database-url",
     name=generate_secret_key("families-api", "apprunner", "NAVIGATOR_DATABASE_URL"),
@@ -130,18 +54,6 @@ families_api_apprunner_navigator_database_url = aws.ssm.Parameter(
     ),
 )
 
-families_api_apprunner_cdn_url = aws.ssm.Parameter(
-    "families-api-apprunner-cdn-url",
-    name=generate_secret_key("families-api", "apprunner", "CDN_URL"),
-    description="Root URL of the CDN",
-    type=aws.ssm.ParameterType.STRING,
-    # TODO: we could look this up based on the stack - but this is easy to change for now
-    value=(
-        "https://cdn.climatepolicyradar.org"
-        if stack == "production"
-        else "https://cdn.dev.climatepolicyradar.org"
-    ),
-)
 
 families_api_ecr_repository = aws.ecr.Repository(
     "families-api-ecr-repository",
@@ -165,50 +77,6 @@ families_api_apprunner_autoscaling_configuration = aws.apprunner.AutoScalingConf
     max_concurrency=10,
     max_size=10,
     min_size=2 if stack == "production" else 1,
-)
-
-families_api_apprunner_service = aws.apprunner.Service(
-    "families-api-apprunner-service",
-    auto_scaling_configuration_arn=families_api_apprunner_autoscaling_configuration.arn,
-    health_check_configuration=aws.apprunner.ServiceHealthCheckConfigurationArgs(
-        interval=10,
-        protocol="TCP",
-        timeout=5,
-    ),
-    instance_configuration=aws.apprunner.ServiceInstanceConfigurationArgs(
-        instance_role_arn=families_api_instance_role.arn,
-    ),
-    network_configuration=aws.apprunner.ServiceNetworkConfigurationArgs(
-        egress_configuration=aws.apprunner.ServiceNetworkConfigurationEgressConfigurationArgs(
-            egress_type="VPC",
-            # This is only needed because we have hidden the RDS store in a different VPC to all our other resources
-            vpc_connector_arn=apprunner_vpc_connector_arn,
-        ),
-        ingress_configuration=aws.apprunner.ServiceNetworkConfigurationIngressConfigurationArgs(
-            is_publicly_accessible=True,
-        ),
-        ip_address_type="IPV4",
-    ),
-    observability_configuration=aws.apprunner.ServiceObservabilityConfigurationArgs(
-        observability_enabled=False,
-    ),
-    service_name="families-api",
-    source_configuration=aws.apprunner.ServiceSourceConfigurationArgs(
-        authentication_configuration=aws.apprunner.ServiceSourceConfigurationAuthenticationConfigurationArgs(
-            access_role_arn=families_api_role.arn,
-        ),
-        image_repository=aws.apprunner.ServiceSourceConfigurationImageRepositoryArgs(
-            image_configuration=aws.apprunner.ServiceSourceConfigurationImageRepositoryImageConfigurationArgs(
-                runtime_environment_secrets={
-                    "NAVIGATOR_DATABASE_URL": families_api_apprunner_navigator_database_url.arn,
-                    "CDN_URL": families_api_apprunner_cdn_url.arn,
-                },
-            ),
-            image_identifier=f"{account_id}.dkr.ecr.eu-west-1.amazonaws.com/families-api:latest",
-            image_repository_type="ECR",
-        ),
-    ),
-    opts=pulumi.ResourceOptions(protect=False),
 )
 
 
@@ -352,6 +220,3 @@ pulumi.export(
         lambda paths: paths[0].endpoint.removeprefix("https://") if paths else None
     ),
 )
-
-
-pulumi.export("apprunner_service_url", families_api_apprunner_service.service_url)


### PR DESCRIPTION
# What does this do?
This removes the families api app runner service.

This is part of the clean up after the ecs express migration.
## Why is it needed?

Lingering code and lingering applications cost money.
## How was it tested?
Ran on staging.