### PR TITLE
fix: remove duplicate application of project and guidance label

### DIFF
--- a/data-in-pipeline/app/transform/navigator_family.py
+++ b/data-in-pipeline/app/transform/navigator_family.py
@@ -1244,31 +1244,6 @@ def _transform_navigator_family(
         )
     )
 
-    # MCF reports and guidance labels
-    if navigator_family.corpus.import_id in mcf_projects_corpus_import_ids:
-        labels.append(
-            LabelRelationship(
-                type="entity_type",
-                value=Label(
-                    id="entity_type::Project",
-                    value="Project",
-                    type="entity_type",
-                ),
-            )
-        )
-
-    if navigator_family.corpus.import_id in mcf_guidance_corpus_import_ids:
-        labels.append(
-            LabelRelationship(
-                type="entity_type",
-                value=Label(
-                    id="entity_type::Guidance",
-                    value="Guidance",
-                    type="entity_type",
-                ),
-            )
-        )
-
     # GST1 labels
     if _part_of_gst1(navigator_family):
         labels.append(

--- a/data-in-pipeline/tests/transform/test_navigator_family_mcf.py
+++ b/data-in-pipeline/tests/transform/test_navigator_family_mcf.py
@@ -201,14 +201,6 @@ def test_transform_navigator_family_with_multilateral_climate_fund_project(
                 ),
             ),
             LabelRelationship(
-                type="entity_type",
-                value=Label(
-                    id="entity_type::Project",
-                    value="Project",
-                    type="entity_type",
-                ),
-            ),
-            LabelRelationship(
                 type="activity_status",
                 value=Label(
                     id="activity_status::Concept approved",
@@ -318,6 +310,24 @@ def test_transform_navigator_family_with_multilateral_climate_fund_project(
                     id="category::Multilateral Climate Fund project",
                     value="Multilateral Climate Fund project",
                     type="category",
+                ),
+            ),
+            LabelRelationship(
+                type="entity_type",
+                value=Label(
+                    id="entity_type::Project",
+                    value="Project",
+                    type="entity_type",
+                    labels=[
+                        LabelRelationship(
+                            type="subconcept_of",
+                            value=Label(
+                                id="category::Multilateral Climate Fund project",
+                                value="Multilateral Climate Fund project",
+                                type="category",
+                            ),
+                        ),
+                    ],
                 ),
             ),
             LabelRelationship(
@@ -704,14 +714,6 @@ def test_transform_navigator_family_with_multilateral_climate_fund_guidance(
                         ),
                     ),
                     LabelRelationship(
-                        type="entity_type",
-                        value=Label(
-                            id="entity_type::Guidance",
-                            value="Guidance",
-                            type="entity_type",
-                        ),
-                    ),
-                    LabelRelationship(
                         type="provider",
                         value=Label(
                             type="agent",
@@ -752,6 +754,24 @@ def test_transform_navigator_family_with_multilateral_climate_fund_guidance(
                             id="category::Multilateral Climate Fund project",
                             value="Multilateral Climate Fund project",
                             type="category",
+                        ),
+                    ),
+                    LabelRelationship(
+                        type="entity_type",
+                        value=Label(
+                            id="entity_type::Guidance",
+                            value="Guidance",
+                            type="entity_type",
+                            labels=[
+                                LabelRelationship(
+                                    type="subconcept_of",
+                                    value=Label(
+                                        id="category::Multilateral Climate Fund project",
+                                        value="Multilateral Climate Fund project",
+                                        type="category",
+                                    ),
+                                ),
+                            ],
                         ),
                     ),
                 ],


### PR DESCRIPTION
# What does this do?

- removes duplicate application of "Project" and "Guidance" label, leaving only the taxonomical labels to be applied, which have the `subconcept_of: MCF`.

we have seen this bug before e.g: https://github.com/climatepolicyradar/navigator-backend/pull/1314:
- we label a document with taxonomical labels (has `subconcept_of` relationships)
- we then label it with a free text label
- we dedupe 👈 this means we loose the relationships


## How was it tested?
pytest

---

fixes https://linear.app/climate-policy-radar/issue/APP-2262/report-and-guidance-are-missing-from-mcf-category
