### PR TITLE
fix: framework law and topic transformations

### DIFF
--- a/data-in-pipeline/app/transform/navigator_family.py
+++ b/data-in-pipeline/app/transform/navigator_family.py
@@ -137,9 +137,52 @@ project_completion_report = Label(
 
 # region Law
 law = Label(type="category", id="category::Law", value="Law")
+framework_law = Label(
+    id="law_type::Framework law",
+    value="Framework law",
+    type="law_type",
+    labels=[LabelRelationship(type="subconcept_of", value=law)],
+)
 
 # region Policy
 policy = Label(type="category", id="category::Policy", value="Policy")
+# we use `topic`, but call this "response area" in the UI
+mitigation = Label(
+    id="topic::Mitigation",
+    value="Mitigation",
+    type="topic",
+    labels=[
+        LabelRelationship(type="subconcept_of", value=law),
+        LabelRelationship(type="subconcept_of", value=policy),
+    ],
+)
+adaptation = Label(
+    id="topic::Adaptation",
+    value="Adaptation",
+    type="topic",
+    labels=[
+        LabelRelationship(type="subconcept_of", value=law),
+        LabelRelationship(type="subconcept_of", value=policy),
+    ],
+)
+loss_and_damage = Label(
+    id="topic::Loss and damage",
+    value="Loss and damage",
+    type="topic",
+    labels=[
+        LabelRelationship(type="subconcept_of", value=law),
+        LabelRelationship(type="subconcept_of", value=policy),
+    ],
+)
+disaster_risk_management = Label(
+    id="topic::Disaster risk management",
+    value="Disaster risk management",
+    type="topic",
+    labels=[
+        LabelRelationship(type="subconcept_of", value=law),
+        LabelRelationship(type="subconcept_of", value=policy),
+    ],
+)
 
 # region Report
 report = Label(type="category", id="category::Report", value="Report")
@@ -2044,49 +2087,33 @@ def _author_type_label(
 
 # region topic label
 # This is also known as "response area" in the UI
+# These are controlled vocabularies
+# @see: https://github.com/climatepolicyradar/data-migrations/blob/main/taxonomies/Laws%20and%20Policies.json#L15-L18
+_topic_to_label_map = {
+    "Mitigation": mitigation,
+    "Adaptation": adaptation,
+    "Loss And Damage": loss_and_damage,
+    "Disaster Risk Management": disaster_risk_management,
+}
+
+
 def _topic_label(
     navigator_family: NavigatorFamily,
 ) -> list[LabelRelationship]:
     labels: list[LabelRelationship] = []
 
-    # These are controlled vocabularies
-    # @see: https://github.com/climatepolicyradar/data-migrations/blob/main/taxonomies/Laws%20and%20Policies.json#L15-L18
-    topic_values = navigator_family.metadata.get("topic")
-    if topic_values and topic_values[0]:
-        topic = topic_values[0]
-        labels.append(
-            LabelRelationship(
-                type="topic",
-                value=Label(
-                    id=f"topic::{topic}",
-                    value=topic,
+    topics = navigator_family.metadata.get("topic")
+
+    if topics and topics[0] and _topic_to_label_map.get(topics[0]):
+        mapped_topic_label = _topic_to_label_map[topics[0]]
+        if mapped_topic_label is not None:
+            labels.append(
+                LabelRelationship(
                     type="topic",
-                    labels=[
-                        LabelRelationship(type="subconcept_of", value=law),
-                        LabelRelationship(type="subconcept_of", value=policy),
-                    ],
-                ),
+                    value=mapped_topic_label,
+                )
             )
-        )
 
-    # These are controlled vocabularies
-    # @see: https://github.com/climatepolicyradar/data-migrations/blob/main/taxonomies/Laws%20and%20Policies.json#L496-L498
-    framework_values = navigator_family.metadata.get("framework")
-
-    # Only Mitigation makes this a Framework law
-    if framework_values and framework_values[0] in ["Mitigation"]:
-        topic = framework_values[0]
-        labels.append(
-            LabelRelationship(
-                type="law_type",
-                value=Label(
-                    id=f"law_type::{topic}",
-                    value="Framework law",
-                    type="law_type",
-                    labels=[LabelRelationship(type="subconcept_of", value=law)],
-                ),
-            )
-        )
     return labels
 
 
@@ -2100,22 +2127,13 @@ def _law_type_label(
     # @see: https://github.com/climatepolicyradar/data-migrations/blob/main/taxonomies/Laws%20and%20Policies.json#L490-L494
     framework_values = navigator_family.metadata.get("framework")
 
-    # Only Mitigation makes this a Framework law
-    if framework_values and framework_values[0] in [
-        "Adaptation",
-        "Mitigation",
-        "Drm/Drr",
-    ]:
-        topic = framework_values[0]
+    # Any value in the `framework` denotes it is a Framework law
+    # @see: https://linear.app/climate-policy-radar/issue/APP-2261/corporate-voluntary-report-missing-from-corporate-disclosure
+    if framework_values:
         labels.append(
             LabelRelationship(
                 type="law_type",
-                value=Label(
-                    id=f"law_type::{topic}",
-                    value="Framework law",
-                    type="law_type",
-                    labels=[LabelRelationship(type="subconcept_of", value=law)],
-                ),
+                value=framework_law,
             )
         )
     return labels

--- a/data-in-pipeline/tests/transform/test_navigator_family.py
+++ b/data-in-pipeline/tests/transform/test_navigator_family.py
@@ -1156,7 +1156,7 @@ def test_transform_navigator_family_with_laws_and_policies_corpus_type(
             LabelRelationship(
                 type="law_type",
                 value=Label(
-                    id="law_type::Mitigation",
+                    id="law_type::Framework law",
                     value="Framework law",
                     type="law_type",
                     labels=[
@@ -2610,10 +2610,21 @@ def test_entity_type_label_oep_always_applies_regardless_of_document_type():
 
 
 @pytest.mark.parametrize(
-    "topic",
-    ["Mitigation", "Adaptation", "Loss and Damage"],
+    ("topic", "expected_id", "expected_value"),
+    [
+        ("Mitigation", "topic::Mitigation", "Mitigation"),
+        ("Adaptation", "topic::Adaptation", "Adaptation"),
+        ("Loss And Damage", "topic::Loss and damage", "Loss and damage"),
+        (
+            "Disaster Risk Management",
+            "topic::Disaster risk management",
+            "Disaster risk management",
+        ),
+    ],
 )
-def test_topic_label_returns_label_for_topic_metadata(topic):
+def test_topic_label_returns_label_for_topic_metadata(
+    topic, expected_id, expected_value
+):
     family = NavigatorFamilyFactory.build(
         corpus=NavigatorCorpusFactory.build(import_id="CCLW.corpus.i00000001.n0000"),
         metadata={"topic": [topic]},
@@ -2621,9 +2632,17 @@ def test_topic_label_returns_label_for_topic_metadata(topic):
     labels = _topic_label(family)
     assert len(labels) == 1
     assert labels[0].type == "topic"
-    assert labels[0].value.id == f"topic::{topic}"
-    assert labels[0].value.value == topic
+    assert labels[0].value.id == expected_id
+    assert labels[0].value.value == expected_value
     assert labels[0].value.type == "topic"
+
+
+def test_topic_label_returns_empty_for_unmapped_topic():
+    family = NavigatorFamilyFactory.build(
+        corpus=NavigatorCorpusFactory.build(import_id="CCLW.corpus.i00000001.n0000"),
+        metadata={"topic": ["Other"]},
+    )
+    assert _topic_label(family) == []
 
 
 def test_topic_label_includes_subconcept_of_law_and_policy():
@@ -2669,26 +2688,6 @@ def test_topic_label_returns_empty_when_topic_first_value_is_empty_string():
     assert _topic_label(family) == []
 
 
-def test_topic_label_returns_law_type_label_for_mitigation_framework():
-    family = NavigatorFamilyFactory.build(
-        corpus=NavigatorCorpusFactory.build(import_id="CCLW.corpus.i00000001.n0000"),
-        metadata={"framework": ["Mitigation"]},
-    )
-    labels = _topic_label(family)
-    assert len(labels) == 1
-    assert labels[0].type == "law_type"
-    assert labels[0].value.id == "law_type::Mitigation"
-    assert labels[0].value.value == "Framework law"
-
-
-def test_topic_label_ignores_non_mitigation_framework_metadata():
-    family = NavigatorFamilyFactory.build(
-        corpus=NavigatorCorpusFactory.build(import_id="CCLW.corpus.i00000001.n0000"),
-        metadata={"framework": ["Adaptation"]},
-    )
-    assert _topic_label(family) == []
-
-
 @pytest.mark.parametrize("framework", ["Adaptation", "Mitigation", "Drm/Drr"])
 def test_law_type_label_returns_label_for_framework_values(framework):
     family = NavigatorFamilyFactory.build(
@@ -2698,7 +2697,7 @@ def test_law_type_label_returns_label_for_framework_values(framework):
     labels = _law_type_label(family)
     assert len(labels) == 1
     assert labels[0].type == "law_type"
-    assert labels[0].value.id == f"law_type::{framework}"
+    assert labels[0].value.id == "law_type::Framework law"
     assert labels[0].value.value == "Framework law"
     assert labels[0].value.type == "law_type"
 
@@ -2724,12 +2723,14 @@ def test_law_type_label_returns_empty_when_no_framework_key():
     assert _law_type_label(family) == []
 
 
-def test_law_type_label_returns_empty_for_non_matching_framework():
+def test_law_type_label_returns_label_for_any_framework_value():
     family = NavigatorFamilyFactory.build(
         corpus=NavigatorCorpusFactory.build(import_id="CCLW.corpus.i00000001.n0000"),
         metadata={"framework": ["Other"]},
     )
-    assert _law_type_label(family) == []
+    labels = _law_type_label(family)
+    assert len(labels) == 1
+    assert labels[0].value.id == "law_type::Framework law"
 
 
 def test_law_type_label_returns_empty_when_framework_is_empty_list():


### PR DESCRIPTION
# What does this do?
- reduces the way we label "Framework law" and `topics` to
  - If anything is in `framework` => "Framework law"
  - If something in `topic` => `topic::{{ topic }}`

## How was it tested?
pytest

---

fixes https://linear.app/climate-policy-radar/issue/APP-2260/law-type-filters-are-all-labeled-as-framework-law
