### PR TITLE
fix: exclude implementing_agency from MCF transformation

### DIFF
--- a/data-in-pipeline/app/transform/navigator_family.py
+++ b/data-in-pipeline/app/transform/navigator_family.py
@@ -473,7 +473,7 @@ LITIGATION_CORPORA = {"Academic.corpus.Litigation.n0000"}
 
 
 MCF_KEY_MAPPING = {"status": "project_status"}
-MCF_EXCLUDED_KEYS = {"region", "external_id"}
+MCF_EXCLUDED_KEYS = {"region", "external_id", "implementing_agency"}
 MCF_ATTRIBUTE_KEYS = {
     "project_id",
     "project_url",

--- a/data-in-pipeline/tests/transform/test_navigator_family_mcf.py
+++ b/data-in-pipeline/tests/transform/test_navigator_family_mcf.py
@@ -305,14 +305,6 @@ def test_transform_navigator_family_with_multilateral_climate_fund_project(
                 ),
             ),
             LabelRelationship(
-                type="implementing_agency",
-                value=Label(
-                    id="implementing_agency::International Bank for Reconstruction",
-                    type="implementing_agency",
-                    value="International Bank for Reconstruction",
-                ),
-            ),
-            LabelRelationship(
                 type="category",
                 value=Label(
                     id="category::Multilateral Climate Fund project",


### PR DESCRIPTION
# What does this do?

- excludes `implementing_agency` from auto transforming. [We use another method that uses the taxonomical label](https://github.com/climatepolicyradar/navigator-backend/blob/main/data-in-pipeline/tests/transform/test_navigator_family.py#L2794-L2804).

We have seen this before where e.g. #1314 

- we label a document with taxonomical labels (has `subconcept_of` relationships)
- we then label it with a free text label
- **we dedupe** 👈 this means we loose the relationships


## How was it tested?

pytest

---

fixes https://linear.app/climate-policy-radar/issue/APP-2263/implementing-agency-is-missing-from-mcf-filter