### PR TITLE
fix: deploy a new docker image

### DIFF
--- a/data-in-api/app/main.py
+++ b/data-in-api/app/main.py
@@ -59,7 +59,7 @@ def root():
 
 
 # We use both routers to make sure we can have /data-in/health available publicly
-# and /health available to the AppRunner health check
+# and /health available to the AppRunner health check.
 @app.get("/health")
 @router.get("/health")
 def health():

--- a/data-in-api/app/repository.py
+++ b/data-in-api/app/repository.py
@@ -36,10 +36,10 @@ LABEL_TYPES_WITH_RELATIONSHIPS = {
 
 
 def check_db_health(db: Session) -> bool:
-    """Check database connection health.
+    """Check database connection health
 
     Performs a simple query to verify the database is accessible
-    and responsive.
+    and responsive
 
     :return: True if database is healthy, False otherwise
     :rtype: bool
@@ -94,7 +94,7 @@ def get_all_documents(
         _LOGGER.exception("System error during document retrieval operation")
         raise
     except Exception as e:
-        _LOGGER.exception(f"Failed to retrieve all documents: {str(e)}")
+        _LOGGER.exception(f"Failed to retrieve all documents: {e!s}")
         raise e
 
 
@@ -120,7 +120,7 @@ def get_document_by_id(db: Session, document_id: str) -> DocumentOutput | None:
         _LOGGER.exception("System error during document retrieval operation")
         raise
     except Exception as e:
-        _LOGGER.exception(f"Failed to retrieve document {document_id}: {str(e)}")
+        _LOGGER.exception(f"Failed to retrieve document {document_id}: {e!s}")
         db.rollback()
         raise e
 
@@ -145,7 +145,7 @@ def select_labels(db: Session, page: int, page_size: int) -> list[LabelOutput]:
         raise
 
     except Exception as e:
-        _LOGGER.exception(f"Failed to retrieve all labels: {str(e)}")
+        _LOGGER.exception(f"Failed to retrieve all labels: {e!s}")
         raise e
 
 
@@ -165,7 +165,7 @@ def select_label(db: Session, label_id: str) -> LabelOutput | None:
         raise
 
     except Exception as e:
-        _LOGGER.exception(f"Failed to retrieve label {label_id}: {str(e)}")
+        _LOGGER.exception(f"Failed to retrieve label {label_id}: {e!s}")
         db.rollback()
         raise e
 


### PR DESCRIPTION
I have a theory our retention policy has deleted our latest docker image for this micro service, our current taks are not picking anything up so the service is rolling back and in a weird hanging state

# What does this do?

This should hopefully trigger a new deploy of the image. 

Diagnosing with Amazon Q below

```

🔴 Root Cause: CannotPullContainerError — Container Image Not Found or Inaccessible
The task is failing with TaskFailedToStart because ECS cannot pull the container image from Amazon ECR. This has caused 52 failed task attempts since 09:23 UTC on 2026-08-03 (today).

Detail | Value
-- | --
Container Image | 532586131621.dkr.ecr.eu-west-1.amazonaws.com/data-in-api
Image Digest | 8e68cb1049769cc87c73a4dbc812f9f62c04c077
Task Execution Role | api-services-production-task-execution-role
Container Status | STOPPED (exit code: none, reason: none)
ENI | eni-0bdffb418b5ec2229 / IP 10.0.46.157

```

## Why is it needed?
The service cannot start without a container image. 
## How was it tested?
